### PR TITLE
SDK-828/SDK-827

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/BranchError.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchError.java
@@ -133,7 +133,7 @@ public class BranchError {
         } else if (statusCode == ERR_BRANCH_ALREADY_INITIALIZED) {
             errorCode_ = ERR_BRANCH_ALREADY_INITIALIZED;
             errMsg = " Session initialization already happened. To force a new session, " +
-                    "set intent extra, branch_force_new_session=true OR call reInitSession()";
+                    "set intent extra, \"branch_force_new_session\", to true.";
         } else if (statusCode >= 500 || statusCode == ERR_BRANCH_UNABLE_TO_REACH_SERVERS) {
             errorCode_ = ERR_BRANCH_UNABLE_TO_REACH_SERVERS;
             errMsg = " Unable to reach the Branch servers, please try again shortly.";


### PR DESCRIPTION
## Reference
SDK-827 - reInitSession should work with just the "branch" extra
SDK-828 - do not eat callback in reInitSession

## Description
In previous PR, I inadvertently made reInitSession not work when the intent had a uri under the extra "branch" and a _missing_ extra "branch_used". This PR changes it back to the previous implementation where this combination of extras was allowed to reinitialize session.
In addition, when certain conditions were not met in reInitSession, we would eat the callback, I'm trying to remove all places where that can happen and invoke the callback with and error.

## Testing Instructions
Test BMF or any other app by reopening the app into the foregrounded Activity with a uri under the extra "branch" and a _missing_ extra "branch_used".

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
