### PR TITLE
fix operator typo, disabling forced fb app link check

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2564,7 +2564,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         }
 
         ServerRequestInitSession initRequest = getInstallOrOpenRequest(callback);
-        if (initState_ == SESSION_STATE.UNINITIALISED && (getSessionReferredLink() == null || enableFacebookAppLinkCheck_)) {
+        if (initState_ == SESSION_STATE.UNINITIALISED && getSessionReferredLink() == null && enableFacebookAppLinkCheck_) {
             // Check if opened by facebook with deferred install data
             boolean appLinkRqSucceeded = DeferredAppLinkDataHandler.fetchDeferredAppLinkData(
                     context_, new DeferredAppLinkDataHandler.AppLinkFetchEvents() {


### PR DESCRIPTION
## Reference
SDK-904 -- No Way to disable FB app link check.

## Description
As per https://branch.slack.com/archives/CS8E89QQ4/p1583766414157100 Alibaba never enabled FB app link check yet we still do it. After some investigation it seems like we left the wrong operator (`||` instead of `&&`) after the refactor in `v4.2.0`.

## Testing Instructions
Integrate Branch at the basic level (without ever calling `Branch.enableFacebookAppLinkCheck()`), run app in debug mode, observe `DeferredAppLinkDataHandler.fetchDeferredAppLinkData` being invoked, after this bug fix, it shouldn't happen anymore. 

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
