### PR TITLE
Sdk 1053/referrer lib v1 crash

### DIFF
--- a/Branch-SDK/build.gradle
+++ b/Branch-SDK/build.gradle
@@ -7,7 +7,7 @@ def jarFileName
 dependencies {
     implementation fileTree(dir: 'libs', include: '*.jar')
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.android.installreferrer:installreferrer:1.0'
+    implementation 'com.android.installreferrer:installreferrer:2.1'
 
     // --- optional dependencies -----
     //Please note that the Branch SDK does not require any of the below optional dependencies to operate. This dependency is listed here so there will not be build errors,

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/DebugTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/DebugTest.java
@@ -8,61 +8,6 @@ import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class DebugTest extends BranchTest {
-    /*
-    DebugMode         TestMode          isTestModeEnabled     isDebugModeEnabled
-       0                  0                false                 false
-       0                  1                true                  true
-       1                  0                false                 true
-       1                  1                true                  true
-    */
-
-    @Test
-    public void testDebugState() {
-        Assert.assertFalse(BranchUtil.isDebugEnabled());
-        Assert.assertFalse(BranchUtil.isTestModeEnabled());
-
-        // Debug Mode
-        Branch.enableDebugMode();
-        Assert.assertTrue(BranchUtil.isDebugEnabled());
-        Assert.assertFalse(BranchUtil.isTestModeEnabled());
-
-        Branch.disableDebugMode();
-        Assert.assertFalse(BranchUtil.isDebugEnabled());
-        Assert.assertFalse(BranchUtil.isTestModeEnabled());
-
-        // Test Mode
-        Branch.enableTestMode();
-        Assert.assertTrue(BranchUtil.isDebugEnabled());
-        Assert.assertTrue(BranchUtil.isTestModeEnabled());
-
-        Branch.disableTestMode();
-        Assert.assertFalse(BranchUtil.isDebugEnabled());
-        Assert.assertFalse(BranchUtil.isTestModeEnabled());
-
-        // Both Debug and Test Mode (variation A, debug before test)
-        Branch.enableDebugMode();
-        Branch.enableTestMode();
-        Assert.assertTrue(BranchUtil.isDebugEnabled());
-        Assert.assertTrue(BranchUtil.isTestModeEnabled());
-
-        Branch.disableDebugMode();
-        Assert.assertTrue(BranchUtil.isDebugEnabled());     // Per Javadoc, debug is enabled if either debug or test is enabled.
-        Assert.assertTrue(BranchUtil.isTestModeEnabled());
-
-        Branch.disableTestMode();
-        Assert.assertFalse(BranchUtil.isDebugEnabled());
-        Assert.assertFalse(BranchUtil.isTestModeEnabled());
-
-        // Both Debug and Test Mode (variation B, test before debug)
-        Branch.enableTestMode();
-        Branch.enableDebugMode();
-        Assert.assertTrue(BranchUtil.isDebugEnabled());
-        Assert.assertTrue(BranchUtil.isTestModeEnabled());
-
-        Branch.disableTestMode();
-        Assert.assertFalse(BranchUtil.isTestModeEnabled());
-        Assert.assertFalse(BranchUtil.isDebugEnabled());    // Per Javadoc, turning off test mode also turns off debug mode.
-    }
 
     @Test
     public void testTestModeA() {

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/DeviceInfoTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/DeviceInfoTest.java
@@ -24,19 +24,7 @@ public class DeviceInfoTest extends BranchTest {
         Assert.assertNotNull(Branch.getInstance(getTestContext()));
         Assert.assertNotNull(DeviceInfo.getInstance());
 
-        // Start with debug mode off and get a hardwareId
         SystemObserver.UniqueId uniqueId1 = DeviceInfo.getInstance().getHardwareID();
-
-        // Enable debug mode
-        Branch.enableDebugMode();
-        SystemObserver.UniqueId uniqueDebugId1 = DeviceInfo.getInstance().getHardwareID();
-        SystemObserver.UniqueId uniqueDebugId2 = DeviceInfo.getInstance().getHardwareID();
-
-        // Per design, two requests for debug IDs must be different.
-        Assert.assertNotEquals(uniqueDebugId1, uniqueDebugId2);
-
-        // A "Real" hardware Id should always be identical, even after switching debug on and off.
-        Branch.disableDebugMode();
         SystemObserver.UniqueId uniqueId2 = DeviceInfo.getInstance().getHardwareID();
         Assert.assertEquals(uniqueId1, uniqueId2);
     }

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/KeyTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/KeyTest.java
@@ -11,7 +11,6 @@ public class KeyTest extends BranchTest {
 
     @Test
     public void testManifestKeys() {
-        Assert.assertFalse(BranchUtil.isDebugEnabled());
         Assert.assertFalse(BranchUtil.isTestModeEnabled());
 
         String branchKey = BranchUtil.readBranchKey(getTestContext());
@@ -25,7 +24,7 @@ public class KeyTest extends BranchTest {
     @Test
     public void testAutoInstanceWithKey() {
         final String expectedKey = "key_XXX";
-        Branch branch = Branch.getAutoInstance(getTestContext(), expectedKey);
+        Branch.getAutoInstance(getTestContext(), expectedKey);
 
         final String actualKey = PrefHelper.getInstance(getTestContext()).getBranchKey();
         Assert.assertEquals(expectedKey, actualKey);

--- a/Branch-SDK/src/main/java/io/branch/indexing/BranchUniversalObject.java
+++ b/Branch-SDK/src/main/java/io/branch/indexing/BranchUniversalObject.java
@@ -620,7 +620,11 @@ public class BranchUniversalObject implements Parcelable {
      * @param callback       An instance of {@link io.branch.referral.Branch.BranchLinkCreateListener} to receive the results
      */
     public void generateShortUrl(@NonNull Context context, @NonNull LinkProperties linkProperties, @Nullable Branch.BranchLinkCreateListener callback) {
-        getLinkBuilder(context, linkProperties).generateShortUrl(callback);
+        if (Branch.getInstance().isTrackingDisabled()) {
+            callback.onLinkCreate(getLinkBuilder(context, linkProperties).getShortUrl(), null);
+        } else {
+            getLinkBuilder(context, linkProperties).generateShortUrl(callback);
+        }
     }
     
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -429,48 +429,30 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     
     /**
      * <p>
-     * Enables the test mode for the SDK. This will use the Branch Test Keys.
-     * This will also enable debug logs.
-     * Note: This is same as setting "io.branch.sdk.TestMode" to "True" in Manifest file
+     * Enables the test mode for the SDK. This will use the Branch Test Keys. This is same as setting
+     * "io.branch.sdk.TestMode" to "True" in Manifest file.
+     *
+     * Note: As of v5.0.1, enableTestMode has been changed. It now uses the test key but will not log or randomize
+     * the device IDs. If you wish to enable logging, please invoke enableLogging. If you wish to simulate
+     * installs, please see add a Test Device (https://help.branch.io/using-branch/docs/adding-test-devices)
+     * then reset your test device's data (https://help.branch.io/using-branch/docs/adding-test-devices#section-resetting-your-test-device-data).
      * </p>
      */
     public static void enableTestMode() {
         BranchUtil.setTestMode(true);
-        enableDebugMode();
+        PrefHelper.LogAlways("enableTestMode has been changed. It now uses the test key but will not" +
+                " log or randomize the device IDs. If you wish to enable logging, please invoke enableLogging." +
+                " If you wish to simulate installs, please see add a Test Device (https://help.branch.io/using-branch/docs/adding-test-devices)" +
+                " then reset your test device's data (https://help.branch.io/using-branch/docs/adding-test-devices#section-resetting-your-test-device-data).");
     }
 
     /**
      * <p>
      * Disables the test mode for the SDK.
-     * This will also disable debug logs.
      * </p>
      */
     public static void disableTestMode() {
         BranchUtil.setTestMode(false);
-        disableDebugMode();
-    }
-
-    /**
-     * Enables debug mode for the SDK.
-     * @deprecated use {@link Branch#enableDebugMode()}
-     */
-    public void setDebug() {
-        enableDebugMode();
-    }
-
-    /**
-     * Enables debug mode for the SDK and log the SDK Version Declaration Tag.
-     */
-    public static void enableDebugMode() {
-        BranchUtil.setDebugMode(true);
-        PrefHelper.LogAlways(GOOGLE_VERSION_TAG);
-    }
-
-    /**
-     * Disables debug mode for the SDK.
-     */
-    public static void disableDebugMode() {
-        BranchUtil.setDebugMode(false);
     }
 
     /**
@@ -2705,23 +2687,12 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         }
         return matched;
     }
-    
-    public static void enableSimulateInstalls() {
-        isSimulatingInstalls_ = true;
-    }
-    
-    public static void disableSimulateInstalls() {
-        isSimulatingInstalls_ = false;
-    }
-
-    static boolean isSimulatingInstalls() {
-        return isSimulatingInstalls_;
-    }
 
     /**
      * Enable Logging, independent of Debug Mode.
      */
     public static void enableLogging() {
+        PrefHelper.LogAlways(GOOGLE_VERSION_TAG);
         PrefHelper.enableLogging(true);
     }
 
@@ -3401,4 +3372,51 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     public boolean reInitSession(Activity activity, BranchUniversalReferralInitListener callback) {Branch.sessionBuilder(activity).withCallback(callback).reInit();return activity == null || activity.getIntent() == null; }
     /** @deprecated use Branch.sessionBuilder(activity).withCallback(callback).reInit();*/
     public boolean reInitSession(Activity activity, BranchReferralInitListener callback) {Branch.sessionBuilder(activity).withCallback(callback).reInit();return activity == null || activity.getIntent() == null; }
+
+    /**
+     * @deprecated setDebug is deprecated and all functionality has been disabled. If you wish to enable
+     * logging, please invoke enableLogging. If you wish to simulate installs, please see add a Test Device
+     * (https://help.branch.io/using-branch/docs/adding-test-devices) then reset your test device's data
+     * (https://help.branch.io/using-branch/docs/adding-test-devices#section-resetting-your-test-device-data).
+     * If you wish to use the test key rather than the live key, please invoke enableTestMode.
+     */
+    public void setDebug() {
+        PrefHelper.LogAlways("setDebug is deprecated and all functionality has been disabled. " +
+                "If you wish to enable logging, please invoke enableLogging. If you wish to simulate installs," +
+                " please see add a Test Device (https://help.branch.io/using-branch/docs/adding-test-devices) " +
+                "then reset your test device's data (https://help.branch.io/using-branch/docs/adding-test-devices#section-resetting-your-test-device-data). " +
+                "If you wish to use the test key rather than the live key, please invoke enableTestMode.");
+    }
+
+    /**
+     * @deprecated enableDebugMode is deprecated and all functionality has been disabled. If you wish to enable
+     * logging, please invoke enableLogging. If you wish to simulate installs, please see add a Test Device
+     * (https://help.branch.io/using-branch/docs/adding-test-devices) then reset your test device's data
+     * (https://help.branch.io/using-branch/docs/adding-test-devices#section-resetting-your-test-device-data).
+     * If you wish to use the test key rather than the live key, please invoke enableTestMode.
+     */
+    public static void enableDebugMode() {
+        PrefHelper.LogAlways("enableDebugMode is deprecated and all functionality has been disabled. " +
+                "If you wish to enable logging, please invoke enableLogging. If you wish to simulate installs," +
+                " please see add a Test Device (https://help.branch.io/using-branch/docs/adding-test-devices) " +
+                "then reset your test device's data (https://help.branch.io/using-branch/docs/adding-test-devices#section-resetting-your-test-device-data). " +
+                "If you wish to use the test key rather than the live key, please invoke enableTestMode.");
+    }
+
+    /** @deprecated (deprecated and all functionality has been disabled, see enableDebugMode for more information) */
+    public static void disableDebugMode() {}
+
+    /**
+     * @deprecated enableSimulateInstalls is deprecated and all functionality has been disabled. If
+     * you wish to simulate installs, please see add a Test Device (https://help.branch.io/using-branch/docs/adding-test-devices)
+     * then reset your test device's data (https://help.branch.io/using-branch/docs/adding-test-devices#section-resetting-your-test-device-data).
+     * */
+    public static void enableSimulateInstalls() {
+        PrefHelper.LogAlways("enableSimulateInstalls is deprecated and all functionality has been disabled. " +
+                "If you wish to simulate installs, please see add a Test Device (https://help.branch.io/using-branch/docs/adding-test-devices) " +
+                "then reset your test device's data (https://help.branch.io/using-branch/docs/adding-test-devices#section-resetting-your-test-device-data).");
+    }
+
+    /** @deprecated see enableSimulateInstalls() for more information */
+    public static void disableSimulateInstalls() { }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchPreinstall.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchPreinstall.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Iterator;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -114,4 +115,23 @@ class BranchPreinstall {
             }
         }
     }
+
+    public static void setBranchPreInstallGoogleReferrer(Context context, HashMap<String, String> referrerMap){
+        Branch branchInstance = Branch.getInstance();
+        PrefHelper prefHelper = PrefHelper.getInstance(context);
+
+        // Set PreInstallData from GoogleReferrer api
+        // only if PreInstallMetaData has not been updated by either of the methods(Manual setting or OS level)
+        if((TextUtils.isEmpty(prefHelper.getInstallMetaData(PreinstallKey.partner.getKey())) && TextUtils.isEmpty(prefHelper.getInstallMetaData(PreinstallKey.campaign.getKey())))){
+            if(!TextUtils.isEmpty(referrerMap.get(Defines.Jsonkey.UTMCampaign.getKey()))){
+                branchInstance.setPreinstallCampaign(referrerMap.get(Defines.Jsonkey.UTMCampaign.getKey()));
+            }
+
+            if(!TextUtils.isEmpty(referrerMap.get(Defines.Jsonkey.UTMMedium.getKey()))){
+                branchInstance.setPreinstallPartner(referrerMap.get(Defines.Jsonkey.UTMMedium.getKey()));
+            }
+        }
+
+    }
+
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
@@ -27,9 +27,6 @@ import java.util.jar.JarFile;
  */
 public class BranchUtil {
 
-    /** For setting debug mode using {@link Branch#setDebug()} api */
-    private static boolean isCustomDebugEnabled_ = false;
-
     /** For setting test mode using {@link Branch#enableTestMode()} */
     private static boolean isTestModeEnabled_ = false;
 
@@ -38,7 +35,6 @@ public class BranchUtil {
 
     // Package Private
     static void shutDown() {
-        isCustomDebugEnabled_ = false;
         isTestModeEnabled_ = false;
         isManifestTestModeEnabled = null;
     }
@@ -103,7 +99,7 @@ public class BranchUtil {
 
     /**
      * Get the value of "io.branch.sdk.TestMode" entry in application manifest or from String res.
-     * This value can be overriden via. {@link Branch#enableTestMode()}
+     * This value can be overridden via. {@link Branch#enableTestMode()}
      *
      * @return value of "io.branch.sdk.TestMode" entry in application manifest or String res.
      * false if "io.branch.sdk.TestMode" is not added in the manifest or String res.
@@ -116,17 +112,8 @@ public class BranchUtil {
         isTestModeEnabled_ = testMode;
     }
 
-    /**
-     * Determine if Debug Mode is enabled.
-     * @return {@code true} if Debug is enabled, or if {@link BranchUtil#isTestModeEnabled()}
-     */
-    public static boolean isDebugEnabled() {
-        return isCustomDebugEnabled_ || isTestModeEnabled();
-    }
-
-    static void setDebugMode(boolean debugMode) {
-        isCustomDebugEnabled_ = debugMode;
-    }
+    /** @deprecated (see enableDebugMode for more information) */
+    public static boolean isDebugEnabled() { return false; }
 
     /**
      * Converts a given link param as {@link JSONObject} to string after adding the source param and removes replaces any illegal characters.

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -24,7 +24,10 @@ public class Defines {
         BranchIdentity("branch_identity"),
         BranchKey("branch_key"),
         @Deprecated BranchData("branch_data"),              //use Defines.IntentKeys.BranchData
-        
+        PlayAutoInstalls("play-auto-installs"),             //UTM_Source set by Xiaomi
+        UTMCampaign("utm_campaign"),
+        UTMMedium("utm_medium"),
+
         Bucket("bucket"),
         DefaultBucket("default"),
         Amount("amount"),

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -284,20 +284,11 @@ class DeviceInfo {
     }
 
     /**
-     * @return true if a Debug HardwareId is needed.
-     * Note that if either Debug is enabled or Fetch has been disabled, then requests for a Hardware Id will return a "fake" ID.
-     */
-    static public boolean isDebugHardwareIdNeeded() {
-        boolean isDebugHardwareIdNeeded = Branch.isDeviceIDFetchDisabled() || BranchUtil.isDebugEnabled();
-        return isDebugHardwareIdNeeded;
-    }
-
-    /**
      * @return the device Hardware ID.
      * Note that if either Debug is enabled or Fetch has been disabled, then return a "fake" ID.
      */
     public SystemObserver.UniqueId getHardwareID() {
-        return getSystemObserver().getUniqueID(context_, isDebugHardwareIdNeeded());
+        return getSystemObserver().getUniqueID(context_, Branch.isDeviceIDFetchDisabled());
     }
 
     public String getOsName() {

--- a/Branch-SDK/src/main/java/io/branch/referral/GooglePlayStoreAttribution.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/GooglePlayStoreAttribution.java
@@ -53,9 +53,12 @@ class GooglePlayStoreAttribution {
                                 }
                                 onReferrerClientFinished(context, rawReferrer, clickTimeStamp, installBeginTimeStamp);
                             } catch (RemoteException ex) {
+                                PrefHelper.Debug("onInstallReferrerSetupFinished() Remote Exception: " + ex.getMessage());
+                                onReferrerClientError();
+                            } catch (Exception ex) {
                                 PrefHelper.Debug("onInstallReferrerSetupFinished() Exception: " + ex.getMessage());
                                 onReferrerClientError();
-                            }
+                            } 
                             break;
                         case InstallReferrerClient.InstallReferrerResponse.FEATURE_NOT_SUPPORTED:// API not available on the current Play Store app
                         case InstallReferrerClient.InstallReferrerResponse.SERVICE_UNAVAILABLE:// Connection could not be established
@@ -143,7 +146,12 @@ class GooglePlayStoreAttribution {
                     prefHelper.setGoogleSearchInstallIdentifier(referrerMap.get(Defines.Jsonkey.GoogleSearchInstallReferrer.getKey()));
                     prefHelper.setGooglePlayReferrer(rawReferrerString);
                 }
-                
+
+                if(referrerMap.containsValue(Defines.Jsonkey.PlayAutoInstalls.getKey())) {
+                    prefHelper.setGooglePlayReferrer(rawReferrerString);
+                    BranchPreinstall.setBranchPreInstallGoogleReferrer(context, referrerMap);
+                }
+
             } catch (UnsupportedEncodingException e) {
                 e.printStackTrace();
             } catch (IllegalArgumentException e) {

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -1296,10 +1296,8 @@ public class PrefHelper {
      * @param message A {@link String} value containing the debug message to record.
      */
     public static void Debug(String message) {
-        if (BranchUtil.isDebugEnabled() || enableLogging_) {
-            if (!TextUtils.isEmpty(message)) {
-                Log.i(TAG, message);
-            }
+        if (enableLogging_ && !TextUtils.isEmpty(message)) {
+            Log.i(TAG, message);
         }
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -45,7 +45,7 @@ abstract class ServerRequestInitSession extends ServerRequest {
         }
         post.put(Defines.Jsonkey.FaceBookAppLinkChecked.getKey(), prefHelper_.getIsAppLinkTriggeredInit());
         post.put(Defines.Jsonkey.IsReferrable.getKey(), prefHelper_.getIsReferrable());
-        post.put(Defines.Jsonkey.Debug.getKey(), BranchUtil.isDebugEnabled());
+        post.put(Defines.Jsonkey.Debug.getKey(), Branch.isDeviceIDFetchDisabled());
 
         updateInstallStateAndTimestamps(post);
         updateEnvironment(context_, post);

--- a/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
@@ -375,7 +375,9 @@ abstract class SystemObserver {
             WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
             if (windowManager != null) {
                 Display display = windowManager.getDefaultDisplay();
-                display.getMetrics(displayMetrics);
+                if (display != null) {
+                    display.getMetrics(displayMetrics);
+                }
             }
         }
         return displayMetrics;
@@ -399,15 +401,7 @@ abstract class SystemObserver {
      */
     @SuppressWarnings("MissingPermission")
     static boolean getWifiConnected(Context context) {
-        if (context != null && PackageManager.PERMISSION_GRANTED == context.checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE)) {
-            ConnectivityManager connManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-            NetworkInfo wifiInfo = null;
-            if (connManager != null) {
-                wifiInfo = connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-            }
-            return ((wifiInfo != null) && wifiInfo.isConnected());
-        }
-        return false;
+        return "wifi".equalsIgnoreCase(getConnectionType(context));
     }
 
     /**
@@ -546,10 +540,8 @@ abstract class SystemObserver {
             this.uniqueId = BLANK;
 
             String androidID = null;
-            if (context != null) {
-                if (!isDebug && !Branch.isSimulatingInstalls()) {
-                    androidID = Secure.getString(context.getContentResolver(), Secure.ANDROID_ID);
-                }
+            if (context != null && !isDebug) {
+                androidID = Secure.getString(context.getContentResolver(), Secure.ANDROID_ID);
             }
 
             if (androidID == null) {

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,8 @@
 # Branch Android SDK change log
+- v5.0.3
+  * _*Master Release*_ - August 10, 2020
+  * Upgrade referrer library
+  
 - v5.0.2
   * _*Master Release*_ - July 22, 2020
   * Remove content discovery

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.0.2
-VERSION_CODE=050002
+VERSION_NAME=5.0.3
+VERSION_CODE=050003
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.


### PR DESCRIPTION
## Reference
SDK-1053 -- Upgrade referrer library as v1.0 appears to cause crashes in apps that use mParticle as well + Release 5.0.3

## Description
https://branch.slack.com/archives/CS8E89QQ4/p1596824188331600

## Testing Instructions
don't really know how to repro the crash (i.e. confirm that it's fixed) as it appears to be intermittent and originating in play referrer library.. other details we know is that it happens in apps that use Branch and mParticle and referrer library v1.0. 

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
