### PR TITLE
INTENG-9411

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -540,7 +540,7 @@ public abstract class ServerRequest {
         updateDisableAdNetworkCallouts();
         //Google ADs ID  and LAT value are updated using reflection. These method need background thread
         //So updating them for install and open on background thread.
-        if (isGAdsParamsRequired() && !BranchUtil.isTestModeEnabled()) {
+        if (isGAdsParamsRequired()) {
             updateGAdsParams();
         }
     }


### PR DESCRIPTION
## Reference
INTENG-9411 -- Android SDK doesn't surface AAID in v1/open using test key.

## Description
aaid is reported in v1/open in love mode but not in test mode

## Testing Instructions
run the testbed in both modes and confirm the payload contains aaid or it doesn't.

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
