### PR TITLE
WIP: INFRA-3814 -- Enable multiple android version builds during CI/CD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/
 .metadata/*
 
 *.gen
+*.pyc
 bin/
 gen/
 

--- a/deploy/build_and_test.py
+++ b/deploy/build_and_test.py
@@ -68,7 +68,7 @@ if __name__ == '__main__':
         # Start running the instrumentation tests
         print formatted_text.in_bold("Running instrumentation tests...")
         os.chdir("./Branch-SDK/")
-        execute_command("gradle connectedCheck --info")
+        execute_command("../gradlew connectedCheck --info")
         print formatted_text.in_bold_green("Finished running the instrumentation tests.\n")
 
     except subprocess.CalledProcessError as e:

--- a/deploy/build_and_test.py
+++ b/deploy/build_and_test.py
@@ -2,6 +2,8 @@
 
 import os
 import subprocess
+import tempfile
+import time
 
 # Custom modules
 from helpers import formatted_text
@@ -21,49 +23,107 @@ def execute_command(cmd, stdout=None, stderr=None):
         print formatted_text.in_bold_red("Exit code: {0}".format(p.returncode))
         raise subprocess.CalledProcessError(p.returncode, cmd, output=stdout)
 
+def restart_adb():
+    # Restart the adb service
+    print formatted_text.in_bold("Restarting the adb service...")
+    execute_command("$ANDROID_HOME/platform-tools/adb kill-server")
+    execute_command("$ANDROID_HOME/platform-tools/adb start-server")
+    execute_command("$ANDROID_HOME/platform-tools/adb devices")
+    print formatted_text.in_bold_green("Successfully finished restarting the adb service.\n")
+
+
+# Launch all AVDs that are available on the system
+def launch_avds():
+    fp, filepath = tempfile.mkstemp();
+    if not os.path.isfile(filepath):
+        print("File path {} does not exist.  Exiting...".format(filepath))
+        sys.exit()
+
+    execute_command("SHELL=/bin/bash $ANDROID_HOME/emulator/emulator -list-avds > {}".format(filepath))
+
+    avds = {}
+    avds = [line.rstrip('\n') for line in open(filepath)]
+
+    print "Launching {} AVDs".format(len(avds))
+
+    for device in avds:
+        try:
+            print("Launching AVD Device: {}...".format(device))
+            # execute_command("SHELL=/bin/bash $ANDROID_HOME/emulator/emulator -avd {} -wipe-data  &".format(device))
+            execute_command("SHELL=/bin/bash $ANDROID_HOME/emulator/emulator -avd {} &".format(device))
+            print formatted_text.in_bold_green("Finished spinning up the AVD.\n")
+
+            # Sleeping here as spinning up these too fast causes others not to start
+            time.sleep(1)
+        except subprocess.CalledProcessError as e:
+            print formatted_text.in_bold_red("Caught a CalledProcessError exception! The last command returned a non-zero exit code value of '{0}'.\n".format(e.returncode))
+            raise
+        except:
+            print formatted_text.in_bold_red("Caught an unexpected exception!\n")
+            raise
+
+    os.remove(filepath);
+
+
+# For each AVD, wait for it to start up
+def wait_avds():
+    print formatted_text.in_bold("Waiting for AVDs...")
+    fp, filepath = tempfile.mkstemp();
+    execute_command("SHELL=/bin/bash $ANDROID_HOME/platform-tools/adb devices | grep emulator | cut -f1 > {}".format(filepath))
+
+    emulators = {}
+    emulators = [line.rstrip('\n') for line in open(filepath)]
+
+    for device in emulators:
+        try:
+            print("Emulator: {}".format(device))
+
+            # Wait for the AVD to finish booting up
+            print formatted_text.in_bold("Waiting for AVD to finish booting up...")
+            execute_command("$ANDROID_HOME/platform-tools/adb -s {} wait-for-device".format(device))
+            print formatted_text.in_bold_green("AVD finished booting up.\n")
+
+            # Unlock the screen of the AVD
+            print formatted_text.in_bold("Unlocking the AVD screen...")
+            execute_command("$ANDROID_HOME/platform-tools/adb -s {} shell input keyevent 82 &".format(device))
+            print formatted_text.in_bold_green("Successfully unlocked the AVD screen.\n")
+        except subprocess.CalledProcessError as e:
+            print formatted_text.in_bold_red("Caught a CalledProcessError exception! The last command returned a non-zero exit code value of '{0}'.\n".format(e.returncode))
+            raise
+        except:
+            print formatted_text.in_bold_red("Caught an unexpected exception!\n")
+            raise
+
+    os.remove(filepath);
+
+# For each AVD, shut it down
+def close_avds():
+    print formatted_text.in_bold("Shutting down the AVD...")
+    execute_command("$ANDROID_HOME/platform-tools/adb devices | grep emulator | cut -f1 | while read line; do echo \"Killing $line\" && $ANDROID_HOME/platform-tools/adb -s $line emu kill; done")
+    print formatted_text.in_bold_green("Successfully shutdown the AVD.\n")
+
+
+def do_setup():
+    # Change into the '<some_absolute_path>/android-sdk/sdk-android/' directory
+    android_root_dir = os.getcwd() # <some_absolute_path>/android-sdk
+    print "Current Working Directory: {0}".format(android_root_dir)
+    sdk_android_dir = "../android-branch-deep-linking-attribution/" # <some_absolute_path>/android-sdk/sdk-android
+    os.chdir(sdk_android_dir)
+    print "Changed to the '{0}' directory\n".format(os.getcwd())
+
 
 # NOTE The build and test script starts here
 if __name__ == '__main__':
     try:
-        # Change into the '<some_absolute_path>/android-sdk/sdk-android/' directory
-        android_root_dir = os.getcwd() # <some_absolute_path>/android-sdk
-        print "Current Working Directory: {0}".format(android_root_dir)
-        sdk_android_dir = "../android-branch-deep-linking-attribution/" # <some_absolute_path>/android-sdk/sdk-android
-        os.chdir(sdk_android_dir)
-        print "Changed to the '{0}' directory\n".format(os.getcwd())
-
-        # # Execute the gradle 'generateRelease' task
-        # print formatted_text.in_bold("Building the Android SDK...")
-        # execute_command("./gradlew build")
-        # print formatted_text.in_bold_green("Successfully finished building the Android SDK.\n")
-
-        # Create a new AVD
-        print formatted_text.in_bold("Creating a new AVD...")
-        # execute_command("echo n | $ANDROID_HOME/tools/bin/avdmanager --verbose create avd -f -n emu -k 'system-images;android-27;google_apis;x86'")
-        print formatted_text.in_bold_green("\nSuccessfully created a new AVD.\n")
+        # Initialization
+        do_setup()
 
         # Restart the adb service
-        print formatted_text.in_bold("Restarting the adb service...")
-        execute_command("$ANDROID_HOME/platform-tools/adb kill-server")
-        execute_command("$ANDROID_HOME/platform-tools/adb start-server")
-        execute_command("$ANDROID_HOME/platform-tools/adb devices")
-        print formatted_text.in_bold_green("Successfully finished restarting the adb service.\n")
+        restart_adb()
 
-        # Start the newly created AVD
-        print formatted_text.in_bold("Spinning up the AVD...")
-        execute_command("SHELL=/bin/bash $ANDROID_HOME/emulator/emulator -avd Nexus_5X_API_27 -wipe-data  &")
-        execute_command("SHELL=/bin/bash $ANDROID_HOME/emulator/emulator -avd Nexus_5X_API_27  &")
-        print formatted_text.in_bold_green("Finished spinning up the AVD.\n")
-
-        # Wait for the AVD to finish booting up
-        print formatted_text.in_bold("Waiting for AVD to finish booting up...")
-        execute_command("$ANDROID_HOME/platform-tools/adb wait-for-device")
-        print formatted_text.in_bold_green("AVD finished booting up.\n")
-
-        # Unlock the screen of the AVD
-        print formatted_text.in_bold("Unlocking the AVD screen...")
-        execute_command("$ANDROID_HOME/platform-tools/adb shell input keyevent 82 &")
-        print formatted_text.in_bold_green("Successfully unlocked the AVD screen.\n")
+        # Launch all AVDs
+        launch_avds()
+        wait_avds()
 
         # Start running the instrumentation tests
         print formatted_text.in_bold("Running instrumentation tests...")
@@ -79,6 +139,4 @@ if __name__ == '__main__':
         raise
     finally:
         # Shutdown the running AVD
-        print formatted_text.in_bold("Shutting down the AVD...")
-        execute_command("$ANDROID_HOME/platform-tools/adb devices | grep emulator | cut -f1 | while read line; do echo \"Killing $line\" && $ANDROID_HOME/platform-tools/adb -s $line emu kill; done")
-        print formatted_text.in_bold_green("Successfully shutdown the AVD.\n")
+        close_avds()


### PR DESCRIPTION
## WORK IN PROGRESS
This is currently Work In Progress

## Reference
INFRA-3814 -- Enable multiple android version builds during CI/CD

## Description
Currently Android CI/CD builds run only against the current version of android. The SDK team wants the build to run against multiple Android versions so that they can reduce the chance of regression bugs against older versions of Android.

At a minimum, we should build against the lowest supported API version (16), and the current target API version (29).   It would be nice to have a couple in between as well.

## Testing Instructions
There are no code changes required for this build.   The python `build_and_deploy` script should run locally as well as on the CI/CD machine

## Risk Assessment [`LOW`]
CI/CD changes only.

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
