### PR TITLE
SDK-236 Adding new event - customer_event_alias

### DIFF
--- a/Branch-SDK/androidTest/io/branch/referral/BranchEventTest.java
+++ b/Branch-SDK/androidTest/io/branch/referral/BranchEventTest.java
@@ -34,6 +34,15 @@ public class BranchEventTest extends BranchTest {
     }
 
     @Test
+    public void testCustomerEventAlias() throws Throwable {
+        BRANCH_STANDARD_EVENT eventType = BRANCH_STANDARD_EVENT.CUSTOMER_EVENT_ALIAS;
+        Assert.assertEquals("CUSTOMER_EVENT_ALIAS", eventType.getName());
+
+        BranchEvent branchEvent = new BranchEvent(eventType);
+        Assert.assertTrue(isStandardEvent(branchEvent));
+    }
+
+    @Test
     public void testCustomEvent() throws Throwable {
         BranchEvent branchEvent = new BranchEvent("CustomEvent");
         Assert.assertFalse(isStandardEvent(branchEvent));

--- a/Branch-SDK/src/io/branch/referral/util/BRANCH_STANDARD_EVENT.java
+++ b/Branch-SDK/src/io/branch/referral/util/BRANCH_STANDARD_EVENT.java
@@ -36,7 +36,8 @@ public enum BRANCH_STANDARD_EVENT {
     SUBSCRIBE("SUBSCRIBE"),
     START_TRIAL("START_TRIAL"),
     CLICK_AD("CLICK_AD"),
-    VIEW_AD("VIEW_AD");
+    VIEW_AD("VIEW_AD"),
+    CUSTOMER_EVENT_ALIAS("CUSTOMER_EVENT_ALIAS");
 
     private final String name;
 

--- a/Branch-SDK/src/io/branch/referral/util/BranchEvent.java
+++ b/Branch-SDK/src/io/branch/referral/util/BranchEvent.java
@@ -297,38 +297,4 @@ public class BranchEvent {
             return true; // Branch event need to be retried on failure.
         }
     }
-
-
-    /**
-     * @deprecated Please use #BranchEvent(BRANCH_STANDARD_EVENT) instead
-     */
-    public static final String VIEW = "View";
-    /**
-     * @deprecated Please use #BranchEvent(BRANCH_STANDARD_EVENT) instead
-     */
-    public static final String ADD_TO_WISH_LIST = "Add to Wishlist";
-    /**
-     * @deprecated Please use #BranchEvent(BRANCH_STANDARD_EVENT) instead
-     */
-    public static final String ADD_TO_CART = "Add to Cart";
-    /**
-     * @deprecated Please use #BranchEvent(BRANCH_STANDARD_EVENT) instead
-     */
-    public static final String PURCHASE_STARTED = "Purchase Started";
-    /**
-     * @deprecated Please use #BranchEvent(BRANCH_STANDARD_EVENT) instead
-     */
-    public static final String PURCHASED = "Purchased";
-    /**
-     * @deprecated Please use #BranchEvent(BRANCH_STANDARD_EVENT) instead
-     */
-    public static final String SHARE_STARTED = "Share Started";
-    /**
-     * @deprecated Please use #BranchEvent(BRANCH_STANDARD_EVENT) instead
-     */
-    public static final String SHARE_COMPLETED = "Share Completed";
-    /**
-     * @deprecated Please use #BranchEvent(BRANCH_STANDARD_EVENT) instead
-     */
-    public static final String CANONICAL_ID_LIST = "$canonical_identifier_list";
 }


### PR DESCRIPTION
## Reference
SDK-236 -- Add new standard event - customer_event_alias.

## Description
Add support for customer_event_alias for Branch's SDK's + /v2/event/standard.

## Testing Instructions
* Sample app should continue to function.
* Unit tests should all pass

I added a test for this particular V2 standard event, although it isn't any different than existing events. 

## Risk Assessment [`LOW`]

- [X] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title
- Correctness & Style
    - [x] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [x] Mission critical pieces are documented in code and out of code as needed
- [x] Unit Tests reviewed and test issue sufficiently
- [x] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
