### PR TITLE
Sdk 661/test plan for initialization

### DIFF
--- a/Branch-SDK-TestBed/InitializationTestPlan.md
+++ b/Branch-SDK-TestBed/InitializationTestPlan.md
@@ -10,7 +10,10 @@ be updated. Unless noted, initialization is expected to work in all scenarios.
 * Application can have multiple activities (all non-routing activities 
 are called `RoutedActivity`)
 * Latest Branch SDK version is being used
-* `initSession` is only called in the `RoutingActivity.onStart`.
+
+
+## Scenario #1:
+* `initSession` is only called in `RoutingActivity.onStart`.
 
 
 ##### 1. Application in background
@@ -36,9 +39,10 @@ will also clear cache and stored data). Open app.
 ##### Hot start:
 * Repro: Close app via the home button. Open app.
 * Initialization entry point is either `RoutingActivity.onStart` or 
-`BranchActivityLifecycleObserver.onResume` depending which activity the 
-user was last on. However, if app is opened via a push notification, the 
-Initialization entry point is guaranteed to be `RoutingActivity.onStart`.
+`BranchActivityLifecycleObserver.onResume` depending on whether `RoutingActivity` 
+or `RoutedActivity` was in foreground last. However, if app is opened via 
+a push notification, the Initialization entry point is guaranteed to be 
+`RoutingActivity.onStart`.
 
 
 ##### 2. Application in foreground
@@ -67,10 +71,7 @@ expect an initialization failure:
     semi-transparent or is not using the full screen)
 
 
-## Assumptions set #2:
-* User followed [Android documentation](https://docs.branch.io/apps/android/)
-* Application can have multiple activities
-* Latest Branch SDK version is being used
+## Scenario #2:
 * `initSession` is called in both `RoutingActivity` and `RoutedActivity`
 
 ##### 1. Application in foreground

--- a/Branch-SDK-TestBed/InitializationTestPlan.md
+++ b/Branch-SDK-TestBed/InitializationTestPlan.md
@@ -16,14 +16,14 @@ be updated. Unless noted, initialization is expected to work in all scenarios.
 * `initSession` is only called in `SplashActivity.onStart`.
 
 
-##### 1. Application in background
+### 1. Application in background
 ```
 Test by opening the app via:
 * launcher icon
 * recent apps tray (not available in cold start)
 * push notification
 ```
-##### Cold start:
+### Cold start:
 * Repro: Close app and remove it from the recent apps list
 (not 100% guarantee that this will work because manufacturers determine
 if application is killed when removed from recents list). Alternatively,
@@ -32,11 +32,11 @@ will also clear cache and stored data). Open app.
 * Initialization entry point = `SplashActivity.onCreate`
 
 
-##### Warm start:
+### Warm start:
 * Repro: Close app via the back button. Open app.
 * Initialization entry point = `SplashActivity.onCreate`
 
-##### Hot start:
+### Hot start:
 * Repro: Close app via the home button. Open app.
 * Initialization entry point is either `SplashActivity.onStart` or 
 `BranchActivityLifecycleObserver.onResume` depending on whether `SplashActivity` 
@@ -45,12 +45,12 @@ a push notification, the Initialization entry point is guaranteed to be
 `SplashActivity.onStart`.
 
 
-##### 2. Application in foreground
+### 2. Application in foreground
 ```
 Test by opening the app via:
 * push notification
 ```
-##### Burning hot start:
+### Burning hot start:
 * Repro: have the app open
 * Initialization entry point = either `SplashActivity.onNewIntent` 
 or `SplashActivity.onStart` depending if user is currently on `SplashActivity`
@@ -74,7 +74,7 @@ expect an initialization failure:
 ## Scenario #2:
 * `initSession` is called in both `SplashActivity` and `NextActivity`
 
-##### 1. Application in foreground
+### 1. Application in foreground
 ```
 Test by opening the app via push notification launching `NextActivity`:
 * when `NextActivity` is currently in foreground
@@ -84,7 +84,7 @@ but user is currently on another `NextActivity`)
 `NextActivity` has NOT been launched before)
 ```
 
-##### Burning hot start:
+### Burning hot start:
 * Repro: have the app open
 
 Again, there are expected failures when `reInitSession` is NOT used in `NextActivity`

--- a/Branch-SDK-TestBed/InitializationTestPlan.md
+++ b/Branch-SDK-TestBed/InitializationTestPlan.md
@@ -5,7 +5,7 @@ find bugs arising from unforeseen initialization scenarios, this list should
 be updated. Unless noted, initialization is expected to work in all scenarios.
 
 
-## Assumptions set #1:
+## Assumptions:
 * User followed [Android documentation](https://docs.branch.io/apps/android/)
 * Application can have multiple activities (all non-routing activities 
 are called `RoutedActivity`)

--- a/Branch-SDK-TestBed/InitializationTestPlan.md
+++ b/Branch-SDK-TestBed/InitializationTestPlan.md
@@ -23,7 +23,7 @@ Test by opening the app via:
 * recent apps tray (not available in cold start)
 * push notification
 ```
-### Cold start:
+#### Cold start:
 * Repro: Close app and remove it from the recent apps list
 (not 100% guarantee that this will work because manufacturers determine
 if application is killed when removed from recents list). Alternatively,
@@ -32,11 +32,11 @@ will also clear cache and stored data). Open app.
 * Initialization entry point = `SplashActivity.onCreate`
 
 
-### Warm start:
+#### Warm start:
 * Repro: Close app via the back button. Open app.
 * Initialization entry point = `SplashActivity.onCreate`
 
-### Hot start:
+#### Hot start:
 * Repro: Close app via the home button. Open app.
 * Initialization entry point is either `SplashActivity.onStart` or 
 `BranchActivityLifecycleObserver.onResume` depending on whether `SplashActivity` 
@@ -50,7 +50,7 @@ a push notification, the Initialization entry point is guaranteed to be
 Test by opening the app via:
 * push notification
 ```
-### Burning hot start:
+#### Burning hot start:
 * Repro: have the app open
 * Initialization entry point = either `SplashActivity.onNewIntent` 
 or `SplashActivity.onStart` depending if user is currently on `SplashActivity`
@@ -84,7 +84,7 @@ but user is currently on another `NextActivity`)
 `NextActivity` has NOT been launched before)
 ```
 
-### Burning hot start:
+#### Burning hot start:
 * Repro: have the app open
 
 Again, there are expected failures when `reInitSession` is NOT used in `NextActivity`

--- a/Branch-SDK-TestBed/InitializationTestPlan.md
+++ b/Branch-SDK-TestBed/InitializationTestPlan.md
@@ -7,13 +7,13 @@ be updated. Unless noted, initialization is expected to work in all scenarios.
 
 ## Assumptions:
 * User followed [Android documentation](https://docs.branch.io/apps/android/)
-* Application can have multiple activities (all non-routing activities 
-are called `RoutedActivity`)
+* Application can have multiple activities (launcher activity is called
+`SplashActivity` and all others are `NextActivity`)
 * Latest Branch SDK version is being used
 
 
 ## Scenario #1:
-* `initSession` is only called in `RoutingActivity.onStart`.
+* `initSession` is only called in `SplashActivity.onStart`.
 
 
 ##### 1. Application in background
@@ -29,20 +29,20 @@ Test by opening the app via:
 if application is killed when removed from recents list). Alternatively,
 call `adb shell pm clear my.app.package.id` from the command line (this 
 will also clear cache and stored data). Open app.
-* Initialization entry point = `RoutingActivity.onCreate`
+* Initialization entry point = `SplashActivity.onCreate`
 
 
 ##### Warm start:
 * Repro: Close app via the back button. Open app.
-* Initialization entry point = `RoutingActivity.onCreate`
+* Initialization entry point = `SplashActivity.onCreate`
 
 ##### Hot start:
 * Repro: Close app via the home button. Open app.
-* Initialization entry point is either `RoutingActivity.onStart` or 
-`BranchActivityLifecycleObserver.onResume` depending on whether `RoutingActivity` 
-or `RoutedActivity` was in foreground last. However, if app is opened via 
+* Initialization entry point is either `SplashActivity.onStart` or 
+`BranchActivityLifecycleObserver.onResume` depending on whether `SplashActivity` 
+or `NextActivity` was in foreground last. However, if app is opened via 
 a push notification, the Initialization entry point is guaranteed to be 
-`RoutingActivity.onStart`.
+`SplashActivity.onStart`.
 
 
 ##### 2. Application in foreground
@@ -52,41 +52,41 @@ Test by opening the app via:
 ```
 ##### Burning hot start:
 * Repro: have the app open
-* Initialization entry point = either `RoutingActivity.onNewIntent` 
-or `RoutingActivity.onStart` depending if user is currently on `RoutingActivity`
-or `RoutedActivity` respectively. There is one exception, if the user is on
-`RoutedActivity` but `RoutingActivity` is still partially visible, then the 
-entry point will be `RoutingActivity.onNewIntent`.
+* Initialization entry point = either `SplashActivity.onNewIntent` 
+or `SplashActivity.onStart` depending if user is currently on `SplashActivity`
+or `NextActivity` respectively. There is one exception, if the user is on
+`NextActivity` but `SplashActivity` is still partially visible, then the 
+entry point will be `SplashActivity.onNewIntent`.
 
 There are four possible scenarios the users can find themselves in, 
 `reInitSession` is either called or not and the user is currently in 
-`RoutingActivity` or in `RoutedActivity`. Note that documentation gives 
+`SplashActivity` or in `NextActivity`. Note that documentation gives 
 instructions to use `reInitSession`, however it's a new instruction, so 
 it may be overlooked by existing users. When the latter happens, we may 
 expect an initialization failure:
 * `reInitSession` is not used (i.e. not following documentation)
-    * User is in `RoutingActivity` = Branch initialization is guaranteed to FAIL
-    * User is in `RoutedActivity` = Branch initialization is expected work _unless_ 
-    `RoutingActivity` is still partially visible (e.g. `RoutedActivity` is
+    * User is in `SplashActivity` = Branch initialization is guaranteed to FAIL
+    * User is in `NextActivity` = Branch initialization is expected work _unless_ 
+    `SplashActivity` is still partially visible (e.g. `NextActivity` is
     semi-transparent or is not using the full screen)
 
 
 ## Scenario #2:
-* `initSession` is called in both `RoutingActivity` and `RoutedActivity`
+* `initSession` is called in both `SplashActivity` and `NextActivity`
 
 ##### 1. Application in foreground
 ```
-Test by opening the app via push notification launching `RoutedActivity`:
-* when `RoutedActivity` is currently in foreground
-* when `RoutedActivity` is in backstack (e.g. has been launched before 
-but user is currently on another `RoutedActivity`)
-* when `RoutedActivity` is NOT in backstack (e.g. this particular 
-`RoutedActivity` has NOT been launched before)
+Test by opening the app via push notification launching `NextActivity`:
+* when `NextActivity` is currently in foreground
+* when `NextActivity` is in backstack (e.g. has been launched before 
+but user is currently on another `NextActivity`)
+* when `NextActivity` is NOT in backstack (e.g. this particular 
+`NextActivity` has NOT been launched before)
 ```
 
 ##### Burning hot start:
 * Repro: have the app open
 
-Again, there are expected failures when `reInitSession` is NOT used in `RoutedActivity`
-* user is currently in `RoutedActivity` = guaranteed initialization failure
-* `RoutedActivity` is in backstack BUT partially visible
+Again, there are expected failures when `reInitSession` is NOT used in `NextActivity`
+* user is currently in `NextActivity` = guaranteed initialization failure
+* `NextActivity` is in backstack BUT partially visible

--- a/Branch-SDK-TestBed/InitializationTestPlan.md
+++ b/Branch-SDK-TestBed/InitializationTestPlan.md
@@ -1,0 +1,64 @@
+# Test plan for different initialization scenarios
+
+This is a test plan enlisting possible initialization scenarios. As CSMs
+find bugs arising from unforeseen initialization scenarios, this list should be updated.
+
+
+### Assumptions:
+* User followed [Android documentation](https://docs.branch.io/apps/android/), 
+so `initSession` is only called in the `RoutingActivity` (aka `LaunchActivity`).
+* Application can have multiple activities (all non-routing activities 
+will be called `RoutedActivity`)
+* Latest Branch SDK version is being used
+
+
+## Scenarios
+
+##### Application in background
+
+Test by opening the app via:
+* launcher icon
+* recent apps tray (not available in cold start)
+* push notification
+
+Cold start: entry point = `RoutingActivity.onCreate`
+* Repro: Close app and remove it from the recent apps list
+(not 100% guarantee that this will work because manufacturers determine
+if application is killed when removed from recents list). Alternatively,
+call `adb shell pm clear my.app.package.id` from the command line (this 
+will also clear cache and stored data). Open app.
+
+
+Warm start: entry point = `RoutingActivity.onCreate`
+* Repro: Close app via the back button. Open app.
+
+Hot start: entry point is either `RoutingActivity.onStart` or `RoutedActivity.onStart` 
+depending which activity the user was last on. However, if app is opened 
+via a push notification, the entry point is guaranteed to be `RoutingActivity.onStart`.
+* Repro: Close app via the home button. Open app.
+
+
+##### Application in foreground
+
+Test by opening the app via:
+* push notification
+
+Burning hot start: entry point = either `RoutingActivity.onNewIntent` 
+or `RoutingActivity.onStart` depending if user is currently on `RoutingActivity`
+or `RoutedActivity` respectively. There is one exception, if the user is on
+`RoutedActivity` but `RoutingActivity` is still partially visible, then the 
+entry point will be `RoutingActivity.onNewIntent`.
+
+There are four possible scenarios the users can find themselves in, 
+`reInitSession` is either called or not and the user may may currently be 
+in either `RoutingActivity` or `RoutedActivity`. Note that documentation 
+gives instructions to use `reInitSession`, however it's a new instruction, 
+so it may be overlooked by existing users:
+* `reInitSession` is not used
+    * User is in `RoutingActivity` = Branch initialization is expected to FAIL
+    * User is in `RoutedActivity` = Branch initialization is expected work _unless_ 
+    `RoutingActivity` is still partially visible (e.g. `RoutedActivity` is
+    semi-transparent or is not using the full screen)
+* `reInitSession` is used
+    * User is in `RoutedActivity` = Branch initialization is expected work
+    * User is in `RoutingActivity` = Branch initialization is expected work

--- a/Branch-SDK-TestBed/InitializationTestPlan.md
+++ b/Branch-SDK-TestBed/InitializationTestPlan.md
@@ -1,64 +1,91 @@
-# Test plan for different initialization scenarios
+# Test plan for different (re)initialization scenarios
 
 This is a test plan enlisting possible initialization scenarios. As CSMs
-find bugs arising from unforeseen initialization scenarios, this list should be updated.
+find bugs arising from unforeseen initialization scenarios, this list should 
+be updated. Unless noted, initialization is expected to work in all scenarios.
 
 
-### Assumptions:
-* User followed [Android documentation](https://docs.branch.io/apps/android/), 
-so `initSession` is only called in the `RoutingActivity` (aka `LaunchActivity`).
+## Assumptions set #1:
+* User followed [Android documentation](https://docs.branch.io/apps/android/)
 * Application can have multiple activities (all non-routing activities 
-will be called `RoutedActivity`)
+are called `RoutedActivity`)
 * Latest Branch SDK version is being used
+* `initSession` is only called in the `RoutingActivity.onStart`.
 
 
-## Scenarios
-
-##### Application in background
-
+##### 1. Application in background
+```
 Test by opening the app via:
 * launcher icon
 * recent apps tray (not available in cold start)
 * push notification
-
-Cold start: entry point = `RoutingActivity.onCreate`
+```
+##### Cold start:
 * Repro: Close app and remove it from the recent apps list
 (not 100% guarantee that this will work because manufacturers determine
 if application is killed when removed from recents list). Alternatively,
 call `adb shell pm clear my.app.package.id` from the command line (this 
 will also clear cache and stored data). Open app.
+* Initialization entry point = `RoutingActivity.onCreate`
 
 
-Warm start: entry point = `RoutingActivity.onCreate`
+##### Warm start:
 * Repro: Close app via the back button. Open app.
+* Initialization entry point = `RoutingActivity.onCreate`
 
-Hot start: entry point is either `RoutingActivity.onStart` or `RoutedActivity.onStart` 
-depending which activity the user was last on. However, if app is opened 
-via a push notification, the entry point is guaranteed to be `RoutingActivity.onStart`.
+##### Hot start:
 * Repro: Close app via the home button. Open app.
+* Initialization entry point is either `RoutingActivity.onStart` or 
+`BranchActivityLifecycleObserver.onResume` depending which activity the 
+user was last on. However, if app is opened via a push notification, the 
+Initialization entry point is guaranteed to be `RoutingActivity.onStart`.
 
 
-##### Application in foreground
-
+##### 2. Application in foreground
+```
 Test by opening the app via:
 * push notification
-
-Burning hot start: entry point = either `RoutingActivity.onNewIntent` 
+```
+##### Burning hot start:
+* Repro: have the app open
+* Initialization entry point = either `RoutingActivity.onNewIntent` 
 or `RoutingActivity.onStart` depending if user is currently on `RoutingActivity`
 or `RoutedActivity` respectively. There is one exception, if the user is on
 `RoutedActivity` but `RoutingActivity` is still partially visible, then the 
 entry point will be `RoutingActivity.onNewIntent`.
 
 There are four possible scenarios the users can find themselves in, 
-`reInitSession` is either called or not and the user may may currently be 
-in either `RoutingActivity` or `RoutedActivity`. Note that documentation 
-gives instructions to use `reInitSession`, however it's a new instruction, 
-so it may be overlooked by existing users:
-* `reInitSession` is not used
-    * User is in `RoutingActivity` = Branch initialization is expected to FAIL
+`reInitSession` is either called or not and the user is currently in 
+`RoutingActivity` or in `RoutedActivity`. Note that documentation gives 
+instructions to use `reInitSession`, however it's a new instruction, so 
+it may be overlooked by existing users. When the latter happens, we may 
+expect an initialization failure:
+* `reInitSession` is not used (i.e. not following documentation)
+    * User is in `RoutingActivity` = Branch initialization is guaranteed to FAIL
     * User is in `RoutedActivity` = Branch initialization is expected work _unless_ 
     `RoutingActivity` is still partially visible (e.g. `RoutedActivity` is
     semi-transparent or is not using the full screen)
-* `reInitSession` is used
-    * User is in `RoutedActivity` = Branch initialization is expected work
-    * User is in `RoutingActivity` = Branch initialization is expected work
+
+
+## Assumptions set #2:
+* User followed [Android documentation](https://docs.branch.io/apps/android/)
+* Application can have multiple activities
+* Latest Branch SDK version is being used
+* `initSession` is called in both `RoutingActivity` and `RoutedActivity`
+
+##### 1. Application in foreground
+```
+Test by opening the app via push notification launching `RoutedActivity`:
+* when `RoutedActivity` is currently in foreground
+* when `RoutedActivity` is in backstack (e.g. has been launched before 
+but user is currently on another `RoutedActivity`)
+* when `RoutedActivity` is NOT in backstack (e.g. this particular 
+`RoutedActivity` has NOT been launched before)
+```
+
+##### Burning hot start:
+* Repro: have the app open
+
+Again, there are expected failures when `reInitSession` is NOT used in `RoutedActivity`
+* user is currently in `RoutedActivity` = guaranteed initialization failure
+* `RoutedActivity` is in backstack BUT partially visible


### PR DESCRIPTION
TestBed app is unfortunately not yet ready for testing initialization scenarios.

BMF is ready though, specifically the branches `test-initialization-scenario-1` and `test-initialization-scenario-2`. The numbers in the latter branch names correspond to the test scenarios described in the test document (see this PR).

Notes
test-initialization-scenario-1
Note that creator activity -> back clicked -> deeplink to splash activity
Note that viewer activity -> back clicked -> deeplink to splash activity
Note that info activity -> go to branch clicked -> deeplink to splash activity
if you want to test semitransparent activities just override the themes of all non-splash activities to `android:theme="@style/Theme.Translucent"`

test-initialization-scenario-2 
Note that creator activity -> back clicked -> deeplink to viewer activity (test deeplink to activity NOT in backstack, don't forget to clean data prior to testing this particular case)
Note that viewer activity -> back clicked -> deeplink to viewer activity
Note that info activity -> go to branch clicked -> deeplink to viewer activity (test deeplink to activity in backstack)
if you want to test semitransparent activities just override the themes of all non-splash activities to `android:theme="@style/Theme.Translucent"`