### PR TITLE
SDK-723

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2791,7 +2791,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      * @see BranchError
      */
     public interface BranchReferralInitListener {
-        void onInitFinished(JSONObject referringParams, BranchError error);
+        void onInitFinished(@Nullable JSONObject referringParams, @Nullable BranchError error);
     }
     
     /**
@@ -2806,7 +2806,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      * @see BranchError
      */
     public interface BranchUniversalReferralInitListener {
-        void onInitFinished(BranchUniversalObject branchUniversalObject, LinkProperties linkProperties, BranchError error);
+        void onInitFinished(@Nullable BranchUniversalObject branchUniversalObject, @Nullable LinkProperties linkProperties, @Nullable BranchError error);
     }
     
     
@@ -2820,7 +2820,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      * @see BranchError
      */
     public interface BranchReferralStateChangedListener {
-        void onStateChanged(boolean changed, BranchError error);
+        void onStateChanged(boolean changed, @Nullable BranchError error);
     }
     
     /**


### PR DESCRIPTION
Added annotation to indicate returned object nullability in branch init session listeners because, if kotlin misspecifies them, the listener will not be invoked.