### PR TITLE
addressed the super rare NPE and simplified getWifiConnected method s…

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
@@ -375,7 +375,9 @@ abstract class SystemObserver {
             WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
             if (windowManager != null) {
                 Display display = windowManager.getDefaultDisplay();
-                display.getMetrics(displayMetrics);
+                if (display != null) {
+                    display.getMetrics(displayMetrics);
+                }
             }
         }
         return displayMetrics;
@@ -399,15 +401,7 @@ abstract class SystemObserver {
      */
     @SuppressWarnings("MissingPermission")
     static boolean getWifiConnected(Context context) {
-        if (context != null && PackageManager.PERMISSION_GRANTED == context.checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE)) {
-            ConnectivityManager connManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-            NetworkInfo wifiInfo = null;
-            if (connManager != null) {
-                wifiInfo = connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-            }
-            return ((wifiInfo != null) && wifiInfo.isConnected());
-        }
-        return false;
+        return "wifi".equalsIgnoreCase(getConnectionType(context));
     }
 
     /**


### PR DESCRIPTION
…o it reuses internal getConnectionType

## Reference
INTENG-8954 -- SDK cause exceptions when it try to access SystemObserver.

## Description
Fixed the potential NPE and refactored the (supposedly faulty) getWifiConnected method, so it stops using the method getNetworkInfo which caused the crash reported in this ticket but decided against replacing the use of  NetworkInfo in its entirety even though it’s been deprecated.

TL;DR I made this decision because the replacements of NetworkInfo are only available on higher versions of Android, so we would still need to keep it around + Google itself still uses NetworkInfo in its guides (https://developer.android.com/training/basics/network-ops/managing.html) + I didn’t find a replacement that would surely be better without being an overkill/introducing other issues (e.g. replacements like NetworkCallbacks are meant to give more timely and accurate state of the network for apps that adjust their operations depending on the connectivity state, whereas we just use this data point as a snapshot of the network state for analytics purposes, other replacements like WifiInfo.getNetworkId() != -1 require location permission on higher Android APIs). Here is more references and discussions https://stackoverflow.com/questions/3841317/how-do-i-see-if-wi-fi-is-connected-on-android

## Testing Instructions
Make sure that when device is connected to WiFi, then the key,`wifi`, is set to `true` in v1 requests (e.g. v1/open) or `false` when the device is not using WiFi.

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
