### PR TITLE
Sdk 935-936-939/debug-test-logging-refactor

### DIFF
--- a/Branch-SDK/src/androidTest/java/io/branch/referral/DebugTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/DebugTest.java
@@ -8,61 +8,6 @@ import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class DebugTest extends BranchTest {
-    /*
-    DebugMode         TestMode          isTestModeEnabled     isDebugModeEnabled
-       0                  0                false                 false
-       0                  1                true                  true
-       1                  0                false                 true
-       1                  1                true                  true
-    */
-
-    @Test
-    public void testDebugState() {
-        Assert.assertFalse(BranchUtil.isDebugEnabled());
-        Assert.assertFalse(BranchUtil.isTestModeEnabled());
-
-        // Debug Mode
-        Branch.enableDebugMode();
-        Assert.assertTrue(BranchUtil.isDebugEnabled());
-        Assert.assertFalse(BranchUtil.isTestModeEnabled());
-
-        Branch.disableDebugMode();
-        Assert.assertFalse(BranchUtil.isDebugEnabled());
-        Assert.assertFalse(BranchUtil.isTestModeEnabled());
-
-        // Test Mode
-        Branch.enableTestMode();
-        Assert.assertTrue(BranchUtil.isDebugEnabled());
-        Assert.assertTrue(BranchUtil.isTestModeEnabled());
-
-        Branch.disableTestMode();
-        Assert.assertFalse(BranchUtil.isDebugEnabled());
-        Assert.assertFalse(BranchUtil.isTestModeEnabled());
-
-        // Both Debug and Test Mode (variation A, debug before test)
-        Branch.enableDebugMode();
-        Branch.enableTestMode();
-        Assert.assertTrue(BranchUtil.isDebugEnabled());
-        Assert.assertTrue(BranchUtil.isTestModeEnabled());
-
-        Branch.disableDebugMode();
-        Assert.assertTrue(BranchUtil.isDebugEnabled());     // Per Javadoc, debug is enabled if either debug or test is enabled.
-        Assert.assertTrue(BranchUtil.isTestModeEnabled());
-
-        Branch.disableTestMode();
-        Assert.assertFalse(BranchUtil.isDebugEnabled());
-        Assert.assertFalse(BranchUtil.isTestModeEnabled());
-
-        // Both Debug and Test Mode (variation B, test before debug)
-        Branch.enableTestMode();
-        Branch.enableDebugMode();
-        Assert.assertTrue(BranchUtil.isDebugEnabled());
-        Assert.assertTrue(BranchUtil.isTestModeEnabled());
-
-        Branch.disableTestMode();
-        Assert.assertFalse(BranchUtil.isTestModeEnabled());
-        Assert.assertFalse(BranchUtil.isDebugEnabled());    // Per Javadoc, turning off test mode also turns off debug mode.
-    }
 
     @Test
     public void testTestModeA() {

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/DeviceInfoTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/DeviceInfoTest.java
@@ -24,19 +24,7 @@ public class DeviceInfoTest extends BranchTest {
         Assert.assertNotNull(Branch.getInstance(getTestContext()));
         Assert.assertNotNull(DeviceInfo.getInstance());
 
-        // Start with debug mode off and get a hardwareId
         SystemObserver.UniqueId uniqueId1 = DeviceInfo.getInstance().getHardwareID();
-
-        // Enable debug mode
-        Branch.enableDebugMode();
-        SystemObserver.UniqueId uniqueDebugId1 = DeviceInfo.getInstance().getHardwareID();
-        SystemObserver.UniqueId uniqueDebugId2 = DeviceInfo.getInstance().getHardwareID();
-
-        // Per design, two requests for debug IDs must be different.
-        Assert.assertNotEquals(uniqueDebugId1, uniqueDebugId2);
-
-        // A "Real" hardware Id should always be identical, even after switching debug on and off.
-        Branch.disableDebugMode();
         SystemObserver.UniqueId uniqueId2 = DeviceInfo.getInstance().getHardwareID();
         Assert.assertEquals(uniqueId1, uniqueId2);
     }

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/KeyTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/KeyTest.java
@@ -11,7 +11,6 @@ public class KeyTest extends BranchTest {
 
     @Test
     public void testManifestKeys() {
-        Assert.assertFalse(BranchUtil.isDebugEnabled());
         Assert.assertFalse(BranchUtil.isTestModeEnabled());
 
         String branchKey = BranchUtil.readBranchKey(getTestContext());
@@ -25,7 +24,7 @@ public class KeyTest extends BranchTest {
     @Test
     public void testAutoInstanceWithKey() {
         final String expectedKey = "key_XXX";
-        Branch branch = Branch.getAutoInstance(getTestContext(), expectedKey);
+        Branch.getAutoInstance(getTestContext(), expectedKey);
 
         final String actualKey = PrefHelper.getInstance(getTestContext()).getBranchKey();
         Assert.assertEquals(expectedKey, actualKey);

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -429,12 +429,21 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     
     /**
      * <p>
-     * Enables the test mode for the SDK. This will use the Branch Test Keys.
-     * Note: This is same as setting "io.branch.sdk.TestMode" to "True" in Manifest file
+     * Enables the test mode for the SDK. This will use the Branch Test Keys. This is same as setting
+     * "io.branch.sdk.TestMode" to "True" in Manifest file.
+     *
+     * Note: As of v5.0.1, enableTestMode has been changed. It now uses the test key but will not log or randomize
+     * the device IDs. If you wish to enable logging, please invoke enableLogging. If you wish to simulate
+     * installs, please see add a Test Device (https://help.branch.io/using-branch/docs/adding-test-devices)
+     * then reset your test device's data (https://help.branch.io/using-branch/docs/adding-test-devices#section-resetting-your-test-device-data).
      * </p>
      */
     public static void enableTestMode() {
         BranchUtil.setTestMode(true);
+        PrefHelper.LogAlways("enableTestMode has been changed. It now uses the test key but will not" +
+                " log or randomize the device IDs. If you wish to enable logging, please invoke enableLogging." +
+                " If you wish to simulate installs, please see add a Test Device (https://help.branch.io/using-branch/docs/adding-test-devices)" +
+                " then reset your test device's data (https://help.branch.io/using-branch/docs/adding-test-devices#section-resetting-your-test-device-data).");
     }
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -430,47 +430,20 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     /**
      * <p>
      * Enables the test mode for the SDK. This will use the Branch Test Keys.
-     * This will also enable debug logs.
      * Note: This is same as setting "io.branch.sdk.TestMode" to "True" in Manifest file
      * </p>
      */
     public static void enableTestMode() {
         BranchUtil.setTestMode(true);
-        enableDebugMode();
     }
 
     /**
      * <p>
      * Disables the test mode for the SDK.
-     * This will also disable debug logs.
      * </p>
      */
     public static void disableTestMode() {
         BranchUtil.setTestMode(false);
-        disableDebugMode();
-    }
-
-    /**
-     * Enables debug mode for the SDK.
-     * @deprecated use {@link Branch#enableDebugMode()}
-     */
-    public void setDebug() {
-        enableDebugMode();
-    }
-
-    /**
-     * Enables debug mode for the SDK and log the SDK Version Declaration Tag.
-     */
-    public static void enableDebugMode() {
-        BranchUtil.setDebugMode(true);
-        PrefHelper.LogAlways(GOOGLE_VERSION_TAG);
-    }
-
-    /**
-     * Disables debug mode for the SDK.
-     */
-    public static void disableDebugMode() {
-        BranchUtil.setDebugMode(false);
     }
 
     /**
@@ -2722,6 +2695,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      * Enable Logging, independent of Debug Mode.
      */
     public static void enableLogging() {
+        PrefHelper.LogAlways(GOOGLE_VERSION_TAG);
         PrefHelper.enableLogging(true);
     }
 
@@ -3401,4 +3375,37 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     public boolean reInitSession(Activity activity, BranchUniversalReferralInitListener callback) {Branch.sessionBuilder(activity).withCallback(callback).reInit();return activity == null || activity.getIntent() == null; }
     /** @deprecated use Branch.sessionBuilder(activity).withCallback(callback).reInit();*/
     public boolean reInitSession(Activity activity, BranchReferralInitListener callback) {Branch.sessionBuilder(activity).withCallback(callback).reInit();return activity == null || activity.getIntent() == null; }
+
+    /**
+     * @deprecated setDebug is deprecated and all functionality has been disabled. If you wish to enable
+     * logging, please invoke enableLogging. If you wish to simulate installs, please see add a Test Device
+     * (https://help.branch.io/using-branch/docs/adding-test-devices) then reset your test device's data
+     * (https://help.branch.io/using-branch/docs/adding-test-devices#section-resetting-your-test-device-data).
+     * If you wish to use the test key rather than the live key, please invoke enableTestMode.
+     */
+    public void setDebug() {
+        PrefHelper.LogAlways("setDebug is deprecated and all functionality has been disabled. " +
+                "If you wish to enable logging, please invoke enableLogging. If you wish to simulate installs," +
+                " please see add a Test Device (https://help.branch.io/using-branch/docs/adding-test-devices) " +
+                "then reset your test device's data (https://help.branch.io/using-branch/docs/adding-test-devices#section-resetting-your-test-device-data). " +
+                "If you wish to use the test key rather than the live key, please invoke enableTestMode.");
+    }
+
+    /**
+     * @deprecated enableDebugMode is deprecated and all functionality has been disabled. If you wish to enable
+     * logging, please invoke enableLogging. If you wish to simulate installs, please see add a Test Device
+     * (https://help.branch.io/using-branch/docs/adding-test-devices) then reset your test device's data
+     * (https://help.branch.io/using-branch/docs/adding-test-devices#section-resetting-your-test-device-data).
+     * If you wish to use the test key rather than the live key, please invoke enableTestMode.
+     */
+    public static void enableDebugMode() {
+        PrefHelper.LogAlways("enableDebugMode is deprecated and all functionality has been disabled. " +
+                "If you wish to enable logging, please invoke enableLogging. If you wish to simulate installs," +
+                " please see add a Test Device (https://help.branch.io/using-branch/docs/adding-test-devices) " +
+                "then reset your test device's data (https://help.branch.io/using-branch/docs/adding-test-devices#section-resetting-your-test-device-data). " +
+                "If you wish to use the test key rather than the live key, please invoke enableTestMode.");
+    }
+
+    /** @deprecated (deprecated and all functionality has been disabled, see enableDebugMode for more information) */
+    public static void disableDebugMode() {}
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2678,18 +2678,6 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         }
         return matched;
     }
-    
-    public static void enableSimulateInstalls() {
-        isSimulatingInstalls_ = true;
-    }
-    
-    public static void disableSimulateInstalls() {
-        isSimulatingInstalls_ = false;
-    }
-
-    static boolean isSimulatingInstalls() {
-        return isSimulatingInstalls_;
-    }
 
     /**
      * Enable Logging, independent of Debug Mode.
@@ -3408,4 +3396,18 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
 
     /** @deprecated (deprecated and all functionality has been disabled, see enableDebugMode for more information) */
     public static void disableDebugMode() {}
+
+    /**
+     * @deprecated enableSimulateInstalls is deprecated and all functionality has been disabled. If
+     * you wish to simulate installs, please see add a Test Device (https://help.branch.io/using-branch/docs/adding-test-devices)
+     * then reset your test device's data (https://help.branch.io/using-branch/docs/adding-test-devices#section-resetting-your-test-device-data).
+     * */
+    public static void enableSimulateInstalls() {
+        PrefHelper.LogAlways("enableSimulateInstalls is deprecated and all functionality has been disabled. " +
+                "If you wish to simulate installs, please see add a Test Device (https://help.branch.io/using-branch/docs/adding-test-devices) " +
+                "then reset your test device's data (https://help.branch.io/using-branch/docs/adding-test-devices#section-resetting-your-test-device-data).");
+    }
+
+    /** @deprecated see enableSimulateInstalls() for more information */
+    public static void disableSimulateInstalls() { }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
@@ -27,9 +27,6 @@ import java.util.jar.JarFile;
  */
 public class BranchUtil {
 
-    /** For setting debug mode using {@link Branch#setDebug()} api */
-    private static boolean isCustomDebugEnabled_ = false;
-
     /** For setting test mode using {@link Branch#enableTestMode()} */
     private static boolean isTestModeEnabled_ = false;
 
@@ -38,7 +35,6 @@ public class BranchUtil {
 
     // Package Private
     static void shutDown() {
-        isCustomDebugEnabled_ = false;
         isTestModeEnabled_ = false;
         isManifestTestModeEnabled = null;
     }
@@ -116,17 +112,8 @@ public class BranchUtil {
         isTestModeEnabled_ = testMode;
     }
 
-    /**
-     * Determine if Debug Mode is enabled.
-     * @return {@code true} if Debug is enabled, or if {@link BranchUtil#isTestModeEnabled()}
-     */
-    public static boolean isDebugEnabled() {
-        return isCustomDebugEnabled_ || isTestModeEnabled();
-    }
-
-    static void setDebugMode(boolean debugMode) {
-        isCustomDebugEnabled_ = debugMode;
-    }
+    /** @deprecated (see enableDebugMode for more information) */
+    public static boolean isDebugEnabled() { return false; }
 
     /**
      * Converts a given link param as {@link JSONObject} to string after adding the source param and removes replaces any illegal characters.

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
@@ -99,7 +99,7 @@ public class BranchUtil {
 
     /**
      * Get the value of "io.branch.sdk.TestMode" entry in application manifest or from String res.
-     * This value can be overriden via. {@link Branch#enableTestMode()}
+     * This value can be overridden via. {@link Branch#enableTestMode()}
      *
      * @return value of "io.branch.sdk.TestMode" entry in application manifest or String res.
      * false if "io.branch.sdk.TestMode" is not added in the manifest or String res.

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -284,20 +284,11 @@ class DeviceInfo {
     }
 
     /**
-     * @return true if a Debug HardwareId is needed.
-     * Note that if either Debug is enabled or Fetch has been disabled, then requests for a Hardware Id will return a "fake" ID.
-     */
-    static public boolean isDebugHardwareIdNeeded() {
-        boolean isDebugHardwareIdNeeded = Branch.isDeviceIDFetchDisabled() || BranchUtil.isDebugEnabled();
-        return isDebugHardwareIdNeeded;
-    }
-
-    /**
      * @return the device Hardware ID.
      * Note that if either Debug is enabled or Fetch has been disabled, then return a "fake" ID.
      */
     public SystemObserver.UniqueId getHardwareID() {
-        return getSystemObserver().getUniqueID(context_, isDebugHardwareIdNeeded());
+        return getSystemObserver().getUniqueID(context_, Branch.isDeviceIDFetchDisabled());
     }
 
     public String getOsName() {

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -1344,10 +1344,8 @@ public class PrefHelper {
      * @param message A {@link String} value containing the debug message to record.
      */
     public static void Debug(String message) {
-        if (BranchUtil.isDebugEnabled() || enableLogging_) {
-            if (!TextUtils.isEmpty(message)) {
-                Log.i(TAG, message);
-            }
+        if (enableLogging_ && !TextUtils.isEmpty(message)) {
+            Log.i(TAG, message);
         }
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -47,7 +47,7 @@ abstract class ServerRequestInitSession extends ServerRequest {
         }
         post.put(Defines.Jsonkey.FaceBookAppLinkChecked.getKey(), prefHelper_.getIsAppLinkTriggeredInit());
         post.put(Defines.Jsonkey.IsReferrable.getKey(), prefHelper_.getIsReferrable());
-        post.put(Defines.Jsonkey.Debug.getKey(), BranchUtil.isTestModeEnabled());
+        post.put(Defines.Jsonkey.Debug.getKey(), Branch.isDeviceIDFetchDisabled());
 
         updateInstallStateAndTimestamps(post);
         updateEnvironment(context_, post);

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -47,7 +47,7 @@ abstract class ServerRequestInitSession extends ServerRequest {
         }
         post.put(Defines.Jsonkey.FaceBookAppLinkChecked.getKey(), prefHelper_.getIsAppLinkTriggeredInit());
         post.put(Defines.Jsonkey.IsReferrable.getKey(), prefHelper_.getIsReferrable());
-        post.put(Defines.Jsonkey.Debug.getKey(), BranchUtil.isDebugEnabled());
+        post.put(Defines.Jsonkey.Debug.getKey(), BranchUtil.isTestModeEnabled());
 
         updateInstallStateAndTimestamps(post);
         updateEnvironment(context_, post);

--- a/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
@@ -546,10 +546,8 @@ abstract class SystemObserver {
             this.uniqueId = BLANK;
 
             String androidID = null;
-            if (context != null) {
-                if (!isDebug && !Branch.isSimulatingInstalls()) {
-                    androidID = Secure.getString(context.getContentResolver(), Secure.ANDROID_ID);
-                }
+            if (context != null && !isDebug) {
+                androidID = Secure.getString(context.getContentResolver(), Secure.ANDROID_ID);
             }
 
             if (androidID == null) {


### PR DESCRIPTION
## Reference
SDK-935 -- deprecate enableDebugMode
SDK-936 -- deprecate enableSimulateInstalls
SDK-936 -- modify enableTestMode

## Description
The debug mode and test modes were convoluted as was logging. Test mode will now make the SDK use Branch test key, debug mode is deprecated altogether, as is enableSimulateInstalls. If clients want to simulate installs, which is what the the latter two method did, they should follow the instructions [here](https://help.branch.io/using-branch/docs/adding-test-devices). Logging can only be enabled by calling enableLogging now.

## Testing Instructions

- Set debug or test mode and see that logging is not enabled
- Observe that hardware id is not randomized when either mode is enabled.
- Same with enableSimulateInstalls (hardware id is not randomized).
- Also observe the warning messages in the stracktrace when enableDebugMode/enableTestMode/enableSimulateInstals are being used. 

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
