### PR TITLE
Inteng 7461

### DIFF
--- a/Branch-SDK/androidTest/io/branch/referral/BranchGAIDTest.java
+++ b/Branch-SDK/androidTest/io/branch/referral/BranchGAIDTest.java
@@ -46,8 +46,8 @@ public class BranchGAIDTest extends BranchEventTest {
         ServerRequest initRequest = queue.peekAt(0);
         doFinalUpdate(initRequest);
 
-        Assert.assertTrue(hasV1GAID(initRequest));
-        Assert.assertFalse(hasV2GAID(initRequest));
+        assumingLatIsDisabledHasGAIDv1(initRequest, true);
+        assumingLatIsDisabledHasGAIDv2(initRequest, false);
     }
 
     @Test
@@ -69,8 +69,8 @@ public class BranchGAIDTest extends BranchEventTest {
         Assert.assertNotNull(serverRequest);
         doFinalUpdate(serverRequest);
 
-        Assert.assertTrue(hasV1GAID(serverRequest));
-        Assert.assertFalse(hasV2GAID(serverRequest));
+        assumingLatIsDisabledHasGAIDv1(serverRequest, true);
+        assumingLatIsDisabledHasGAIDv2(serverRequest, false);
     }
 
     @Test
@@ -90,8 +90,8 @@ public class BranchGAIDTest extends BranchEventTest {
         Assert.assertNotNull(serverRequest);
         doFinalUpdate(serverRequest);
 
-        Assert.assertTrue(hasV1GAID(serverRequest));
-        Assert.assertFalse(hasV2GAID(serverRequest));
+        assumingLatIsDisabledHasGAIDv1(serverRequest, true);
+        assumingLatIsDisabledHasGAIDv2(serverRequest, false);
 
         DebugLogQueue(getTestContext());
     }
@@ -116,8 +116,8 @@ public class BranchGAIDTest extends BranchEventTest {
         Assert.assertNotNull(serverRequest);
         doFinalUpdate(serverRequest);
 
-        Assert.assertTrue(hasV1GAID(serverRequest));
-        Assert.assertFalse(hasV2GAID(serverRequest));
+        assumingLatIsDisabledHasGAIDv1(serverRequest, true);
+        assumingLatIsDisabledHasGAIDv2(serverRequest, false);
     }
 
     @Test
@@ -131,8 +131,8 @@ public class BranchGAIDTest extends BranchEventTest {
         Assert.assertNotNull(serverRequest);
         doFinalUpdate(serverRequest);
 
-        Assert.assertTrue(hasV1GAID(serverRequest));
-        Assert.assertFalse(hasV2GAID(serverRequest));
+        assumingLatIsDisabledHasGAIDv1(serverRequest, true);
+        assumingLatIsDisabledHasGAIDv2(serverRequest, false);
     }
 
     @Test
@@ -146,8 +146,8 @@ public class BranchGAIDTest extends BranchEventTest {
         Assert.assertNotNull(serverRequest);
         doFinalUpdate(serverRequest);
 
-        Assert.assertTrue(hasV1GAID(serverRequest));
-        Assert.assertFalse(hasV2GAID(serverRequest));
+        assumingLatIsDisabledHasGAIDv1(serverRequest, true);
+        assumingLatIsDisabledHasGAIDv2(serverRequest, false);
     }
 
     @Test
@@ -177,10 +177,43 @@ public class BranchGAIDTest extends BranchEventTest {
         ServerRequest serverRequest = logEvent(getTestContext(), branchEvent);
         Assert.assertNotNull(serverRequest);
 
-        Assert.assertFalse(hasV1GAID(serverRequest));
-        Assert.assertTrue(hasV2GAID(serverRequest));
+        assumingLatIsDisabledHasGAIDv1(serverRequest, false);
+        assumingLatIsDisabledHasGAIDv2(serverRequest, true);
     }
 
+    // Check to see if the LAT is available (V1)
+    private boolean hasV1LAT(ServerRequest request) {
+        JSONObject jsonObject = request.getGetParams();
+        int lat = jsonObject.optInt(Defines.Jsonkey.LATVal.getKey(), -1);
+        return lat >= 0;
+    }
+
+    // Check to see if the LAT is available (V2)
+    private boolean hasV2LAT(ServerRequest request) {
+        JSONObject jsonObject = request.getGetParams();
+        JSONObject userDataObj = jsonObject.optJSONObject(Defines.Jsonkey.UserData.getKey());
+
+        if (userDataObj == null) {
+            return false;
+        }
+
+        int lat = userDataObj.optInt(Defines.Jsonkey.LimitedAdTracking.getKey(), -1);
+        return lat >= 0;
+    }
+
+    private boolean LATIsEnabledV1(ServerRequest request) {
+        JSONObject jsonObject = request.getGetParams();
+        return jsonObject.optInt(Defines.Jsonkey.LATVal.getKey(), -1) == 1;
+    }
+
+    private boolean LATIsEnabledV2(ServerRequest request) {
+        JSONObject jsonObject = request.getGetParams();
+        JSONObject userDataObj = jsonObject.optJSONObject(Defines.Jsonkey.UserData.getKey());
+
+        Assert.assertNotNull(userDataObj);
+
+        return userDataObj.optInt(Defines.Jsonkey.LimitedAdTracking.getKey(), -1) == 1;
+    }
 
     // Check to see if the GAID is available (V1)
     private boolean hasV1GAID(ServerRequest request) {
@@ -202,5 +235,34 @@ public class BranchGAIDTest extends BranchEventTest {
         return (gaid.length() > 0);
     }
 
+    private void assumingLatIsDisabledHasGAIDv1(ServerRequest serverRequest, boolean assertTrue) {
+        if (assertTrue) {
+            Assert.assertTrue(hasV1LAT(serverRequest));
+
+            if (LATIsEnabledV1(serverRequest)) {
+                Assert.assertFalse(hasV1GAID(serverRequest));
+            } else {
+                Assert.assertTrue(hasV1GAID(serverRequest));
+            }
+        } else {
+            Assert.assertFalse(hasV1LAT(serverRequest));
+            Assert.assertFalse(hasV1GAID(serverRequest));
+        }
+    }
+
+    private void assumingLatIsDisabledHasGAIDv2(ServerRequest serverRequest, boolean assertTrue) {
+        if (assertTrue) {
+            Assert.assertTrue(hasV2LAT(serverRequest));
+
+            if (LATIsEnabledV2(serverRequest)) {
+                Assert.assertFalse(hasV2GAID(serverRequest));
+            } else {
+                Assert.assertTrue(hasV2GAID(serverRequest));
+            }
+        } else {
+            Assert.assertFalse(hasV2LAT(serverRequest));
+            Assert.assertFalse(hasV2GAID(serverRequest));
+        }
+    }
 }
 

--- a/Branch-SDK/androidTest/io/branch/referral/BranchGAIDTest.java
+++ b/Branch-SDK/androidTest/io/branch/referral/BranchGAIDTest.java
@@ -47,7 +47,9 @@ public class BranchGAIDTest extends BranchEventTest {
         doFinalUpdate(initRequest);
 
         assumingLatIsDisabledHasGAIDv1(initRequest, true);
+        assumingLatIsDisabledHasAdIdFromAdIdsObjectV1(initRequest, true);
         assumingLatIsDisabledHasGAIDv2(initRequest, false);
+        assumingLatIsDisabledHasAdIdFromAdIdsObjectV2(initRequest, false);
     }
 
     @Test
@@ -70,7 +72,9 @@ public class BranchGAIDTest extends BranchEventTest {
         doFinalUpdate(serverRequest);
 
         assumingLatIsDisabledHasGAIDv1(serverRequest, true);
+        assumingLatIsDisabledHasAdIdFromAdIdsObjectV1(serverRequest, true);
         assumingLatIsDisabledHasGAIDv2(serverRequest, false);
+        assumingLatIsDisabledHasAdIdFromAdIdsObjectV2(serverRequest, false);
     }
 
     @Test
@@ -91,7 +95,9 @@ public class BranchGAIDTest extends BranchEventTest {
         doFinalUpdate(serverRequest);
 
         assumingLatIsDisabledHasGAIDv1(serverRequest, true);
+        assumingLatIsDisabledHasAdIdFromAdIdsObjectV1(serverRequest, true);
         assumingLatIsDisabledHasGAIDv2(serverRequest, false);
+        assumingLatIsDisabledHasAdIdFromAdIdsObjectV2(serverRequest, false);
 
         DebugLogQueue(getTestContext());
     }
@@ -117,7 +123,9 @@ public class BranchGAIDTest extends BranchEventTest {
         doFinalUpdate(serverRequest);
 
         assumingLatIsDisabledHasGAIDv1(serverRequest, true);
+        assumingLatIsDisabledHasAdIdFromAdIdsObjectV1(serverRequest, true);
         assumingLatIsDisabledHasGAIDv2(serverRequest, false);
+        assumingLatIsDisabledHasAdIdFromAdIdsObjectV2(serverRequest, false);
     }
 
     @Test
@@ -132,7 +140,9 @@ public class BranchGAIDTest extends BranchEventTest {
         doFinalUpdate(serverRequest);
 
         assumingLatIsDisabledHasGAIDv1(serverRequest, true);
+        assumingLatIsDisabledHasAdIdFromAdIdsObjectV1(serverRequest, true);
         assumingLatIsDisabledHasGAIDv2(serverRequest, false);
+        assumingLatIsDisabledHasAdIdFromAdIdsObjectV2(serverRequest, false);
     }
 
     @Test
@@ -147,7 +157,9 @@ public class BranchGAIDTest extends BranchEventTest {
         doFinalUpdate(serverRequest);
 
         assumingLatIsDisabledHasGAIDv1(serverRequest, true);
+        assumingLatIsDisabledHasAdIdFromAdIdsObjectV1(serverRequest, true);
         assumingLatIsDisabledHasGAIDv2(serverRequest, false);
+        assumingLatIsDisabledHasAdIdFromAdIdsObjectV2(serverRequest, false);
     }
 
     @Test
@@ -178,7 +190,9 @@ public class BranchGAIDTest extends BranchEventTest {
         Assert.assertNotNull(serverRequest);
 
         assumingLatIsDisabledHasGAIDv1(serverRequest, false);
+        assumingLatIsDisabledHasAdIdFromAdIdsObjectV1(serverRequest, false);
         assumingLatIsDisabledHasGAIDv2(serverRequest, true);
+        assumingLatIsDisabledHasAdIdFromAdIdsObjectV2(serverRequest, true);
     }
 
     // Check to see if the LAT is available (V1)
@@ -262,6 +276,48 @@ public class BranchGAIDTest extends BranchEventTest {
         } else {
             Assert.assertFalse(hasV2LAT(serverRequest));
             Assert.assertFalse(hasV2GAID(serverRequest));
+        }
+    }
+
+    private String getAdIdFromAdIdsObject(ServerRequest request) {
+        JSONObject jsonObject = request.getGetParams();
+        JSONObject adIdsObject = jsonObject.optJSONObject(Defines.Jsonkey.AdvertisingIDs.getKey());
+        if (adIdsObject == null) return "";
+
+        if (jsonObject.optString(Defines.Jsonkey.OS.getKey()).toLowerCase().contains("amazon")) {
+            return adIdsObject.optString(Defines.Jsonkey.FireAdId.getKey());
+        } else {
+            return adIdsObject.optString(Defines.Jsonkey.AAID.getKey());
+        }
+    }
+
+    private void assumingLatIsDisabledHasAdIdFromAdIdsObjectV1(ServerRequest serverRequest, boolean assertTrue) {
+        boolean hasAdIdFromAdIdsObject = getAdIdFromAdIdsObject(serverRequest).length() > 0;
+        if (assertTrue) {
+            Assert.assertTrue(hasV1LAT(serverRequest));
+
+            if (LATIsEnabledV1(serverRequest)) {
+                Assert.assertFalse(hasAdIdFromAdIdsObject);
+            } else {
+                Assert.assertTrue(hasAdIdFromAdIdsObject);
+            }
+        } else {
+            Assert.assertFalse(hasV1LAT(serverRequest));
+        }
+    }
+
+    private void assumingLatIsDisabledHasAdIdFromAdIdsObjectV2(ServerRequest serverRequest, boolean assertTrue) {
+        boolean hasAdIdFromAdIdsObject = getAdIdFromAdIdsObject(serverRequest).length() > 0;
+        if (assertTrue) {
+            Assert.assertTrue(hasV2LAT(serverRequest));
+
+            if (LATIsEnabledV2(serverRequest)) {
+                Assert.assertFalse(hasAdIdFromAdIdsObject);
+            } else {
+                Assert.assertTrue(hasAdIdFromAdIdsObject);
+            }
+        } else {
+            Assert.assertFalse(hasV2LAT(serverRequest));
         }
     }
 }

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -21,7 +21,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StyleRes;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.View;
 
 import io.branch.referral.Defines.PreinstallKey;
@@ -1492,23 +1491,10 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         boolean fullyInitialized = trackingController != null &&
                 deviceInfo_ != null && deviceInfo_.getSystemObserver() != null &&
                 prefHelper_ != null && prefHelper_.getSessionID() != null;
-        if (!fullyInitialized) {
-            Log.i("TESTIN", "fullyInitialized = false");
-            Log.i("TESTIN", "trackingController = " + trackingController +
-                    "deviceInfo_ = " + deviceInfo_ +
-                    "prefHelper_ = " + prefHelper_);
-            return;
-        }
+        if (!fullyInitialized) return;
 
-        // prefHelper_.getSessionID() is a shared pref that gets set using a value from server response
-        // deviceInfo_.getSystemObserver().getGAIDInitializationSessionID() gets set in do in background of the AAID prefetch task
-
-        // what if
         boolean aaidInitializedInThisSession = prefHelper_.getSessionID().equals(deviceInfo_.getSystemObserver().getGAIDInitializationSessionID());
-        Log.i("TESTIN", "prefHelper_.getSessionID() = " + prefHelper_.getSessionID());
-        Log.i("TESTIN", "getGAIDInitializationSessionID() = " + deviceInfo_.getSystemObserver().getGAIDInitializationSessionID());
         if (!aaidInitializedInThisSession && !isGAParamsFetchInProgress_ && !trackingController.isTrackingDisabled()) {
-            Log.i("TESTIN", "FETCHING AGAIN!");
             isGAParamsFetchInProgress_ = true;
             deviceInfo_.getSystemObserver().prefetchGAdsParams(context,this);
         }

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -1486,21 +1486,6 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             }
         }
     }
-
-    private void maybeRefreshAdvertisingID(Context context) {
-        boolean fullyInitialized = trackingController != null &&
-                deviceInfo_ != null && deviceInfo_.getSystemObserver() != null &&
-                prefHelper_ != null && prefHelper_.getSessionID() != null;
-        if (!fullyInitialized) return;
-
-        final String AIDInitializationSessionID = deviceInfo_.getSystemObserver().getAIDInitializationSessionID();
-        boolean AIDInitializedInThisSession = prefHelper_.getSessionID().equals(AIDInitializationSessionID);
-
-        if (!AIDInitializedInThisSession && !isGAParamsFetchInProgress_ && !trackingController.isTrackingDisabled()) {
-            isGAParamsFetchInProgress_ = true;
-            deviceInfo_.getSystemObserver().prefetchGAdsParams(context,this);
-        }
-    }
     
     private boolean reportInitSession(BranchReferralInitListener callback) {
         if (callback != null) {
@@ -2867,7 +2852,21 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             }
             BranchViewHandler.getInstance().onCurrentActivityDestroyed(activity);
         }
-        
+
+        private void maybeRefreshAdvertisingID(Context context) {
+            boolean fullyInitialized = trackingController != null &&
+                    deviceInfo_ != null && deviceInfo_.getSystemObserver() != null &&
+                    prefHelper_ != null && prefHelper_.getSessionID() != null;
+            if (!fullyInitialized) return;
+
+            final String AIDInitializationSessionID = deviceInfo_.getSystemObserver().getAIDInitializationSessionID();
+            boolean AIDInitializedInThisSession = prefHelper_.getSessionID().equals(AIDInitializationSessionID);
+
+            if (!AIDInitializedInThisSession && !isGAParamsFetchInProgress_ && !trackingController.isTrackingDisabled()) {
+                isGAParamsFetchInProgress_ = true;
+                deviceInfo_.getSystemObserver().prefetchGAdsParams(context,Branch.this);
+            }
+        }
     }
     
     private void startSession(Activity activity) {

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -1493,8 +1493,10 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                 prefHelper_ != null && prefHelper_.getSessionID() != null;
         if (!fullyInitialized) return;
 
-        boolean aaidInitializedInThisSession = prefHelper_.getSessionID().equals(deviceInfo_.getSystemObserver().getGAIDInitializationSessionID());
-        if (!aaidInitializedInThisSession && !isGAParamsFetchInProgress_ && !trackingController.isTrackingDisabled()) {
+        final String AIDInitializationSessionID = deviceInfo_.getSystemObserver().getAIDInitializationSessionID();
+        boolean AIDInitializedInThisSession = prefHelper_.getSessionID().equals(AIDInitializationSessionID);
+
+        if (!AIDInitializedInThisSession && !isGAParamsFetchInProgress_ && !trackingController.isTrackingDisabled()) {
             isGAParamsFetchInProgress_ = true;
             deviceInfo_.getSystemObserver().prefetchGAdsParams(context,this);
         }

--- a/Branch-SDK/src/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/io/branch/referral/Defines.java
@@ -84,6 +84,7 @@ public class Defines {
         WiFi("wifi"),
         LocalIP("local_ip"),
         UserData("user_data"),
+        AdvertisingIDs("advertising_ids"),
         DeveloperIdentity("developer_identity"),
         UserAgent("user_agent"),
         SDK("sdk"),

--- a/Branch-SDK/src/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/io/branch/referral/Defines.java
@@ -72,6 +72,7 @@ public class Defines {
         LinkIdentifier("link_identifier"),
         GoogleAdvertisingID("google_advertising_id"),       // V1 Only, "Google Advertising Id"
         AAID("aaid"),                                       // V2 Only, "Android Advertising Id"
+        FireAdId("fire_ad_id"),
         LATVal("lat_val"),
         LimitedAdTracking("limit_ad_tracking"),
         limitFacebookTracking("limit_facebook_tracking"),

--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -358,6 +358,7 @@ public class PrefHelper {
      *                   Branch API upon successful initialisation.
      */
     public void setSessionID(String session_id) {
+        Log.i("TESTIN", "setting session ID to " + session_id);
         setString(KEY_SESSION_ID, session_id);
     }
     

--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -358,7 +358,6 @@ public class PrefHelper {
      *                   Branch API upon successful initialisation.
      */
     public void setSessionID(String session_id) {
-        Log.i("TESTIN", "setting session ID to " + session_id);
         setString(KEY_SESSION_ID, session_id);
     }
     

--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -388,39 +388,27 @@ public abstract class ServerRequest {
         BRANCH_API_VERSION version = getBranchRemoteAPIVersion();
         int LATVal = DeviceInfo.getInstance().getSystemObserver().getLATVal();
         String gaid = DeviceInfo.getInstance().getSystemObserver().getGAID();
-        if (!TextUtils.isEmpty(gaid)) {
-            try {
-                if (version == BRANCH_API_VERSION.V2 || version == BRANCH_API_VERSION.V1_CPID ||
-                        version == BRANCH_API_VERSION.V1_LATD) {
-                    JSONObject userDataObj = params_.optJSONObject(Defines.Jsonkey.UserData.getKey());
-                    if (userDataObj != null) {
+        try {
+            if (version == BRANCH_API_VERSION.V2 || version == BRANCH_API_VERSION.V1_CPID ||
+                    version == BRANCH_API_VERSION.V1_LATD) {
+                JSONObject userDataObj = params_.optJSONObject(Defines.Jsonkey.UserData.getKey());
+                if (userDataObj != null) {
+                    userDataObj.put(Defines.Jsonkey.LimitedAdTracking.getKey(), LATVal);
+                    if (!TextUtils.isEmpty(gaid)) {
                         userDataObj.put(Defines.Jsonkey.AAID.getKey(), gaid);
-                        userDataObj.put(Defines.Jsonkey.LimitedAdTracking.getKey(), LATVal);
                         userDataObj.remove(Defines.Jsonkey.UnidentifiedDevice.getKey());
+                    } else if (!userDataObj.has(Defines.Jsonkey.AndroidID.getKey())) {
+                        userDataObj.put(Defines.Jsonkey.UnidentifiedDevice.getKey(), true);
                     }
-                } else {
+                }
+            } else {
+                if (!TextUtils.isEmpty(gaid)) {
                     params_.put(Defines.Jsonkey.GoogleAdvertisingID.getKey(), gaid);
-                    params_.put(Defines.Jsonkey.LATVal.getKey(), LATVal);
                 }
-            } catch (JSONException e) {
-                e.printStackTrace();
+                params_.put(Defines.Jsonkey.LATVal.getKey(), LATVal);
             }
-        } else { // Add unidentified_device when neither GAID nor AndroidID are present
-            if (version == BRANCH_API_VERSION.V2 || version == BRANCH_API_VERSION.V1_CPID) {
-                try {
-                    if (version == BRANCH_API_VERSION.V2 || version == BRANCH_API_VERSION.V1_CPID ||
-                            version == BRANCH_API_VERSION.V1_LATD) {
-                        JSONObject userDataObj = params_.optJSONObject(Defines.Jsonkey.UserData.getKey());
-                        if (userDataObj != null) {
-                            if (!userDataObj.has(Defines.Jsonkey.AndroidID.getKey())) {
-                                userDataObj.put(Defines.Jsonkey.UnidentifiedDevice.getKey(), true);
-                            }
-                        }
-                    }
-                } catch (JSONException ignore) {
-                
-                }
-            }
+        } catch (JSONException e) {
+            e.printStackTrace();
         }
     }
     

--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -398,8 +398,7 @@ public abstract class ServerRequest {
                         userDataObj.put(Defines.Jsonkey.AAID.getKey(), gaid);
                         userDataObj.remove(Defines.Jsonkey.UnidentifiedDevice.getKey());
                         // for future use
-                        JSONObject advertisingIDs = new JSONObject().put(Defines.Jsonkey.AAID.getKey(), gaid);
-                        params_.put(Defines.Jsonkey.AdvertisingIDs.getKey(), advertisingIDs);
+                        addAdvertisingIdsObject(userDataObj, gaid);
                     } else if (payloadContainsNoDeviceIdentifiers(userDataObj)) {
                         userDataObj.put(Defines.Jsonkey.UnidentifiedDevice.getKey(), true);
                     }
@@ -408,8 +407,7 @@ public abstract class ServerRequest {
                 if (!TextUtils.isEmpty(gaid)) {
                     params_.put(Defines.Jsonkey.GoogleAdvertisingID.getKey(), gaid);
                     // for future use
-                    JSONObject advertisingIDs = new JSONObject().put(Defines.Jsonkey.AAID.getKey(), gaid);
-                    params_.put(Defines.Jsonkey.AdvertisingIDs.getKey(), advertisingIDs);
+                    addAdvertisingIdsObject(params_, gaid);
                 } else if (payloadContainsNoDeviceIdentifiers(params_)) {
                     params_.put(Defines.Jsonkey.UnidentifiedDevice.getKey(), true);
                 }
@@ -425,7 +423,21 @@ public abstract class ServerRequest {
                 !payload.has(Defines.Jsonkey.DeviceFingerprintID.getKey()) &&
                 !payload.has(Defines.ModuleNameKeys.imei.getKey()) &&
                 (!payload.has(Defines.Jsonkey.UnidentifiedDevice.getKey()) ||
-                        !payload.optBoolean(Defines.Jsonkey.UnidentifiedDevice.getKey()))
+                        !payload.optBoolean(Defines.Jsonkey.UnidentifiedDevice.getKey()));
+    }
+
+    private void addAdvertisingIdsObject(JSONObject payload, String aid) {
+        String os = payload.optString(Defines.Jsonkey.OS.getKey());
+        if (TextUtils.isEmpty(os)) return;
+
+        String aid_key = os.toLowerCase().contains("amazon") ? Defines.Jsonkey.FireAdId.getKey() :
+                Defines.Jsonkey.AAID.getKey();
+        try {
+            JSONObject advertisingIdsObject = new JSONObject().put(aid_key, aid);
+            payload.put(Defines.Jsonkey.AdvertisingIDs.getKey(), advertisingIdsObject);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
     }
     
     private void updateDeviceInfo() {

--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -397,19 +397,35 @@ public abstract class ServerRequest {
                     if (!TextUtils.isEmpty(gaid)) {
                         userDataObj.put(Defines.Jsonkey.AAID.getKey(), gaid);
                         userDataObj.remove(Defines.Jsonkey.UnidentifiedDevice.getKey());
-                    } else if (!userDataObj.has(Defines.Jsonkey.AndroidID.getKey())) {
+                        // for future use
+                        JSONObject advertisingIDs = new JSONObject().put(Defines.Jsonkey.AAID.getKey(), gaid);
+                        params_.put(Defines.Jsonkey.AdvertisingIDs.getKey(), advertisingIDs);
+                    } else if (payloadContainsNoDeviceIdentifiers(userDataObj)) {
                         userDataObj.put(Defines.Jsonkey.UnidentifiedDevice.getKey(), true);
                     }
                 }
             } else {
                 if (!TextUtils.isEmpty(gaid)) {
                     params_.put(Defines.Jsonkey.GoogleAdvertisingID.getKey(), gaid);
+                    // for future use
+                    JSONObject advertisingIDs = new JSONObject().put(Defines.Jsonkey.AAID.getKey(), gaid);
+                    params_.put(Defines.Jsonkey.AdvertisingIDs.getKey(), advertisingIDs);
+                } else if (payloadContainsNoDeviceIdentifiers(params_)) {
+                    params_.put(Defines.Jsonkey.UnidentifiedDevice.getKey(), true);
                 }
                 params_.put(Defines.Jsonkey.LATVal.getKey(), LATVal);
             }
         } catch (JSONException e) {
             e.printStackTrace();
         }
+    }
+
+    private boolean payloadContainsNoDeviceIdentifiers(JSONObject payload) {
+        return !payload.has(Defines.Jsonkey.AndroidID.getKey()) &&
+                !payload.has(Defines.Jsonkey.DeviceFingerprintID.getKey()) &&
+                !payload.has(Defines.ModuleNameKeys.imei.getKey()) &&
+                (!payload.has(Defines.Jsonkey.UnidentifiedDevice.getKey()) ||
+                        !payload.optBoolean(Defines.Jsonkey.UnidentifiedDevice.getKey()))
     }
     
     private void updateDeviceInfo() {

--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -439,20 +439,6 @@ public abstract class ServerRequest {
         return os.toLowerCase().contains("amazon") ? Defines.Jsonkey.FireAdId.getKey() :
                 Defines.Jsonkey.AAID.getKey();
     }
-
-    private void addAdvertisingIdsObject(JSONObject payload, String aid) {
-        String os = payload.optString(Defines.Jsonkey.OS.getKey());
-        if (TextUtils.isEmpty(os)) return;
-
-        String aid_key = os.toLowerCase().contains("amazon") ? Defines.Jsonkey.FireAdId.getKey() :
-                Defines.Jsonkey.AAID.getKey();
-        try {
-            JSONObject advertisingIdsObject = new JSONObject().put(aid_key, aid);
-            payload.put(Defines.Jsonkey.AdvertisingIDs.getKey(), advertisingIdsObject);
-        } catch (JSONException e) {
-            e.printStackTrace();
-        }
-    }
     
     private void updateDeviceInfo() {
         BRANCH_API_VERSION version = getBranchRemoteAPIVersion();

--- a/Branch-SDK/src/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/io/branch/referral/SystemObserver.java
@@ -12,6 +12,7 @@ import android.net.NetworkInfo;
 import android.provider.Settings.Secure;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
+import android.util.Log;
 import android.view.Display;
 import android.view.WindowManager;
 
@@ -44,6 +45,7 @@ abstract class SystemObserver {
 
     private static final int GAID_FETCH_TIME_OUT = 1500;
     private String GAIDString_ = null;
+    private String GAIDInitializationSessionID;
     private int LATVal_ = 0;
 
     /**
@@ -302,16 +304,12 @@ abstract class SystemObserver {
      * Method to prefetch the GAID and LAT values.
      *
      * @param context Context.
-     * @param callback {@link GAdsParamsFetchEvents} instance to notify process completion
-     * @return {@link Boolean} with true if GAID fetch process started.
+     * @param callback {@link GAdsParamsFetchEvents} instance to notify process completion.
      */
-    boolean prefetchGAdsParams(Context context, GAdsParamsFetchEvents callback) {
-        boolean isPrefetchStarted = false;
-        if (TextUtils.isEmpty(GAIDString_)) {
-            isPrefetchStarted = true;
-            new GAdsPrefetchTask(context, callback).executeTask();
-        }
-        return isPrefetchStarted;
+    void prefetchGAdsParams(Context context, GAdsParamsFetchEvents callback) {
+        Log.i("TESTIN", "prefetchGAdsParams called");
+        GAIDInitializationSessionID = PrefHelper.getInstance(context).getSessionID();
+        new GAdsPrefetchTask(context, callback).executeTask();
     }
 
     /**
@@ -341,8 +339,12 @@ abstract class SystemObserver {
                     if (context != null) {
                         android.os.Process.setThreadPriority(android.os.Process.THREAD_PRIORITY_URGENT_AUDIO);
                         Object adInfoObj = getAdInfoObject(context);
-                        setAdvertisingId(adInfoObj);
                         setLATValue(adInfoObj);
+                        if (LATVal_ == 1) {
+                            GAIDString_ = null;
+                        } else {
+                            setAdvertisingId(adInfoObj);
+                        }
                     }
                     latch.countDown();
                 }
@@ -583,5 +585,9 @@ abstract class SystemObserver {
             return imei;
         }
         return null;
+    }
+
+    public String getGAIDInitializationSessionID() {
+        return GAIDInitializationSessionID;
     }
 }

--- a/Branch-SDK/src/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/io/branch/referral/SystemObserver.java
@@ -44,8 +44,10 @@ abstract class SystemObserver {
 
     private static final int GAID_FETCH_TIME_OUT = 1500;
     private String GAIDString_ = null;
-    private String GAIDInitializationSessionID;
     private int LATVal_ = 0;
+
+    /* Needed to avoid duplicating GAID initialization from App.onCreate and Activity.onStart */
+    private String AIDInitializationSessionID_;
 
     /**
      * <p>Gets the {@link String} value of the {@link Secure#ANDROID_ID} setting in the device. This
@@ -306,7 +308,7 @@ abstract class SystemObserver {
      * @param callback {@link GAdsParamsFetchEvents} instance to notify process completion.
      */
     void prefetchGAdsParams(Context context, GAdsParamsFetchEvents callback) {
-        GAIDInitializationSessionID = PrefHelper.getInstance(context).getSessionID();
+        AIDInitializationSessionID_ = PrefHelper.getInstance(context).getSessionID();
         new GAdsPrefetchTask(context, callback).executeTask();
     }
 
@@ -585,7 +587,7 @@ abstract class SystemObserver {
         return null;
     }
 
-    public String getGAIDInitializationSessionID() {
-        return GAIDInitializationSessionID;
+    String getAIDInitializationSessionID() {
+        return AIDInitializationSessionID_;
     }
 }

--- a/Branch-SDK/src/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/io/branch/referral/SystemObserver.java
@@ -12,7 +12,6 @@ import android.net.NetworkInfo;
 import android.provider.Settings.Secure;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.Display;
 import android.view.WindowManager;
 
@@ -307,7 +306,6 @@ abstract class SystemObserver {
      * @param callback {@link GAdsParamsFetchEvents} instance to notify process completion.
      */
     void prefetchGAdsParams(Context context, GAdsParamsFetchEvents callback) {
-        Log.i("TESTIN", "prefetchGAdsParams called");
         GAIDInitializationSessionID = PrefHelper.getInstance(context).getSessionID();
         new GAdsPrefetchTask(context, callback).executeTask();
     }


### PR DESCRIPTION
Addresses the fact that GAID is not `null`(i.e. not omitted from the payload) when limit ad tracking (LAT) is turned on, which was the core bug described in INTENG-7461 (please also see my comments in the ticket regarding LAT).

In addition, I reset GAID and LAT values on every app launch since it is possible to end up in a situation where user changes, say, their LAT preference while keeping the app in the background, then when the app is launched again, the SDK will behave as if LAT never changed. Sorry, I realize now that I should have created a separate ticket for this and I can do it + split up this PR, if it helps to archive and keep track of things. Let me know!
*******************************
Note, there is one more crazy edge case that I know will fail to update LAT/GAID references within the SDK and that is when the user is in a split screen mode (i.e. Settings/BranchSKD-enabled-App):

- user starts app with LAT disabled,
- switched settings app and changes LAT value,
- clicks on the app again.

The reason this will fail is because the app will not call `Activity.onCreate()` (where I refresh GAID) only `Activity.onResume()`, however IMHO this is better than refreshing  GAID on every `Activity.onResume()` because refreshing GAID creates and AsyncTask, which is arguably costly.