### PR TITLE
SDK-757 -- Update Strong Match Helper to use androidx

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/BranchStrongMatchHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchStrongMatchHelper.java
@@ -42,9 +42,9 @@ class BranchStrongMatchHelper {
 
     {
         try {
-            CustomTabsClientClass = Class.forName("android.support.customtabs.CustomTabsClient");
-            CustomTabsCallbackClass = Class.forName("android.support.customtabs.CustomTabsCallback");
-            CustomTabsSessionClass = Class.forName("android.support.customtabs.CustomTabsSession");
+            CustomTabsClientClass = Class.forName("androidx.browser.customtabs.CustomTabsClient");
+            CustomTabsCallbackClass = Class.forName("androidx.browser.customtabs.CustomTabsCallback");
+            CustomTabsSessionClass = Class.forName("androidx.browser.customtabs.CustomTabsSession");
             ICustomTabsServiceClass = Class.forName("android.support.customtabs.ICustomTabsService");
         } catch (Throwable t) {
             isCustomTabsAvailable_ = false;


### PR DESCRIPTION
## Reference
SDK-757 -- Update Strong Match Helper to use androidx.

## Description
The documentation advises to add com.android.support:customtabs to dependencies for 100% matching. However the customtabs library has been superseded by the androidx.browser:browser library.

## Implementation Notes
Not all of the class strings port as expected.  The CustomTabService is still in the android support library.   This is something that is a little unexpected, however looking at the service implementation the strings can be found here:  https://android.googlesource.com/platform/frameworks/support/+/a9ac247af2afd4115c3eb6d16c05bc92737d6305/browser/src/main/java/androidx/browser/customtabs/CustomTabsService.java

## Testing Instructions
Using the Branch SDK TestBed application,
* Option 1: Using the debugger, step through the code and ensure the methods are found correctly
* Option 2: Check ADB Debug output.   There should be a line in there
```
BranchSDK: Strong match request https://app.link/_strong_match...
```

## Risk Assessment [`MEDIUM`]
Medium Risk, as the strong matching is all reflection based and not all methods are in the androidx library.

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.