### PR TITLE
SDK-285 - Add public method to get SDK version number

### DIFF
--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchTest.java
@@ -77,6 +77,11 @@ public class BranchTest {
 
         Assert.assertEquals(branch, Branch.getInstance());
     }
+    
+    @Test
+    public void testSdkVersion() {
+        Assert.assertNotNull(Branch.getSdkVersionNumber());
+    }
 
     Context getTestContext() {
         return mContext;

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -3800,6 +3800,14 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     public static InitSessionBuilder sessionBuilder(Activity activity) {
         return new InitSessionBuilder(activity);
     }
+    
+    /**
+     * Method will return the current Branch SDK version number
+     * @return String value representing the current SDK version number (e.g. 4.3.2)
+     */
+    public static String getSdkVersionNumber() {
+        return BuildConfig.VERSION_NAME;
+    }
 
     //-------------------------- Branch Builders--------------------------------------//
 


### PR DESCRIPTION
## Reference
SDK-285

## Description
Added a public method to retrieve the current Branch SDK version number

## Testing Instructions
Run unit test `testSdkVersion` from within BranchTests

## Risk Assessment [`LOW`]

- [Phil Cappelli] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
