### PR TITLE
SDK-649

### DIFF
--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
@@ -471,6 +471,11 @@ public class MainActivity extends Activity {
     @Override
     public void onNewIntent(Intent intent) {
         this.setIntent(intent);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
         Branch.getInstance().reInitSession(this, new BranchReferralInitListener() {
             @Override
             public void onInitFinished(JSONObject referringParams, BranchError error) {

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
@@ -470,12 +470,8 @@ public class MainActivity extends Activity {
 
     @Override
     public void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
         this.setIntent(intent);
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
         Branch.getInstance().reInitSession(this, new BranchReferralInitListener() {
             @Override
             public void onInitFinished(JSONObject referringParams, BranchError error) {

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2554,6 +2554,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             }
         }
 
+        // Re 'forceBranchSession':
         // Check if new session is being forced. There are two use cases for setting the ForceNewBranchSession to true:
         // 1. Launch an activity via a push notification while app is in foreground but does not have
         // the particular activity in the backstack, in such cases, users can't utilize reInitSession() because
@@ -2565,9 +2566,9 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                 currentActivityReference_.get().getIntent() : null;
         boolean forceBranchSession = checkIntentForSessionRestart(intent);
 
-        boolean reInitSession = !isFirstInitialization;// use case: launch current (or former but currently partially visible) activity via a push notification
+        // !isFirstInitialization condition equals true only when user calls reInitSession()
 
-        if (getInitState() == SESSION_STATE.UNINITIALISED || reInitSession | forceBranchSession) {
+        if (getInitState() == SESSION_STATE.UNINITIALISED || !isFirstInitialization || forceBranchSession) {
             registerAppInit(initRequest, false);
         } else if (callback != null) {
             // Else, let the user know session initialization failed because it's already initialized.

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchError.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchError.java
@@ -42,7 +42,7 @@ public class BranchError {
     public static final int ERR_BRANCH_INVALID_REQUEST = -116;
     /* Tracking is disabled. Requested operations will not work when tracking is disabled */
     public static final int ERR_BRANCH_TRACKING_DISABLED = -117;
-    /* Tracking is disabled. Requested operations will not work when tracking is disabled */
+    /* Branch session is already initialized */
     public static final int ERR_BRANCH_ALREADY_INITIALIZED = -118;
     
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchError.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchError.java
@@ -42,6 +42,8 @@ public class BranchError {
     public static final int ERR_BRANCH_INVALID_REQUEST = -116;
     /* Tracking is disabled. Requested operations will not work when tracking is disabled */
     public static final int ERR_BRANCH_TRACKING_DISABLED = -117;
+    /* Tracking is disabled. Requested operations will not work when tracking is disabled */
+    public static final int ERR_BRANCH_ALREADY_INITIALIZED = -118;
     
     /**
      * <p>Returns the message explaining the error.</p>
@@ -128,6 +130,10 @@ public class BranchError {
         } else if (statusCode == ERR_BRANCH_TRACKING_DISABLED) {
             errorCode_ = ERR_BRANCH_TRACKING_DISABLED;
             errMsg = " Tracking is disabled. Requested operation cannot be completed when tracking is disabled";
+        } else if (statusCode == ERR_BRANCH_ALREADY_INITIALIZED) {
+            errorCode_ = ERR_BRANCH_ALREADY_INITIALIZED;
+            errMsg = " Session initialization already happened. To force a new session, " +
+                    "set intent extra, branch_force_new_session=true, and call reInitSession()";
         } else if (statusCode >= 500 || statusCode == ERR_BRANCH_UNABLE_TO_REACH_SERVERS) {
             errorCode_ = ERR_BRANCH_UNABLE_TO_REACH_SERVERS;
             errMsg = " Unable to reach the Branch servers, please try again shortly.";


### PR DESCRIPTION
The main thing in this PR is returning an error on consecutive session initialization (aka when session is already initialized but initSession is called again).

Removed check for `branch_force_new_session` in reinitSession because it is now expected to be called from `onNewIntent` (this is actually a separate ticket, SDK-654)

Overloaded `reInitSession` so it can be called with `BranchUniversalReferralInitListener` not just `BranchReferralInitListener`