### PR TITLE
SDK-944 Release 5.0.1

### DIFF
--- a/Branch-SDK/src/androidTest/java/io/branch/referral/DeviceInfoTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/DeviceInfoTest.java
@@ -51,7 +51,7 @@ public class DeviceInfoTest extends BranchTest {
         SystemObserver.UniqueId uniqueId1 = DeviceInfo.getInstance().getHardwareID();
 
         // Enable simulated installs
-        Branch.enableSimulateInstalls();
+        Branch.disableDeviceIDFetch(true);
         SystemObserver.UniqueId uniqueSimulatedId1 = DeviceInfo.getInstance().getHardwareID();
         SystemObserver.UniqueId uniqueSimulatedId2 = DeviceInfo.getInstance().getHardwareID();
 
@@ -59,7 +59,7 @@ public class DeviceInfoTest extends BranchTest {
         Assert.assertNotEquals(uniqueSimulatedId1, uniqueSimulatedId2);
 
         // A "Real" hardware Id should always be identical, even after switching simulation mode on and off.
-        Branch.disableSimulateInstalls();
+        Branch.disableDeviceIDFetch(false);
         SystemObserver.UniqueId uniqueId2 = DeviceInfo.getInstance().getHardwareID();
         Assert.assertEquals(uniqueId1, uniqueId2);
     }

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -5,12 +5,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.text.TextUtils;
 
-import androidx.annotation.NonNull;
-
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 import io.branch.indexing.ContentDiscoverer;
 import io.branch.indexing.ContentDiscoveryManifest;

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,13 @@
 # Branch Android SDK change log
+- v5.0.1
+  * _*Master Release*_ - March 8, 2020
+  * Report GAID when test key is used
+  * Detect TUNE migrations, report them via the `update` field in open/install payload
+  * Deprecate enableSimulateInstalls
+  * Deprecate enableDebugMode
+  * Modify enableTestMode
+  * Support for air-preload campaigns via Play Install Referrer API
+
 - v5.0.0
   * _*Master Release*_ - March 17, 2020
   * Bump up major version to signify switch to session builder from initSession (old functionality is maintained)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.0.0
-VERSION_CODE=050000
+VERSION_NAME=5.0.1
+VERSION_CODE=050001
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.


### PR DESCRIPTION
## Reference
SDK-944 -- Release 5.0.1

## Description
Just adding release notes and bumping up version name and code.

Ignore the unit test change, there were PRs merged to master instead of Staging, so this change will fix the unit tests once everything is in master.

Merge this PR first, then [this](https://github.com/BranchMetrics/android-branch-deep-linking-attribution/pull/834).