### PR TITLE
[SDK-1077]: add request when available in enableLogging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,4 @@
-version: 2.1
-
-orbs:
-  android: circleci/android@0.2.1
+version: 2
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
-version: 2
+version: 2.1
+
+orbs:
+  android: circleci/android@0.2.1
+
 jobs:
   build:
     working_directory: ~/code
@@ -6,12 +10,21 @@ jobs:
       - image: circleci/android:api-28
     steps:
       - checkout
+      - restore_cache:
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
       - run:
-          name: Update SDK Tools
-          command: $ANDROID_HOME/tools/bin/sdkmanager --update
+          name: Download Dependencies
+          command: ./gradlew androidDependencies
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
       - run:
           name: Run Lint
           command: ./gradlew lint
+      - run:
+          name: Run Test
+          command: ./gradlew test
       - run:
           name: Run Build
           command: ./gradlew build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,14 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "Branch-SDK/build.gradle" }}
       - run:
           name: Download Dependencies
           command: ./gradlew androidDependencies
       - save_cache:
           paths:
             - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "Branch-SDK/build.gradle" }}
       - run:
           name: Run Lint
           command: ./gradlew lint

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2405,7 +2405,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             addExtraInstrumentationData(thisReq_.getRequestPath() + "-" + Defines.Jsonkey.Queue_Wait_Time.getKey(), String.valueOf(thisReq_.getQueueWaitTime()));
             thisReq_.doFinalUpdateOnBackgroundThread();
             if (isTrackingDisabled() && thisReq_.prepareExecuteWithoutTracking() == false) {
-                return new ServerResponse(thisReq_.getRequestPath(), BranchError.ERR_BRANCH_TRACKING_DISABLED);
+                return new ServerResponse(thisReq_.getRequestPath(), BranchError.ERR_BRANCH_TRACKING_DISABLED, "");
             }
             if (thisReq_.isGetRequest()) {
                 return branchRemoteInterface_.make_restful_get(thisReq_.getRequestUrl(), thisReq_.getGetParams(), thisReq_.getRequestPath(), prefHelper_.getBranchKey());

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -372,4 +372,29 @@ public class Defines {
         }
 
     }
+
+    /**
+     * <p>
+     * Defines Branch header keys
+     * </p>
+     */
+    public enum HeaderKey {
+        RequestId("X-Branch-Request-Id");
+
+        private String key = "";
+
+        HeaderKey(String key) {
+            this.key = key;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        @Override
+        public String toString() {
+            return key;
+        }
+
+    }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerResponse.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerResponse.java
@@ -1,6 +1,5 @@
 package io.branch.referral;
 
-import androidx.annotation.Nullable;
 import org.json.JSONArray;
 import org.json.JSONObject;
 

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerResponse.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerResponse.java
@@ -35,15 +35,21 @@ public class ServerResponse {
     private Object post_;
 
     /**
+     * Unique timestamp based request id provided from internal Branch servers for debugging
+     */
+    private String requestId_;
+
+    /**
      * <p>Main constructor method for the {@link ServerResponse} class that allows for the instantiation
      * of a server response object as a direct result of a server call.</p>
      *
      * @param tag        A {@link String} value of the <i>Tag</i> attribute of the current link.
      * @param statusCode {@link Integer} value of the HTTP status code.
      */
-    public ServerResponse(String tag, int statusCode) {
+    public ServerResponse(String tag, int statusCode, String requestId) {
         tag_ = tag;
         statusCode_ = statusCode;
+        requestId_ = requestId;
     }
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerResponse.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerResponse.java
@@ -1,5 +1,6 @@
 package io.branch.referral;
 
+import androidx.annotation.Nullable;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -33,6 +34,11 @@ public class ServerResponse {
      * cast to a type before use to allow the appropriate "get" methods to be used.
      */
     private Object post_;
+
+    /**
+     * Unique timestamp based request id provided from internal Branch servers for debugging
+     */
+    private String requestId_;
 
 
     /**
@@ -106,6 +112,14 @@ public class ServerResponse {
         return null;
     }
 
+    /**
+     * Set the passed request id
+     *
+     * @param requestId_ passed in from the response headers
+     */
+    public void setRequestId_(@Nullable String requestId_) {
+        this.requestId_ = requestId_;
+    }
 
     /**
      * Get the reason for failure if there any

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerResponse.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerResponse.java
@@ -36,12 +36,6 @@ public class ServerResponse {
     private Object post_;
 
     /**
-     * Unique timestamp based request id provided from internal Branch servers for debugging
-     */
-    private String requestId_;
-
-
-    /**
      * <p>Main constructor method for the {@link ServerResponse} class that allows for the instantiation
      * of a server response object as a direct result of a server call.</p>
      *
@@ -110,15 +104,6 @@ public class ServerResponse {
         }
 
         return null;
-    }
-
-    /**
-     * Set the passed request id
-     *
-     * @param requestId_ passed in from the response headers
-     */
-    public void setRequestId_(@Nullable String requestId_) {
-        this.requestId_ = requestId_;
     }
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterface.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterface.java
@@ -8,6 +8,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.Locale;
+
 import io.branch.referral.Branch;
 import io.branch.referral.BranchError;
 import io.branch.referral.BuildConfig;
@@ -195,7 +197,7 @@ public abstract class BranchRemoteInterface {
 
         ServerResponse result = new ServerResponse(tag, statusCode, requestId);
         if(!TextUtils.isEmpty(requestId)){
-            PrefHelper.Debug(String.format("returned request-id: [ %s ] with %s", requestId, responseString));
+            PrefHelper.Debug(String.format(Locale.getDefault(), "Server returned: [%s] Status: [%d]; Data: %s", requestId, statusCode, responseString));
         } else {
             PrefHelper.Debug(String.format("returned %s", responseString));
         }

--- a/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterface.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterface.java
@@ -98,7 +98,7 @@ public abstract class BranchRemoteInterface {
 
         try {
             BranchResponse response = doRestfulGet(modifiedUrl);
-            return processEntityForJSON(response.responseData, response.responseCode, tag, response.requestId);
+            return processEntityForJSON(response, tag);
         } catch (BranchRemoteException branchError) {
             if (branchError.branchErrorCode == BranchError.ERR_BRANCH_REQ_TIMED_OUT) {
                 return new ServerResponse(tag, BranchError.ERR_BRANCH_REQ_TIMED_OUT);
@@ -135,7 +135,7 @@ public abstract class BranchRemoteInterface {
 
         try {
             BranchResponse response = doRestfulPost(url, body);
-            return processEntityForJSON(response.responseData, response.responseCode, tag, response.requestId);
+            return processEntityForJSON(response, tag);
         } catch (BranchRemoteException branchError) {
             if (branchError.branchErrorCode == BranchError.ERR_BRANCH_REQ_TIMED_OUT) {
                 return new ServerResponse(tag, BranchError.ERR_BRANCH_REQ_TIMED_OUT);
@@ -171,18 +171,21 @@ public abstract class BranchRemoteInterface {
      * that contains the same data. This data is then attached as the post data of the
      * {@link ServerResponse} object returned.</p>
      *
-     * @param responseString Branch server response received. A  string form of the input or error stream payload
-     * @param statusCode     An {@link Integer} value containing the HTTP response code.
+     * @param response Branch server response received containing response data with headers and response code
      * @param tag            A {@link String} value containing the tag value to be applied to the
      *                       resultant {@link ServerResponse} object.
      * @return A {@link ServerResponse} object representing the resultant output object from Branch Remote server
      * response in Branch SDK terms.
      * see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html">HTTP/1.1: Status Codes</a>
      */
-    private ServerResponse processEntityForJSON(String responseString, int statusCode, String tag,@Nullable String requestId) {
+    private ServerResponse processEntityForJSON(BranchResponse response, String tag) {
+        String responseString = response.responseData;
+        String requestId = response.requestId;
+
+        int statusCode = response.responseCode;
+
         ServerResponse result = new ServerResponse(tag, statusCode);
         if(!TextUtils.isEmpty(requestId)){
-            result.setRequestId_(requestId);
             PrefHelper.Debug(String.format("returned request-id: [ %s ] with %s", requestId, responseString));
         } else {
             PrefHelper.Debug(String.format("returned %s", responseString));

--- a/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
@@ -5,6 +5,9 @@ import android.net.TrafficStats;
 import android.os.NetworkOnMainThreadException;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import com.google.android.gms.common.util.Strings;
+
 import io.branch.referral.BranchError;
 import io.branch.referral.Defines;
 import io.branch.referral.PrefHelper;
@@ -77,14 +80,14 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
             } else {
                 try {
                     if (responseCode != HttpsURLConnection.HTTP_OK && connection.getErrorStream() != null) {
-                        return new BranchResponse(getResponseString(connection.getErrorStream()), responseCode, requestId);
+                        return new BranchResponse(getResponseString(connection.getErrorStream()), responseCode, Strings.emptyToNull(requestId));
                     } else {
-                        return new BranchResponse(getResponseString(connection.getInputStream()), responseCode, requestId);
+                        return new BranchResponse(getResponseString(connection.getInputStream()), responseCode, Strings.emptyToNull(requestId));
                     }
                 } catch (FileNotFoundException ex) {
                     // In case of Resource conflict getInputStream will throw FileNotFoundException. Handle it here in order to send the right status code
                     PrefHelper.Debug("A resource conflict occurred with this request " + url);
-                    return new BranchResponse(null, responseCode, requestId);
+                    return new BranchResponse(null, responseCode, Strings.emptyToNull(requestId));
                 }
             }
         } catch (SocketException ex) {
@@ -168,11 +171,11 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
                     } else {
                         inputStream = connection.getInputStream();
                     }
-                    return new BranchResponse(getResponseString(inputStream), responseCode, requestId);
+                    return new BranchResponse(getResponseString(inputStream), responseCode, Strings.emptyToNull(requestId));
                 } catch (FileNotFoundException ex) {
                     // In case of Resource conflict getInputStream will throw FileNotFoundException. Handle it here in order to send the right status code
                     PrefHelper.Debug("A resource conflict occurred with this request " + url);
-                    return new BranchResponse(null, responseCode, requestId);
+                    return new BranchResponse(null, responseCode, Strings.emptyToNull(requestId));
                 } finally {
                     try {
                         if (inputStream != null) {
@@ -207,7 +210,7 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
                 if (ex instanceof NetworkOnMainThreadException)
                     PrefHelper.Debug("Branch Error: Don't call our synchronous methods on the main thread!!!");
             }
-            return new BranchResponse(null, 500, requestId);
+            return new BranchResponse(null, 500, Strings.emptyToNull(requestId));
         } finally {
             if (connection != null) {
                 connection.disconnect();

--- a/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
@@ -6,6 +6,7 @@ import android.os.NetworkOnMainThreadException;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.branch.referral.BranchError;
+import io.branch.referral.Defines;
 import io.branch.referral.PrefHelper;
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
@@ -217,8 +218,8 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
     @Nullable
     private String getRequestIdFromHeader(@NonNull HttpsURLConnection connection) {
         if (!connection.getHeaderFields().isEmpty() && connection.getHeaderFields()
-            .containsKey("X-Branch-Request-Id")) {
-            return connection.getHeaderField("X-Branch-Request-Id");
+            .containsKey(Defines.HeaderKey.RequestId.getKey())) {
+            return connection.getHeaderField(Defines.HeaderKey.RequestId.getKey());
         }
         return null;
     }

--- a/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
@@ -49,7 +49,6 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
     ///-------------- private methods to implement RESTful GET / POST using HttpURLConnection ---------------//
     private BranchResponse doRestfulGet(String url, int retryNumber) throws BranchRemoteException {
         HttpsURLConnection connection = null;
-        String requestId = null;
         try {
             int timeout = prefHelper.getTimeout();
             if (timeout <= 0) {
@@ -62,7 +61,7 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
             connection.setConnectTimeout(timeout);
             connection.setReadTimeout(timeout);
 
-            requestId = getRequestIdFromHeader(connection);
+            String requestId = getRequestIdFromHeader(connection);
 
             int responseCode = connection.getResponseCode();
             if (responseCode >= 500 &&

--- a/build.gradle
+++ b/build.gradle
@@ -28,3 +28,11 @@ allprojects {
 subprojects {
     tasks.withType(Javadoc).all { enabled = false }
 }
+
+tasks.withType(Test) {
+    testLogging {
+        exceptionFormat "full"
+        events "started", "skipped", "passed", "failed"
+        showStandardStreams true
+    }
+}


### PR DESCRIPTION
## Reference
SDK-1077: [android] Update native SDK to report X-Branch-Request-ID when present

## Description
Print request-id in the logs when;
1. EnableLogging is set
2. X-Branch-Request-Id-Header is present in the response header

```
I/BranchSDK: returned request-id: [ 1231231__!32123123 ] with {"session_id":"849308671259384261","identity_id":"849308509983354059","link":"https://bnctestbed.test-app.link?%24identity_id=849308509983354059","data":"{\"+clicked_branch_link\":false,\"+is_first_session\":false}","device_fingerprint_id":"849308509959273715"}
```

## Testing Instructions
- [X] Manual

## Risk Assessment [`LOW`]

- [X] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/core-team 
