### PR TITLE
Revert "Merge pull request #665"

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
-import android.os.Build;
 import androidx.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.Log;
@@ -31,8 +30,7 @@ public class PrefHelper {
     /**
      * The base URL to use for all calls to the Branch API.
      */
-    static final String BRANCH_BASE_URL_V2 = "https://api2.branch.io/";
-    static final String BRANCH_BASE_URL_V1 = "https://api.branch.io/";
+    static final String BRANCH_BASE_URL = "https://api2.branch.io/";
 
     /**
      * The base URL to use for all CDN calls.
@@ -217,7 +215,6 @@ public class PrefHelper {
 
     /**
      * <p>Returns the base URL to use for all calls to the Branch API as a {@link String}.</p>
-     * NOTE: Below API v20, TLS 1.2 does not work reliably, so we will fall back in that case.
      *
      * @return A {@link String} variable containing the hard-coded base URL that the Branch
      * API uses.
@@ -226,12 +223,7 @@ public class PrefHelper {
         if (URLUtil.isHttpsUrl(customServerURL_)) {
             return customServerURL_;
         }
-
-        if (Build.VERSION.SDK_INT >= 20) {
-            return BRANCH_BASE_URL_V2;
-        } else {
-            return BRANCH_BASE_URL_V1;
-        }
+        return BRANCH_BASE_URL;
     }
 
     /**


### PR DESCRIPTION
This reverts commit affc3c30d7a4c0a03dd5074ed1fd9a99d7c1f4cf, reversing
changes made to f9af7987bf7b9d5e06d2aa7222319e1c05f10cb5.

## Reference
N/A

## Description
Both `https://api.branch.io/` and `https://api2.branch.io/` have the same TLS configuration, with TLS 1.0 and 1.1 disabled, so calls will fail on API < 20 on devices not supporting TLS 1.2+ anyway.

My guess is that this was changed after #665 was merged, please confirm with your infra team.

Provided there are no other reasons to use `https://api.branch.io/` than for the TLS fallback, we can safely revert this.

## Testing Instructions
Test on API < 20 and API >= 20, confirm v2 of the API is being hit.

## Risk Assessment [`MEDIUM`]
Using same value as original PR.

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
