### PR TITLE
SDK-843 disable ad network callouts

### DIFF
--- a/Branch-SDK-TestBed/build.gradle
+++ b/Branch-SDK-TestBed/build.gradle
@@ -2,13 +2,15 @@ apply plugin: 'com.android.application'
 
 dependencies {
     implementation project(':Branch-SDK')
-    implementation ('com.google.android.gms:play-services-ads:16.0.0')
+    implementation('com.google.android.gms:play-services-ads:16.0.0')
 
     /* Add chrome custom tabs for guaranteed matching */
-    implementation ('androidx.browser:browser:1.0.0') {
+    implementation('androidx.browser:browser:1.0.0') {
         exclude module: 'support-v4'
     }
 
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
@@ -53,7 +55,5 @@ if (propFile.exists()) {
         android.buildTypes.release.signingConfig = null
     }
 } else {
-        android.buildTypes.release.signingConfig = null
+    android.buildTypes.release.signingConfig = null
 }
-
-

--- a/Branch-SDK-TestBed/build.gradle
+++ b/Branch-SDK-TestBed/build.gradle
@@ -2,15 +2,13 @@ apply plugin: 'com.android.application'
 
 dependencies {
     implementation project(':Branch-SDK')
-    implementation('com.google.android.gms:play-services-ads:16.0.0')
+    implementation ('com.google.android.gms:play-services-ads:16.0.0')
 
     /* Add chrome custom tabs for guaranteed matching */
-    implementation('androidx.browser:browser:1.0.0') {
+    implementation ('androidx.browser:browser:1.0.0') {
         exclude module: 'support-v4'
     }
 
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
@@ -55,5 +53,7 @@ if (propFile.exists()) {
         android.buildTypes.release.signingConfig = null
     }
 } else {
-    android.buildTypes.release.signingConfig = null
+        android.buildTypes.release.signingConfig = null
 }
+
+

--- a/Branch-SDK-TestBed/src/main/AndroidManifest.xml
+++ b/Branch-SDK-TestBed/src/main/AndroidManifest.xml
@@ -2,32 +2,28 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.branch.branchandroiddemo"
     android:versionCode="1"
-    android:versionName="1.0">
+    android:versionName="1.0" >
 
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:name=".CustomBranchApp"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
-        android:label="@string/app_name">
-        <activity android:name=".SettingsActivity"></activity>
+        android:label="@string/app_name"
+        android:name="io.branch.branchandroiddemo.CustomBranchApp" >
         <activity
-            android:name=".MainActivity"
+            android:name="io.branch.branchandroiddemo.MainActivity"
             android:label="@string/app_name"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
             <!-- Non AppLink example -->
             <intent-filter>
-                <data android:scheme="branchtest" />
-
+                <data android:scheme="branchtest"/>
                 <action android:name="android.intent.action.VIEW" />
-
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
             </intent-filter>
@@ -35,74 +31,46 @@
             <!-- AppLink example -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
-
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <!-- <data android:scheme="https" android:host="bnc.lt" android:pathPrefix="/your_app_id_obtained form Branch dash board " /> -->
-                <data
-                    android:host="bnc.lt"
-                    android:pathPrefix="/xhsd"
-                    android:scheme="https" /> <!-- Live App link -->
-                <data
-                    android:host="bnc.lt"
-                    android:pathPrefix="/Ojqd"
-                    android:scheme="https" /> <!-- Test App link -->
+                <data android:scheme="https" android:host="bnc.lt" android:pathPrefix="/xhsd" /> <!-- Live App link-->
+                <data android:scheme="https" android:host="bnc.lt" android:pathPrefix="/Ojqd" /> <!-- Test App link-->
             </intent-filter>
 
-            <!-- Custom App link example. You can create your custom app link domain on Branch dash board -->
+            <!-- Custom App link example. You can create your custom app link domain on Branch dash board-->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
-
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:host="bnctestbed.app.link"
-                    android:scheme="https" /> <!-- Custom App link - Live -->
-                <data
-                    android:host="bnctestbed-alternate.app.link"
-                    android:scheme="https" /> <!-- Custom App Alternate link - Live -->
-                <data
-                    android:host="bnctestbed.test-app.link"
-                    android:scheme="https" /> <!-- Custom App link - Test -->
-                <data
-                    android:host="bnctestbed-alternate.test-app.link"
-                    android:scheme="https" /> <!-- Custom App Alternate link - Test -->
+                <data android:scheme="https" android:host="bnctestbed.app.link" /> <!-- Custom App link - Live -->
+                <data android:scheme="https" android:host="bnctestbed-alternate.app.link" /> <!-- Custom App Alternate link - Live -->
+                <data android:scheme="https" android:host="bnctestbed.test-app.link" /> <!-- Custom App link - Test -->
+                <data android:scheme="https" android:host="bnctestbed-alternate.test-app.link" /> <!-- Custom App Alternate link - Test -->
             </intent-filter>
         </activity>
-        <activity android:name=".CreditHistoryActivity" />
-        <activity android:name=".AutoDeepLinkTestActivity">
 
+        <activity android:name="io.branch.branchandroiddemo.CreditHistoryActivity"/>
+
+        <activity android:name=".AutoDeepLinkTestActivity">
             <!-- Keys for auto deep linking this activity -->
-            <meta-data
-                android:name="io.branch.sdk.auto_link_keys"
-                android:value="auto_deeplink_key_1,auto_deeplink_key_2" />
+            <meta-data android:name="io.branch.sdk.auto_link_keys" android:value="auto_deeplink_key_1,auto_deeplink_key_2" />
 
             <!-- Deep link path for auto deep linking -->
-            <meta-data
-                android:name="io.branch.sdk.auto_link_path"
-                android:value="custom/path/*,another/path/" />
+            <meta-data android:name="io.branch.sdk.auto_link_path" android:value="custom/path/*,another/path/" />
 
             <!-- Optional request ID for launching this activity on auto deep link key matches -->
-            <meta-data
-                android:name="io.branch.sdk.auto_link_request_code"
-                android:value="@integer/AutoDeeplinkRequestCode" />
+            <meta-data android:name="io.branch.sdk.auto_link_request_code" android:value="@integer/AutoDeeplinkRequestCode" />
         </activity>
 
-        <meta-data
-            android:name="io.branch.sdk.TestMode"
-            android:value="true" /> <!-- Set to true to use Branch_Test_Key -->
-        <meta-data
-            android:name="io.branch.sdk.BranchKey"
-            android:value="key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv" />
-        <meta-data
-            android:name="io.branch.sdk.BranchKey.test"
-            android:value="key_test_hdcBLUy1xZ1JD0tKg7qrLcgirFmPPVJc" /> <!-- Optional. Set to true to disable auto deep link feature -->
-        <meta-data
-            android:name="io.branch.sdk.auto_link_disable"
-            android:value="false" />
+        <meta-data android:name="io.branch.sdk.TestMode" android:value="true" /> <!-- Set to true to use Branch_Test_Key -->
+        <meta-data android:name="io.branch.sdk.BranchKey" android:value="key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv" />
+        <meta-data android:name="io.branch.sdk.BranchKey.test" android:value="key_test_hdcBLUy1xZ1JD0tKg7qrLcgirFmPPVJc" />
+
+        <!-- Optional. Set to true to disable auto deep link feature-->
+        <meta-data android:name="io.branch.sdk.auto_link_disable" android:value="false"/>
 
         <uses-library android:name="android.test.runner" />
-    </application>
 
+    </application>
 </manifest>

--- a/Branch-SDK-TestBed/src/main/AndroidManifest.xml
+++ b/Branch-SDK-TestBed/src/main/AndroidManifest.xml
@@ -51,6 +51,7 @@
         </activity>
 
         <activity android:name="io.branch.branchandroiddemo.CreditHistoryActivity"/>
+        <activity android:name=".SettingsActivity"/>
 
         <activity android:name=".AutoDeepLinkTestActivity">
             <!-- Keys for auto deep linking this activity -->

--- a/Branch-SDK-TestBed/src/main/AndroidManifest.xml
+++ b/Branch-SDK-TestBed/src/main/AndroidManifest.xml
@@ -2,28 +2,32 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.branch.branchandroiddemo"
     android:versionCode="1"
-    android:versionName="1.0" >
+    android:versionName="1.0">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".CustomBranchApp"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
-        android:label="@string/app_name"
-        android:name="io.branch.branchandroiddemo.CustomBranchApp" >
+        android:label="@string/app_name">
+        <activity android:name=".SettingsActivity"></activity>
         <activity
-            android:name="io.branch.branchandroiddemo.MainActivity"
+            android:name=".MainActivity"
             android:label="@string/app_name"
-            android:launchMode="singleTask" >
+            android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
             <!-- Non AppLink example -->
             <intent-filter>
-                <data android:scheme="branchtest"/>
+                <data android:scheme="branchtest" />
+
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
             </intent-filter>
@@ -31,46 +35,74 @@
             <!-- AppLink example -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <!-- <data android:scheme="https" android:host="bnc.lt" android:pathPrefix="/your_app_id_obtained form Branch dash board " /> -->
-                <data android:scheme="https" android:host="bnc.lt" android:pathPrefix="/xhsd" /> <!-- Live App link-->
-                <data android:scheme="https" android:host="bnc.lt" android:pathPrefix="/Ojqd" /> <!-- Test App link-->
+                <data
+                    android:host="bnc.lt"
+                    android:pathPrefix="/xhsd"
+                    android:scheme="https" /> <!-- Live App link -->
+                <data
+                    android:host="bnc.lt"
+                    android:pathPrefix="/Ojqd"
+                    android:scheme="https" /> <!-- Test App link -->
             </intent-filter>
 
-            <!-- Custom App link example. You can create your custom app link domain on Branch dash board-->
+            <!-- Custom App link example. You can create your custom app link domain on Branch dash board -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="https" android:host="bnctestbed.app.link" /> <!-- Custom App link - Live -->
-                <data android:scheme="https" android:host="bnctestbed-alternate.app.link" /> <!-- Custom App Alternate link - Live -->
-                <data android:scheme="https" android:host="bnctestbed.test-app.link" /> <!-- Custom App link - Test -->
-                <data android:scheme="https" android:host="bnctestbed-alternate.test-app.link" /> <!-- Custom App Alternate link - Test -->
+
+                <data
+                    android:host="bnctestbed.app.link"
+                    android:scheme="https" /> <!-- Custom App link - Live -->
+                <data
+                    android:host="bnctestbed-alternate.app.link"
+                    android:scheme="https" /> <!-- Custom App Alternate link - Live -->
+                <data
+                    android:host="bnctestbed.test-app.link"
+                    android:scheme="https" /> <!-- Custom App link - Test -->
+                <data
+                    android:host="bnctestbed-alternate.test-app.link"
+                    android:scheme="https" /> <!-- Custom App Alternate link - Test -->
             </intent-filter>
         </activity>
-
-        <activity android:name="io.branch.branchandroiddemo.CreditHistoryActivity"/>
-
+        <activity android:name=".CreditHistoryActivity" />
         <activity android:name=".AutoDeepLinkTestActivity">
+
             <!-- Keys for auto deep linking this activity -->
-            <meta-data android:name="io.branch.sdk.auto_link_keys" android:value="auto_deeplink_key_1,auto_deeplink_key_2" />
+            <meta-data
+                android:name="io.branch.sdk.auto_link_keys"
+                android:value="auto_deeplink_key_1,auto_deeplink_key_2" />
 
             <!-- Deep link path for auto deep linking -->
-            <meta-data android:name="io.branch.sdk.auto_link_path" android:value="custom/path/*,another/path/" />
+            <meta-data
+                android:name="io.branch.sdk.auto_link_path"
+                android:value="custom/path/*,another/path/" />
 
             <!-- Optional request ID for launching this activity on auto deep link key matches -->
-            <meta-data android:name="io.branch.sdk.auto_link_request_code" android:value="@integer/AutoDeeplinkRequestCode" />
+            <meta-data
+                android:name="io.branch.sdk.auto_link_request_code"
+                android:value="@integer/AutoDeeplinkRequestCode" />
         </activity>
 
-        <meta-data android:name="io.branch.sdk.TestMode" android:value="true" /> <!-- Set to true to use Branch_Test_Key -->
-        <meta-data android:name="io.branch.sdk.BranchKey" android:value="key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv" />
-        <meta-data android:name="io.branch.sdk.BranchKey.test" android:value="key_test_hdcBLUy1xZ1JD0tKg7qrLcgirFmPPVJc" />
-
-        <!-- Optional. Set to true to disable auto deep link feature-->
-        <meta-data android:name="io.branch.sdk.auto_link_disable" android:value="false"/>
+        <meta-data
+            android:name="io.branch.sdk.TestMode"
+            android:value="true" /> <!-- Set to true to use Branch_Test_Key -->
+        <meta-data
+            android:name="io.branch.sdk.BranchKey"
+            android:value="key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv" />
+        <meta-data
+            android:name="io.branch.sdk.BranchKey.test"
+            android:value="key_test_hdcBLUy1xZ1JD0tKg7qrLcgirFmPPVJc" /> <!-- Optional. Set to true to disable auto deep link feature -->
+        <meta-data
+            android:name="io.branch.sdk.auto_link_disable"
+            android:value="false" />
 
         <uses-library android:name="android.test.runner" />
-
     </application>
+
 </manifest>

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
@@ -374,6 +374,14 @@ public class MainActivity extends Activity {
             }
         });
 
+        findViewById(R.id.settings_btn).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent intent = new Intent(getApplicationContext(), SettingsActivity.class);
+                startActivity(intent);
+            }
+        });
+
         // Tracking events
         findViewById(R.id.cmdTrackCustomEvent).setOnClickListener(new OnClickListener() {
             @Override

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/SettingsActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/SettingsActivity.java
@@ -1,0 +1,39 @@
+package io.branch.branchandroiddemo;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Switch;
+
+import io.branch.referral.Branch;
+import io.branch.referral.Defines;
+import io.branch.referral.PrefHelper;
+
+public class SettingsActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_settings);
+
+        final Switch disableAdNetworkCalloutsSwitch = findViewById(R.id.disable_ad_network_callouts);
+
+        /*
+         * Initialize switch state from SharedPreferences.
+         */
+        final PrefHelper prefHelper = PrefHelper.getInstance(this);
+        disableAdNetworkCalloutsSwitch.setChecked(prefHelper.getAdNetworkCalloutsDisabled());
+
+        /*
+         * Update the setting whenever the switch changes state.
+         */
+        disableAdNetworkCalloutsSwitch.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Branch.getInstance().disableAdNetworkCallouts(disableAdNetworkCalloutsSwitch.isChecked());
+            }
+        });
+    }
+}

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/SettingsActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/SettingsActivity.java
@@ -1,23 +1,25 @@
 package io.branch.branchandroiddemo;
 
-import androidx.appcompat.app.AppCompatActivity;
+import android.app.Activity;
 
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Switch;
 
 import io.branch.referral.Branch;
-import io.branch.referral.Defines;
 import io.branch.referral.PrefHelper;
 
-public class SettingsActivity extends AppCompatActivity {
+public class SettingsActivity extends Activity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_settings);
 
+        setupDisableAdNetworkCalloutsSwitch();
+     }
+
+    void setupDisableAdNetworkCalloutsSwitch() {
         final Switch disableAdNetworkCalloutsSwitch = findViewById(R.id.disable_ad_network_callouts);
 
         /*
@@ -35,5 +37,6 @@ public class SettingsActivity extends AppCompatActivity {
                 Branch.getInstance().disableAdNetworkCallouts(disableAdNetworkCalloutsSwitch.isChecked());
             }
         });
+
     }
 }

--- a/Branch-SDK-TestBed/src/main/res/layout/activity_main.xml
+++ b/Branch-SDK-TestBed/src/main/res/layout/activity_main.xml
@@ -149,6 +149,14 @@
                 android:text="Fire notif"
                 android:layout_marginTop="20dp"/>
 
+            <Button
+                android:id="@+id/settings_btn"
+                style="@style/testbed_button_style"
+                android:layout_below="@+id/notif_btn"
+                android:layout_centerHorizontal="true"
+                android:text="@string/settings"
+                android:layout_marginTop="20dp"/>
+
         </RelativeLayout>
 
     </ScrollView>

--- a/Branch-SDK-TestBed/src/main/res/layout/activity_settings.xml
+++ b/Branch-SDK-TestBed/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical" >
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:text="@string/disable_ad_network_callouts"/>
+        <Switch
+            android:id="@+id/disable_ad_network_callouts"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+    </LinearLayout>
+</LinearLayout>

--- a/Branch-SDK-TestBed/src/main/res/layout/activity_settings.xml
+++ b/Branch-SDK-TestBed/src/main/res/layout/activity_settings.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical" >
+    android:orientation="vertical">
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/Branch-SDK-TestBed/src/main/res/values/strings.xml
+++ b/Branch-SDK-TestBed/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="launch_mode_normal">"Launched by normal application flow"</string>
 
     <string name="disable_ad_network_callouts">Disable ad network callouts</string>
+    <string name="settings">Settings</string>
 </resources>

--- a/Branch-SDK-TestBed/src/main/res/values/strings.xml
+++ b/Branch-SDK-TestBed/src/main/res/values/strings.xml
@@ -11,4 +11,5 @@
     <string name="launch_mode_branch">"Launched by Branch on auto deep linking!"</string>
     <string name="launch_mode_normal">"Launched by normal application flow"</string>
 
+    <string name="disable_ad_network_callouts">Disable ad network callouts</string>
 </resources>

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
@@ -1,14 +1,10 @@
 package io.branch.referral;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.Build;
 
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.prefs.Preferences;
-
 
 public class PrefHelperTest extends BranchTest {
 

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
@@ -1,10 +1,13 @@
 package io.branch.referral;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Build;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.prefs.Preferences;
 
 
 public class PrefHelperTest extends BranchTest {
@@ -52,5 +55,23 @@ public class PrefHelperTest extends BranchTest {
     public void testSetAPIUrl_InvalidEmpty() {
         PrefHelper.setAPIUrl("");
         assertDefaultURL();
+    }
+
+    @Test
+    public void testSetAdNetworkCalloutsDisabled() {
+        Context context = getTestContext();
+        PrefHelper prefHelper = PrefHelper.getInstance(context);
+        prefHelper.setAdNetworkCalloutsDisabled(true);
+
+        Assert.assertTrue(prefHelper.getAdNetworkCalloutsDisabled());
+    }
+
+    @Test
+    public void testSetAdNetworkCalloutsEnabled() {
+        Context context = getTestContext();
+        PrefHelper prefHelper = PrefHelper.getInstance(context);
+        prefHelper.setAdNetworkCalloutsDisabled(false);
+
+        Assert.assertFalse(prefHelper.getAdNetworkCalloutsDisabled());
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -469,7 +469,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     /**
      * Disables debug mode for the SDK.
      */
-    public void disableDebugMode() {
+    public static void disableDebugMode() {
         BranchUtil.setDebugMode(false);
     }
 
@@ -478,7 +478,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      *
      * @param disabled (@link Boolean) whether ad network callouts should be disabled.
      */
-    public void disableAdNetworkCallouts(boolean disabled = true) {
+    public void disableAdNetworkCallouts(boolean disabled) {
         PrefHelper.getInstance(context_).setAdNetworkCalloutsDisabled(disabled);
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -469,8 +469,15 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     /**
      * Disables debug mode for the SDK.
      */
-    public static void disableDebugMode() {
+    public void disableDebugMode() {
         BranchUtil.setDebugMode(false);
+    }
+
+    /**
+     *
+     */
+    public void disableAdNetworkCallouts(boolean disabled) {
+        PrefHelper.getInstance(context_).setAdNetworkCalloutsDisabled(disabled);
     }
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -474,9 +474,11 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     }
 
     /**
+     * Disable (or re-enable) ad network callouts. This setting is persistent.
      *
+     * @param disabled (@link Boolean) whether ad network callouts should be disabled.
      */
-    public void disableAdNetworkCallouts(boolean disabled) {
+    public void disableAdNetworkCallouts(boolean disabled = true) {
         PrefHelper.getInstance(context_).setAdNetworkCalloutsDisabled(disabled);
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -199,6 +199,7 @@ public class Defines {
         Condition("$condition"),
         CreationTimestamp("$creation_timestamp"),
         TrackingDisabled("tracking_disabled"),
+        DisableAdNetworkCallouts("disable_ad_network_callouts"),
         Instant("instant");
         
         private String key = "";

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -495,14 +495,18 @@ public class PrefHelper {
     }
 
     /**
+     * Specify whether ad network callouts should be disabled. By default, they are enabled.
      *
+     * @param disabled (@link Boolean) whether ad network callouts should be disabled
      */
     public void setAdNetworkCalloutsDisabled(boolean disabled) {
         setBool(KEY_AD_NETWORK_CALLOUTS_DISABLED, disabled);
     }
 
     /**
+     * Determine whether ad network callouts have been disabled.
      *
+     * @return A (@link Boolean) indicating whether ad network callouts have been disabled.
      */
     public boolean getAdNetworkCalloutsDisabled() {
         return getBool(KEY_AD_NETWORK_CALLOUTS_DISABLED);

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -106,6 +106,7 @@ public class PrefHelper {
     static final String KEY_REFERRER_CLICK_TS = "bnc_referrer_click_ts";
     static final String KEY_INSTALL_BEGIN_TS = "bnc_install_begin_ts";
     static final String KEY_TRACKING_STATE = "bnc_tracking_state";
+    static final String KEY_AD_NETWORK_CALLOUTS_DISABLED = "bnc_ad_network_callouts_disabled";
     
     private static String Branch_Key = null;
     /**
@@ -492,7 +493,21 @@ public class PrefHelper {
     public boolean getIsAppLinkTriggeredInit() {
         return getBool(KEY_IS_TRIGGERED_BY_FB_APP_LINK);
     }
-    
+
+    /**
+     *
+     */
+    public void setAdNetworkCalloutsDisabled(boolean disabled) {
+        setBool(KEY_AD_NETWORK_CALLOUTS_DISABLED, disabled);
+    }
+
+    /**
+     *
+     */
+    public boolean getAdNetworkCalloutsDisabled() {
+        return getBool(KEY_AD_NETWORK_CALLOUTS_DISABLED);
+    }
+
     /**
      * <p>Sets the {@link #KEY_EXTERNAL_INTENT_URI} with value with given intent URI String.</p>
      *

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -513,8 +513,7 @@ public abstract class ServerRequest {
     private void updateDisableAdNetworkCallouts() {
         JSONObject updateJson = getBranchRemoteAPIVersion() == BRANCH_API_VERSION.V1 ? params_ : params_.optJSONObject(Defines.Jsonkey.UserData.getKey());
         if (updateJson != null) {
-            PrefHelper prefHelper = PrefHelper.getInstance(context_);
-            boolean disableAdNetworkCallouts = prefHelper.getAdNetworkCalloutsDisabled();
+            boolean disableAdNetworkCallouts = prefHelper_.getAdNetworkCalloutsDisabled();
             if (disableAdNetworkCallouts) {
                 try {
                     updateJson.putOpt(Defines.Jsonkey.DisableAdNetworkCallouts.getKey(), disableAdNetworkCallouts);

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -509,6 +509,20 @@ public abstract class ServerRequest {
             }
         }
     }
+
+    private void updateDisableAdNetworkCallouts() {
+        JSONObject updateJson = getBranchRemoteAPIVersion() == BRANCH_API_VERSION.V1 ? params_ : params_.optJSONObject(Defines.Jsonkey.UserData.getKey());
+        if (updateJson != null) {
+            PrefHelper prefHelper = PrefHelper.getInstance(context_);
+            boolean disableAdNetworkCallouts = prefHelper.getAdNetworkCalloutsDisabled();
+            if (disableAdNetworkCallouts) {
+                try {
+                    updateJson.putOpt(Defines.Jsonkey.DisableAdNetworkCallouts.getKey(), disableAdNetworkCallouts);
+                } catch (JSONException ignore) {
+                }
+            }
+        }
+    }
     
     void doFinalUpdateOnMainThread() {
         updateRequestMetadata();
@@ -524,6 +538,7 @@ public abstract class ServerRequest {
         
         // Update the dynamic device info params
         updateDeviceInfo();
+        updateDisableAdNetworkCallouts();
         //Google ADs ID  and LAT value are updated using reflection. These method need background thread
         //So updating them for install and open on background thread.
         if (isGAdsParamsRequired() && !BranchUtil.isTestModeEnabled()) {
@@ -609,7 +624,7 @@ public abstract class ServerRequest {
     public void onPreExecute() {
     
     }
-    
+
     protected void updateEnvironment(Context context, JSONObject post) {
         try {
             String environment = DeviceInfo.getInstance().isPackageInstalled() ? Defines.Jsonkey.NativeApp.getKey() : Defines.Jsonkey.InstantApp.getKey();


### PR DESCRIPTION
## Reference
SDK-843 -- Android - add new method disableAdNetworkCallouts()

## Description
This change optionally adds a parameter `disable_ad_network_callouts` to all API requests (both V1 & V2) once `Branch.getInstance().disableAdNetworkCallouts(true);` is called. This setting is persistent via user preferences. This prevents network calls to SANs for compliance with CCPA.

Related PR from iOS repo: https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/pull/1007

~~As discussed, this will include some modifications to TestBed for the benefit of QA. I'll make that a separate PR.~~ Included changes to TestBed in this PR. There is now a Settings button at the bottom of the main activity that launches a Settings activity with only one switch, to disable ad network callouts. This can be expanded later.

## Testing Instructions
Begin with TestBed as is. Run the app and observe the following in the logcat:

```
2020-03-13 13:42:29.266 24001-24054/io.branch.branchandroiddemo I/BranchSDK: posting to https://api2.branch.io/v1/open
2020-03-13 13:42:29.279 24001-24054/io.branch.branchandroiddemo I/BranchSDK: Post value = {"device_fingerprint_id":"766726725391860588","identity_id":"766726725395952698","hardware_id":"152d50cb-8d77-4088-aca9-9d133db62dc2","is_hardware_id_real":false,"brand":"Google","model":"AOSP on IA Emulator","screen_dpi":420,"screen_height":1794,"screen_width":1080,"wifi":true,"ui_mode":"UI_MODE_TYPE_NORMAL","os":"Android","os_version":28,"cpu_type":"i686","build":"PSR1.180720.117","locale":"en_US","connection_type":"wifi","device_carrier":"Android","os_version_android":"9","country":"US","language":"en","local_ip":"192.168.200.2","app_version":"4.3.2","facebook_app_link_checked":false,"is_referrable":0,"debug":true,"update":1,"latest_install_time":1584040116043,"latest_update_time":1584132147094,"first_install_time":1584040116043,"previous_update_time":1584053522885,"environment":"FULL_APP","cd":{"mv":"-1","pn":"io.branch.branchandroiddemo"},"metadata":{},"instrumentation":{"v1\/open-qwt":"0"},"sdk":"android4.3.2","branch_key":"key_test_hdcBLUy1xZ1JD0tKg7qrLcgirFmPPVJc"}
```

This does not contain a `disable_ad_network_callbacks` field.

Use the Settings button on the Main activity to go to the Settings activity. There you can enable and disable ad network callouts. First disable them, then go back and make any request.

Now run the app and observe:

```
2020-03-13 13:50:27.150 24935-24996/io.branch.branchandroiddemo I/BranchSDK: posting to https://api2.branch.io/v1/open
2020-03-13 13:50:27.156 24935-24996/io.branch.branchandroiddemo I/BranchSDK: Post value = {"device_fingerprint_id":"766726725391860588","identity_id":"766726725395952698","hardware_id":"62dff824-bbd8-46e7-b453-de1c57934102","is_hardware_id_real":false,"brand":"Google","model":"AOSP on IA Emulator","screen_dpi":420,"screen_height":1794,"screen_width":1080,"wifi":true,"ui_mode":"UI_MODE_TYPE_NORMAL","os":"Android","os_version":28,"cpu_type":"i686","build":"PSR1.180720.117","locale":"en_US","connection_type":"wifi","device_carrier":"Android","os_version_android":"9","country":"US","language":"en","local_ip":"192.168.200.2","app_version":"4.3.2","facebook_app_link_checked":false,"is_referrable":0,"debug":true,"update":1,"latest_install_time":1584040116043,"latest_update_time":1584132625665,"first_install_time":1584040116043,"previous_update_time":1584132147094,"environment":"FULL_APP","cd":{"mv":"-1","pn":"io.branch.branchandroiddemo"},"metadata":{},"disable_ad_network_callouts":true,"instrumentation":{"v1\/open-qwt":"0"},"sdk":"android4.3.2","branch_key":"key_test_hdcBLUy1xZ1JD0tKg7qrLcgirFmPPVJc"}
```

This includes `"disable_ad_network_callouts":true`. Now remove the call to `disableAdNetworkCallouts()` and run the app again. The post still includes `disable_ad_network_callouts` because the setting is persistent in user preferences.

On the Settings activity, re-enable ad network callouts, return to the main activity and make any request.

The `disable_ad_network_callouts` parameter is no longer included in posts.

## Risk Assessment LOW
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
