### PR TITLE
Add catch block for new InstallReferrer Runtime Exception

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/GooglePlayStoreAttribution.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/GooglePlayStoreAttribution.java
@@ -53,9 +53,12 @@ class GooglePlayStoreAttribution {
                                 }
                                 onReferrerClientFinished(context, rawReferrer, clickTimeStamp, installBeginTimeStamp);
                             } catch (RemoteException ex) {
+                                PrefHelper.Debug("onInstallReferrerSetupFinished() Remote Exception: " + ex.getMessage());
+                                onReferrerClientError();
+                            } catch (Exception ex) {
                                 PrefHelper.Debug("onInstallReferrerSetupFinished() Exception: " + ex.getMessage());
                                 onReferrerClientError();
-                            }
+                            } 
                             break;
                         case InstallReferrerClient.InstallReferrerResponse.FEATURE_NOT_SUPPORTED:// API not available on the current Play Store app
                         case InstallReferrerClient.InstallReferrerResponse.SERVICE_UNAVAILABLE:// Connection could not be established


### PR DESCRIPTION
## Reference
INTENG-10758 -- [Headspace] Android mParticle Kit SDK Crashing App 

## Description
SDK crashes reported where Googles Install Referrer API is returning an error. We handle a Remote Exception error in our SDK but the API is returning something else

## Testing Instructions
None - unclear how to trigger this exception

## Risk Assessment [`LOW`]

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
