### PR TITLE
when tracking is disabled, create long links

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/indexing/BranchUniversalObject.java
+++ b/Branch-SDK/src/main/java/io/branch/indexing/BranchUniversalObject.java
@@ -620,7 +620,11 @@ public class BranchUniversalObject implements Parcelable {
      * @param callback       An instance of {@link io.branch.referral.Branch.BranchLinkCreateListener} to receive the results
      */
     public void generateShortUrl(@NonNull Context context, @NonNull LinkProperties linkProperties, @Nullable Branch.BranchLinkCreateListener callback) {
-        getLinkBuilder(context, linkProperties).generateShortUrl(callback);
+        if (Branch.getInstance().isTrackingDisabled()) {
+            callback.onLinkCreate(getLinkBuilder(context, linkProperties).getShortUrl(), null);
+        } else {
+            getLinkBuilder(context, linkProperties).generateShortUrl(callback);
+        }
     }
     
     /**


### PR DESCRIPTION
## Reference
INTENG-10396

## Description
When tracking is disabled, return long link instead of error.

## Testing Instructions
disable tracking before session initialization and observe that created links are long not short. 

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
