### PR TITLE
Sdk 1090 fix timeout

### DIFF
--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
@@ -64,6 +64,7 @@ public class MainActivity extends Activity {
         ((ToggleButton) findViewById(R.id.tracking_cntrl_btn)).setChecked(Branch.getInstance().isTrackingDisabled());
 
         createNotificationChannel();
+        Branch.getInstance().setNetworkTimeout(10000);
 
         // Create a BranchUniversal object for the content referred on this activity instance
         branchUniversalObject = new BranchUniversalObject()

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
@@ -64,7 +64,6 @@ public class MainActivity extends Activity {
         ((ToggleButton) findViewById(R.id.tracking_cntrl_btn)).setChecked(Branch.getInstance().isTrackingDisabled());
 
         createNotificationChannel();
-        Branch.getInstance().setNetworkTimeout(10000);
 
         // Create a BranchUniversal object for the content referred on this activity instance
         branchUniversalObject = new BranchUniversalObject()

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1,5 +1,6 @@
 package io.branch.referral;
 
+import static io.branch.referral.BranchError.ERR_BRANCH_REQ_TIMED_OUT;
 import static io.branch.referral.BranchPreinstall.getPreinstallSystemData;
 import static io.branch.referral.BranchUtil.isTestModeEnabled;
 
@@ -590,24 +591,19 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      */
     public static Branch getInstance(@NonNull Context context, @NonNull String branchKey) {
         if (branchReferral_ == null) {
-            branchReferral_ = Branch.initInstance(context);
-        }
-        if (branchReferral_.prefHelper_.isValidBranchKey(branchKey)) {
-            boolean isNewBranchKeySet = branchReferral_.prefHelper_.setBranchKey(branchKey);
-            //on setting a new key clear link cache and pending requests
-            if (isNewBranchKeySet) {
-                branchReferral_.linkCache_.clear();
-                branchReferral_.requestQueue_.clear();
+            branchReferral_ = new Branch(context.getApplicationContext());
+            if (branchReferral_.prefHelper_.isValidBranchKey(branchKey)) {
+                branchReferral_.prefHelper_.setBranchKey(branchKey);
+            } else {
+                PrefHelper.Debug("Branch Key is invalid. Please check your BranchKey");
             }
-        } else {
-            PrefHelper.Debug("Branch Key is invalid. Please check your BranchKey");
         }
         return branchReferral_;
     }
     
     private static Branch getBranchInstance(@NonNull Context context, boolean isLive, String branchKey) {
         if (branchReferral_ == null) {
-            branchReferral_ = Branch.initInstance(context);
+            branchReferral_ = new Branch(context.getApplicationContext());
 
             // Configure live or test mode
             boolean testModeAvailable = BranchUtil.checkTestMode(context);
@@ -766,16 +762,6 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         branchReferral_.setIsReferrable(isReferrable);
         return branchReferral_;
     }
-    
-    /**
-     * <p>Initialises an instance of the Branch object.</p>
-     *
-     * @param context A {@link Context} from which this call was made.
-     * @return An initialised {@link Branch} object.
-     */
-    private static Branch initInstance(@NonNull Context context) {
-        return new Branch(context.getApplicationContext());
-    }
 
     // Package Private
     // For Unit Testing, we need to reset the Branch state
@@ -822,8 +808,10 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     }
     
     /**
-     * <p>Sets the number of times to re-attempt a timed-out request to the Branch API, before
-     * considering the request to have failed entirely. Default 3.</p>
+     * Sets the max number of times to re-attempt a timed-out request to the Branch API, before
+     * considering the request to have failed entirely. Default to 3. Note that the the network
+     * timeout, as set in {@link #setNetworkTimeout(int)}, together with the retry interval value from
+     * {@link #setRetryInterval(int)} will determine if the max retry count will be attempted.
      *
      * @param retryCount An {@link Integer} specifying the number of times to retry before giving
      *                   up and declaring defeat.
@@ -835,8 +823,8 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     }
     
     /**
-     * <p>Sets the amount of time in milliseconds to wait before re-attempting a timed-out request
-     * to the Branch API. Default 5500 ms.</p>
+     * Sets the amount of time in milliseconds to wait before re-attempting a timed-out request
+     * to the Branch API. Default 1000 ms.
      *
      * @param retryInterval An {@link Integer} value specifying the number of milliseconds to
      *                      wait before re-attempting a timed-out request.
@@ -848,10 +836,9 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     }
     
     /**
-     * <p>Sets the duration in milliseconds that the system should wait for a response before considering
-     * any Branch API call to have timed out. Default 3000 ms.</p>
-     * <p>Increase this to perform better in low network speed situations, but at the expense of
-     * responsiveness to error situation.</p>
+     * <p>Sets the duration in milliseconds that the system should wait for a response before timing
+     * out any Branch API. Default 5500 ms. Note that this is the total time allocated for all request
+     * retries as set in {@link #setRetryCount(int)}.
      *
      * @param timeout An {@link Integer} value specifying the number of milliseconds to wait before
      *                considering the request to have timed out.
@@ -1816,8 +1803,10 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                             networkCount_ = 0;
                             handleFailure(requestQueue_.getSize() - 1, BranchError.ERR_NO_SESSION);
                         } else {
-                            BranchPostTask postTask = new BranchPostTask(req);
+                            final CountDownLatch latch = new CountDownLatch(1);
+                            final BranchPostTask postTask = new BranchPostTask(req, latch);
                             postTask.executeTask();
+                            startTimeoutTimer(latch, postTask, prefHelper_.getTimeout());
                         }
                     } else {
                         networkCount_ = 0;
@@ -1831,6 +1820,21 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    private void startTimeoutTimer(final CountDownLatch latch, final BranchPostTask postTask, final int timeout) {
+        new Thread(new Runnable() {@Override public void run() {
+            try {
+                if (!latch.await(timeout, TimeUnit.MILLISECONDS)) {
+                    // don't interrupt in case the task is already in onPostExecute(...).
+                    postTask.cancel(true);
+                    requestQueue_.remove(postTask.thisReq_);
+                    postTask.thisReq_.handleFailure(ERR_BRANCH_REQ_TIMED_OUT,  "Timed out: " + postTask.thisReq_.getRequestUrl());
+                }
+            } catch (InterruptedException ignored) {
+                PrefHelper.Debug("benas");
+            }
+        }}).start();
     }
 
     // Determine if a Request needs a Session to proceed.
@@ -2391,9 +2395,11 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      */
     private class BranchPostTask extends BranchAsyncTask<Void, Void, ServerResponse> {
         ServerRequest thisReq_;
+        private final CountDownLatch latch_;
         
-        public BranchPostTask(ServerRequest request) {
+        public BranchPostTask(ServerRequest request, CountDownLatch latch) {
             thisReq_ = request;
+            latch_ = latch;
         }
         
         @Override
@@ -2421,143 +2427,150 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         @Override
         protected void onPostExecute(ServerResponse serverResponse) {
             super.onPostExecute(serverResponse);
-            if (serverResponse != null) {
-                try {
-                    int status = serverResponse.getStatusCode();
-                    hasNetwork_ = true;
-                    
-                    if (serverResponse.getStatusCode() == BranchError.ERR_BRANCH_TRACKING_DISABLED) {
-                        thisReq_.reportTrackingDisabledError();
-                        requestQueue_.remove(thisReq_);
-                        
-                    } else {
-                        //If the request is not succeeded
-                        if (status != 200) {
-                            //If failed request is an initialisation request then mark session not initialised
-                            if (thisReq_ instanceof ServerRequestInitSession) {
-                                setInitState(SESSION_STATE.UNINITIALISED);
-                            }
-                            // On a bad request or in canse of a conflict notify with call back and remove the request.
-                            if (status == 400 || status == 409) {
-                                requestQueue_.remove(thisReq_);
-                                if (thisReq_ instanceof ServerRequestCreateUrl) {
-                                    ((ServerRequestCreateUrl) thisReq_).handleDuplicateURLError();
-                                } else {
-                                    PrefHelper.LogAlways("Branch API Error: Conflicting resource error code from API");
-                                    handleFailure(0, status);
-                                }
-                            }
-                            //On Network error or Branch is down fail all the pending requests in the queue except
-                            //for request which need to be replayed on failure.
-                            else {
-                                hasNetwork_ = false;
-                                //Collect all request from the queue which need to be failed.
-                                ArrayList<ServerRequest> requestToFail = new ArrayList<>();
-                                for (int i = 0; i < requestQueue_.getSize(); i++) {
-                                    requestToFail.add(requestQueue_.peekAt(i));
-                                }
-                                //Remove the requests from the request queue first
-                                for (ServerRequest req : requestToFail) {
-                                    if (req == null || !req.shouldRetryOnFail()) { // Should remove any nullified request object also from queue
-                                        requestQueue_.remove(req);
-                                    }
-                                }
-                                // Then, set the network count to zero, indicating that requests can be started again.
-                                networkCount_ = 0;
-                                
-                                //Finally call the request callback with the error.
-                                for (ServerRequest req : requestToFail) {
-                                    if (req != null) {
-                                        req.handleFailure(status, serverResponse.getFailReason());
-                                        //If request need to be replayed, no need for the callbacks
-                                        if (req.shouldRetryOnFail())
-                                            req.clearCallbacks();
-                                    }
-                                }
-                            }
+            latch_.countDown();
+
+            if (serverResponse == null || isCancelled()) return;
+
+            try {
+                int status = serverResponse.getStatusCode();
+                hasNetwork_ = true;
+
+                if (serverResponse.getStatusCode() == BranchError.ERR_BRANCH_TRACKING_DISABLED) {
+                    thisReq_.reportTrackingDisabledError();
+                    requestQueue_.remove(thisReq_);
+
+                } else {
+                    //If the request is not succeeded
+                    if (status != 200) {
+                        //If failed request is an initialisation request then mark session not initialised
+                        if (thisReq_ instanceof ServerRequestInitSession) {
+                            setInitState(SESSION_STATE.UNINITIALISED);
                         }
-                        // If the request succeeded
-                        else {
-                            hasNetwork_ = true;
-                            //On create  new url cache the url.
+                        // On a bad request or in canse of a conflict notify with call back and remove the request.
+                        if (status == 400 || status == 409) {
+                            requestQueue_.remove(thisReq_);
                             if (thisReq_ instanceof ServerRequestCreateUrl) {
-                                if (serverResponse.getObject() != null) {
-                                    final String url = serverResponse.getObject().getString("url");
-                                    // cache the link
-                                    linkCache_.put(((ServerRequestCreateUrl) thisReq_).getLinkPost(), url);
-                                }
-                            }
-                            //On Logout clear the link cache and all pending requests
-                            else if (thisReq_ instanceof ServerRequestLogout) {
-                                linkCache_.clear();
-                                requestQueue_.clear();
-                            }
-                            requestQueue_.dequeue();
-                            
-                            // If this request changes a session update the session-id to queued requests.
-                            if (thisReq_ instanceof ServerRequestInitSession
-                                    || thisReq_ instanceof ServerRequestIdentifyUserRequest) {
-                                // Immediately set session and Identity and update the pending request with the params
-                                JSONObject respJson = serverResponse.getObject();
-                                if (respJson != null) {
-                                    boolean updateRequestsInQueue = false;
-                                    if (!isTrackingDisabled()) { // Update PII data only if tracking is disabled
-                                        if (respJson.has(Defines.Jsonkey.SessionID.getKey())) {
-                                            prefHelper_.setSessionID(respJson.getString(Defines.Jsonkey.SessionID.getKey()));
-                                            updateRequestsInQueue = true;
-                                        }
-                                        if (respJson.has(Defines.Jsonkey.IdentityID.getKey())) {
-                                            String new_Identity_Id = respJson.getString(Defines.Jsonkey.IdentityID.getKey());
-                                            if (!prefHelper_.getIdentityID().equals(new_Identity_Id)) {
-                                                //On setting a new identity Id clear the link cache
-                                                linkCache_.clear();
-                                                prefHelper_.setIdentityID(respJson.getString(Defines.Jsonkey.IdentityID.getKey()));
-                                                updateRequestsInQueue = true;
-                                            }
-                                        }
-                                        if (respJson.has(Defines.Jsonkey.DeviceFingerprintID.getKey())) {
-                                            prefHelper_.setDeviceFingerPrintID(respJson.getString(Defines.Jsonkey.DeviceFingerprintID.getKey()));
-                                            updateRequestsInQueue = true;
-                                        }
-                                    }
-                                    
-                                    if (updateRequestsInQueue) {
-                                        updateAllRequestsInQueue();
-                                    }
-                                    
-                                    if (thisReq_ instanceof ServerRequestInitSession) {
-                                        setInitState(SESSION_STATE.INITIALISED);
-                                        thisReq_.onRequestSucceeded(serverResponse, branchReferral_);
-                                        if (!((ServerRequestInitSession) thisReq_).handleBranchViewIfAvailable((serverResponse))) {
-                                            checkForAutoDeepLinkConfiguration();
-                                        }
-                                        // Count down the latch holding getLatestReferringParamsSync
-                                        if (getLatestReferringParamsLatch != null) {
-                                            getLatestReferringParamsLatch.countDown();
-                                        }
-                                        // Count down the latch holding getFirstReferringParamsSync
-                                        if (getFirstReferringParamsLatch != null) {
-                                            getFirstReferringParamsLatch.countDown();
-                                        }
-                                    } else {
-                                        // For setting identity just call only request succeeded
-                                        thisReq_.onRequestSucceeded(serverResponse, branchReferral_);
-                                    }
-                                }
+                                ((ServerRequestCreateUrl) thisReq_).handleDuplicateURLError();
                             } else {
-                                //Publish success to listeners
-                                thisReq_.onRequestSucceeded(serverResponse, branchReferral_);
+                                PrefHelper.LogAlways("Branch API Error: Conflicting resource error code from API");
+                                handleFailure(0, status);
+                            }
+                        }
+                        //On Network error or Branch is down fail all the pending requests in the queue except
+                        //for request which need to be replayed on failure.
+                        else {
+                            hasNetwork_ = false;
+                            //Collect all request from the queue which need to be failed.
+                            ArrayList<ServerRequest> requestToFail = new ArrayList<>();
+                            for (int i = 0; i < requestQueue_.getSize(); i++) {
+                                requestToFail.add(requestQueue_.peekAt(i));
+                            }
+                            //Remove the requests from the request queue first
+                            for (ServerRequest req : requestToFail) {
+                                if (req == null || !req.shouldRetryOnFail()) { // Should remove any nullified request object also from queue
+                                    requestQueue_.remove(req);
+                                }
+                            }
+                            // Then, set the network count to zero, indicating that requests can be started again.
+                            networkCount_ = 0;
+
+                            //Finally call the request callback with the error.
+                            for (ServerRequest req : requestToFail) {
+                                if (req != null) {
+                                    req.handleFailure(status, serverResponse.getFailReason());
+                                    //If request need to be replayed, no need for the callbacks
+                                    if (req.shouldRetryOnFail())
+                                        req.clearCallbacks();
+                                }
                             }
                         }
                     }
-                    networkCount_ = 0;
-                    if (hasNetwork_ && initState_ != SESSION_STATE.UNINITIALISED) {
-                        processNextQueueItem();
+                    // If the request succeeded
+                    else {
+                        hasNetwork_ = true;
+                        //On create  new url cache the url.
+                        if (thisReq_ instanceof ServerRequestCreateUrl) {
+                            if (serverResponse.getObject() != null) {
+                                final String url = serverResponse.getObject().getString("url");
+                                // cache the link
+                                linkCache_.put(((ServerRequestCreateUrl) thisReq_).getLinkPost(), url);
+                            }
+                        }
+                        //On Logout clear the link cache and all pending requests
+                        else if (thisReq_ instanceof ServerRequestLogout) {
+                            linkCache_.clear();
+                            requestQueue_.clear();
+                        }
+                        requestQueue_.dequeue();
+
+                        // If this request changes a session update the session-id to queued requests.
+                        if (thisReq_ instanceof ServerRequestInitSession
+                                || thisReq_ instanceof ServerRequestIdentifyUserRequest) {
+                            // Immediately set session and Identity and update the pending request with the params
+                            JSONObject respJson = serverResponse.getObject();
+                            if (respJson != null) {
+                                boolean updateRequestsInQueue = false;
+                                if (!isTrackingDisabled()) { // Update PII data only if tracking is disabled
+                                    if (respJson.has(Defines.Jsonkey.SessionID.getKey())) {
+                                        prefHelper_.setSessionID(respJson.getString(Defines.Jsonkey.SessionID.getKey()));
+                                        updateRequestsInQueue = true;
+                                    }
+                                    if (respJson.has(Defines.Jsonkey.IdentityID.getKey())) {
+                                        String new_Identity_Id = respJson.getString(Defines.Jsonkey.IdentityID.getKey());
+                                        if (!prefHelper_.getIdentityID().equals(new_Identity_Id)) {
+                                            //On setting a new identity Id clear the link cache
+                                            linkCache_.clear();
+                                            prefHelper_.setIdentityID(respJson.getString(Defines.Jsonkey.IdentityID.getKey()));
+                                            updateRequestsInQueue = true;
+                                        }
+                                    }
+                                    if (respJson.has(Defines.Jsonkey.DeviceFingerprintID.getKey())) {
+                                        prefHelper_.setDeviceFingerPrintID(respJson.getString(Defines.Jsonkey.DeviceFingerprintID.getKey()));
+                                        updateRequestsInQueue = true;
+                                    }
+                                }
+
+                                if (updateRequestsInQueue) {
+                                    updateAllRequestsInQueue();
+                                }
+
+                                if (thisReq_ instanceof ServerRequestInitSession) {
+                                    setInitState(SESSION_STATE.INITIALISED);
+                                    thisReq_.onRequestSucceeded(serverResponse, branchReferral_);
+                                    if (!((ServerRequestInitSession) thisReq_).handleBranchViewIfAvailable((serverResponse))) {
+                                        checkForAutoDeepLinkConfiguration();
+                                    }
+                                    // Count down the latch holding getLatestReferringParamsSync
+                                    if (getLatestReferringParamsLatch != null) {
+                                        getLatestReferringParamsLatch.countDown();
+                                    }
+                                    // Count down the latch holding getFirstReferringParamsSync
+                                    if (getFirstReferringParamsLatch != null) {
+                                        getFirstReferringParamsLatch.countDown();
+                                    }
+                                } else {
+                                    // For setting identity just call only request succeeded
+                                    thisReq_.onRequestSucceeded(serverResponse, branchReferral_);
+                                }
+                            }
+                        } else {
+                            //Publish success to listeners
+                            thisReq_.onRequestSucceeded(serverResponse, branchReferral_);
+                        }
                     }
-                } catch (JSONException ex) {
-                    ex.printStackTrace();
                 }
+                networkCount_ = 0;
+                if (hasNetwork_ && initState_ != SESSION_STATE.UNINITIALISED) {
+                    processNextQueueItem();
+                }
+            } catch (JSONException ex) {
+                ex.printStackTrace();
             }
+        }
+
+        @Override
+        protected void onCancelled(ServerResponse v) {
+            new ServerResponse(thisReq_.getRequestPath(), ERR_BRANCH_REQ_TIMED_OUT, "");
         }
     }
     

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1826,10 +1826,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         new Thread(new Runnable() {@Override public void run() {
             try {
                 if (!latch.await(timeout, TimeUnit.MILLISECONDS)) {
-                    // don't interrupt in case the task is already in onPostExecute(...).
                     postTask.cancel(true);
-                    requestQueue_.remove(postTask.thisReq_);
-                    postTask.thisReq_.handleFailure(ERR_BRANCH_REQ_TIMED_OUT,  "Timed out: " + postTask.thisReq_.getRequestUrl());
                 }
             } catch (InterruptedException ignored) {
                 PrefHelper.Debug("benas");
@@ -2570,7 +2567,8 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
 
         @Override
         protected void onCancelled(ServerResponse v) {
-            new ServerResponse(thisReq_.getRequestPath(), ERR_BRANCH_REQ_TIMED_OUT, "");
+            thisReq_.handleFailure(ERR_BRANCH_REQ_TIMED_OUT,  "Timed out: " + thisReq_.getRequestUrl());
+            requestQueue_.remove(thisReq_);
         }
     }
     

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterOpen.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterOpen.java
@@ -103,12 +103,6 @@ class ServerRequestRegisterOpen extends ServerRequestInitSession {
         onInitSessionCompleted(resp, branch);
     }
     
-    void setInitFinishedCallback(Branch.BranchReferralInitListener callback) {
-        if (callback != null) {      // Update callback if set with valid callback instance.
-            callback_ = callback;
-        }
-    }
-    
     @Override
     public void handleFailure(int statusCode, String causeMsg) {
         if (callback_ != null && !Branch.getInstance().isIDLSession()) {

--- a/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterface.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterface.java
@@ -97,16 +97,14 @@ public abstract class BranchRemoteInterface {
         long reqStartTime = System.currentTimeMillis();
         PrefHelper.Debug("getting " + modifiedUrl);
 
-        String requestId = "";
-
         try {
             BranchResponse response = doRestfulGet(modifiedUrl);
-            return processEntityForJSON(response, tag);
+            return processEntityForJSON(response, tag, response.requestId);
         } catch (BranchRemoteException branchError) {
             if (branchError.branchErrorCode == BranchError.ERR_BRANCH_REQ_TIMED_OUT) {
-                return new ServerResponse(tag, BranchError.ERR_BRANCH_REQ_TIMED_OUT, requestId);
+                return new ServerResponse(tag, BranchError.ERR_BRANCH_REQ_TIMED_OUT, "");
             } else { // All other errors are considered as connectivity error
-                return new ServerResponse(tag, BranchError.ERR_BRANCH_NO_CONNECTIVITY, requestId);
+                return new ServerResponse(tag, BranchError.ERR_BRANCH_NO_CONNECTIVITY, "");
             }
         } finally {
             // Add total round trip time
@@ -136,15 +134,14 @@ public abstract class BranchRemoteInterface {
         PrefHelper.Debug("posting to " + url);
         PrefHelper.Debug("Post value = " + body.toString());
 
-        String requestId = "";
         try {
             BranchResponse response = doRestfulPost(url, body);
-            return processEntityForJSON(response, tag);
+            return processEntityForJSON(response, tag, response.requestId);
         } catch (BranchRemoteException branchError) {
             if (branchError.branchErrorCode == BranchError.ERR_BRANCH_REQ_TIMED_OUT) {
-                return new ServerResponse(tag, BranchError.ERR_BRANCH_REQ_TIMED_OUT, requestId);
+                return new ServerResponse(tag, BranchError.ERR_BRANCH_REQ_TIMED_OUT, "");
             } else { // All other errors are considered as connectivity error
-                return new ServerResponse(tag, BranchError.ERR_BRANCH_NO_CONNECTIVITY, requestId);
+                return new ServerResponse(tag, BranchError.ERR_BRANCH_NO_CONNECTIVITY, "");
             }
         } finally {
             if (Branch.getInstance() != null) {
@@ -170,9 +167,8 @@ public abstract class BranchRemoteInterface {
      * response in Branch SDK terms.
      * see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html">HTTP/1.1: Status Codes</a>
      */
-    private ServerResponse processEntityForJSON(BranchResponse response, String tag) {
+    private ServerResponse processEntityForJSON(BranchResponse response, String tag, String requestId) {
         String responseString = response.responseData;
-        String requestId = response.requestId;
 
         int statusCode = response.responseCode;
 
@@ -256,7 +252,7 @@ public abstract class BranchRemoteInterface {
     public static class BranchResponse {
         private final String responseData;
         private final int responseCode;
-        private final String requestId;
+        String requestId;
 
         /**
          * Creates a BranchResponse object with response data and status code
@@ -264,10 +260,9 @@ public abstract class BranchRemoteInterface {
          * @param responseData The data returned by branch server. Nullable in case of errors.(Note :please see {@link io.branch.referral.network.BranchRemoteInterface.BranchRemoteException} for a better handling of errors)
          * @param responseCode Standard Http Response code (rfc2616 http error codes)
          */
-        public BranchResponse(@Nullable String responseData, int responseCode, @Nullable String requestId) {
+        public BranchResponse(@Nullable String responseData, int responseCode) {
             this.responseData = responseData;
             this.responseCode = responseCode;
-            this.requestId = requestId;
         }
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
@@ -171,27 +171,20 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
                 retryNumber++;
                 return doRestfulPost(url, payload, retryNumber);
             } else {
-                InputStream inputStream = null;
+                BranchResponse result;
                 try {
                     if (responseCode != HttpsURLConnection.HTTP_OK && connection.getErrorStream() != null) {
-                        inputStream = connection.getErrorStream();
+                        result = new BranchResponse(getResponseString(connection.getErrorStream()), responseCode);
                     } else {
-                        inputStream = connection.getInputStream();
+                        result = new BranchResponse(getResponseString(connection.getInputStream()), responseCode);
                     }
-                    return new BranchResponse(getResponseString(inputStream), responseCode);
                 } catch (FileNotFoundException ex) {
                     // In case of Resource conflict getInputStream will throw FileNotFoundException. Handle it here in order to send the right status code
                     PrefHelper.Debug("A resource conflict occurred with this request " + url);
-                    return new BranchResponse(null, responseCode);
-                } finally {
-                    try {
-                        if (inputStream != null) {
-                            inputStream.close();
-                        }
-                    } catch(IOException e) {
-                        e.printStackTrace();
-                    }
+                    result = new BranchResponse(null, responseCode);
                 }
+                result.requestId = requestId;
+                return result;
             }
 
 

--- a/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
@@ -71,8 +71,7 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
             maybeSetCloseRequestFlag(connection);
 
             int responseCode = connection.getResponseCode();
-            if (responseCode >= 500 &&
-                    retryNumber < prefHelper.getRetryCount()) {
+            if (responseCode >= 500 && retryNumber < prefHelper.getRetryCount()) {
                 try {
                     Thread.sleep(prefHelper.getRetryInterval());
                 } catch (InterruptedException e) {
@@ -81,17 +80,20 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
                 retryNumber++;
                 return doRestfulGet(url, retryNumber);
             } else {
+                BranchResponse result;
                 try {
                     if (responseCode != HttpsURLConnection.HTTP_OK && connection.getErrorStream() != null) {
-                        return new BranchResponse(getResponseString(connection.getErrorStream()), responseCode, Strings.emptyToNull(requestId));
+                        result = new BranchResponse(getResponseString(connection.getErrorStream()), responseCode);
                     } else {
-                        return new BranchResponse(getResponseString(connection.getInputStream()), responseCode, Strings.emptyToNull(requestId));
+                        result = new BranchResponse(getResponseString(connection.getInputStream()), responseCode);
                     }
                 } catch (FileNotFoundException ex) {
                     // In case of Resource conflict getInputStream will throw FileNotFoundException. Handle it here in order to send the right status code
                     PrefHelper.Debug("A resource conflict occurred with this request " + url);
-                    return new BranchResponse(null, responseCode, Strings.emptyToNull(requestId));
+                    result = new BranchResponse(null, responseCode);
                 }
+                result.requestId = Strings.emptyToNull(requestId);
+                return result;
             }
         } catch (SocketException ex) {
             PrefHelper.Debug("Http connect exception: " + ex.getMessage());
@@ -176,11 +178,11 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
                     } else {
                         inputStream = connection.getInputStream();
                     }
-                    return new BranchResponse(getResponseString(inputStream), responseCode, Strings.emptyToNull(requestId));
+                    return new BranchResponse(getResponseString(inputStream), responseCode);
                 } catch (FileNotFoundException ex) {
                     // In case of Resource conflict getInputStream will throw FileNotFoundException. Handle it here in order to send the right status code
                     PrefHelper.Debug("A resource conflict occurred with this request " + url);
-                    return new BranchResponse(null, responseCode, Strings.emptyToNull(requestId));
+                    return new BranchResponse(null, responseCode);
                 } finally {
                     try {
                         if (inputStream != null) {
@@ -215,7 +217,7 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
                 if (ex instanceof NetworkOnMainThreadException)
                     PrefHelper.Debug("Branch Error: Don't call our synchronous methods on the main thread!!!");
             }
-            return new BranchResponse(null, 500, Strings.emptyToNull(requestId));
+            return new BranchResponse(null, 500);
         } finally {
             if (connection != null) {
                 connection.disconnect();

--- a/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
@@ -31,7 +31,6 @@ import org.json.JSONObject;
  * This class provides implementation for Branch RESTful operations using HTTP URL Connection.
  */
 public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
-    private static final int DEFAULT_TIMEOUT = 3000;
     private static final int THREAD_TAG_POST= 102;
 
     private @NonNull final Branch branch;
@@ -57,9 +56,6 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
         PrefHelper prefHelper = PrefHelper.getInstance(branch.getApplicationContext());
         try {
             int timeout = prefHelper.getTimeout();
-            if (timeout <= 0) {
-                timeout = DEFAULT_TIMEOUT;
-            }
             String appendKey = url.contains("?") ? "&" : "?";
             String modifiedUrl = url + appendKey + RETRY_NUMBER + "=" + retryNumber;
             URL urlObject = new URL(modifiedUrl);
@@ -125,12 +121,8 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
 
     private BranchResponse doRestfulPost(String url, JSONObject payload, int retryNumber) throws BranchRemoteException {
         HttpsURLConnection connection = null;
-        String requestId = null;
         PrefHelper prefHelper = PrefHelper.getInstance(branch.getApplicationContext());
         int timeout = prefHelper.getTimeout();
-        if (timeout <= 0) {
-            timeout = DEFAULT_TIMEOUT;
-        }
         try {
             payload.put(RETRY_NUMBER, retryNumber);
         } catch (JSONException ignore) {
@@ -157,7 +149,7 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
             outputStreamWriter.flush();
             outputStreamWriter.close();
 
-            requestId = connection.getHeaderField(Defines.HeaderKey.RequestId.getKey());
+            String requestId = connection.getHeaderField(Defines.HeaderKey.RequestId.getKey());
             maybeSetCloseRequestFlag(connection);
 
             int responseCode = connection.getResponseCode();


### PR DESCRIPTION
## Reference
https://branch.atlassian.net/browse/SDK-1090

## Description
Currently the SDK does not actually respect the value passed in the API, `setNetworkTimeout`, because of the `HttpsURLConnection.setConnectTimeout(...)` implementation that applies the passed in timeout to all IP addresses that an endpoint resolves to. We host `v1/open` endpoint on 10+ machines, so in a typical case with our default timeout of 5.5. seconds, we will not timeout for like a full minute.

Applied solution:
Artificially cap the allocated time given to the request to complete, and cancel the request otherwise. This is the solution I'm planning to implement for right now.

## Testing Instructions
Run the tester app, try to set the network timeout to various values and observe timeouts happen at the expected time. Here is a command to run emulator with super high latency to repro timeouts:
`emulator -avd NameOfYouEmulator -netspeed 1:1 -netdelay 500`

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
MEDIUM

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
