### PR TITLE
Core 1588 hashed partner params

### DIFF
--- a/Branch-SDK/build.gradle
+++ b/Branch-SDK/build.gradle
@@ -15,14 +15,15 @@ dependencies {
 
     implementation 'com.google.firebase:firebase-appindexing:19.0.0'
 
-    // testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-
-    // Unit tests with Google Ads
     androidTestImplementation 'com.google.android.gms:play-services-ads-identifier:17.0.0'
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.json:json:20201115'
+    testImplementation 'org.skyscreamer:jsonassert:1.5.0'
 }
 
 android {

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -299,8 +299,6 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     private final PrefHelper prefHelper_;
     private final DeviceInfo deviceInfo_;
     private final Context context_;
-
-    final Object lock = new Object();
     
     private final Semaphore serverSema_ = new Semaphore(1);
     
@@ -764,7 +762,6 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         ServerRequestQueue.shutDown();
         PrefHelper.shutDown();
         BranchUtil.shutDown();
-        DeviceInfo.shutDown();
 
         // BranchStrongMatchHelper.shutDown();
         // BranchViewHandler.shutDown();
@@ -958,6 +955,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      * </p>
      */
     void closeSessionInternal() {
+        clearPartnerParameters();
         executeClose();
         prefHelper_.setExternalIntentUri(null);
         trackingController.updateTrackingState(context_); // Update the tracking state for next cold start
@@ -1632,14 +1630,14 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      * See Facebook's documentation for details on valid parameters
      */
     public void addFacebookPartnerParameterWithName(@NonNull String key, @NonNull String value) {
-
+        prefHelper_.partnerParams_.addFacebookParameter(key, value);
     }
 
     /**
      * Clears all Partner Parameters
      */
     public void clearPartnerParameters() {
-
+        prefHelper_.partnerParams_.clearAllParameters();
     }
     
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -24,6 +24,8 @@ import android.os.Handler;
 import android.text.TextUtils;
 import android.view.View;
 
+import com.google.firebase.BuildConfig;
+
 import io.branch.referral.Defines.PreinstallKey;
 import io.branch.referral.ServerRequestGetLATD.BranchLastAttributedTouchDataListener;
 import org.json.JSONArray;
@@ -294,21 +296,21 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     private static Branch branchReferral_;
     
     private BranchRemoteInterface branchRemoteInterface_;
-    private PrefHelper prefHelper_;
+    private final PrefHelper prefHelper_;
     private final DeviceInfo deviceInfo_;
-    private Context context_;
+    private final Context context_;
 
-    final Object lock;
+    final Object lock = new Object();
     
-    private Semaphore serverSema_;
+    private final Semaphore serverSema_ = new Semaphore(1);
     
     private final ServerRequestQueue requestQueue_;
     
-    private int networkCount_;
+    private int networkCount_ = 0;
     
-    private boolean hasNetwork_;
+    private boolean hasNetwork_ = true;
     
-    private Map<BranchLinkData, String> linkCache_;
+    private final Map<BranchLinkData, String> linkCache_ = new HashMap<>();
     
     
     /* Set to true when application is instantiating {@BranchApp} by extending or adding manifest entry. */
@@ -362,14 +364,14 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     /* Request code  used to launch and activity on auto deep linking unless DEF_AUTO_DEEP_LINK_REQ_CODE is not specified for teh activity in manifest.*/
     private static final int DEF_AUTO_DEEP_LINK_REQ_CODE = 1501;
     
-    private final ConcurrentHashMap<String, String> instrumentationExtraData_;
+    private final ConcurrentHashMap<String, String> instrumentationExtraData_ = new ConcurrentHashMap<>();
 
     /* In order to get Google's advertising ID an AsyncTask is needed, however Fire OS does not require AsyncTask, so isGAParamsFetchInProgress_ would remain false */
     private boolean isGAParamsFetchInProgress_ = false;
 
     private static String cookieBasedMatchDomain_ = "app.link"; // Domain name used for cookie based matching.
     
-    private static int LATCH_WAIT_UNTIL = 2500; //used for getLatestReferringParamsSync and getFirstReferringParamsSync, fail after this many milliseconds
+    private static final int LATCH_WAIT_UNTIL = 2500; //used for getLatestReferringParamsSync and getFirstReferringParamsSync, fail after this many milliseconds
     
     /* List of keys whose values are collected from the Intent Extra.*/
     private static final String[] EXTERNAL_INTENT_EXTRA_KEY_WHITE_LIST = new String[]{
@@ -405,14 +407,8 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         prefHelper_ = PrefHelper.getInstance(context);
         trackingController = new TrackingController(context);
         branchRemoteInterface_ = new BranchRemoteInterfaceUrlConnection(this);
-        deviceInfo_ = DeviceInfo.initialize(context);
+        deviceInfo_ = new DeviceInfo(context);
         requestQueue_ = ServerRequestQueue.getInstance(context);
-        serverSema_ = new Semaphore(1);
-        lock = new Object();
-        networkCount_ = 0;
-        hasNetwork_ = true;
-        linkCache_ = new HashMap<>();
-        instrumentationExtraData_ = new ConcurrentHashMap<>();
         if (!trackingController.isTrackingDisabled()) { // Do not get GAID when tracking is disabled
             isGAParamsFetchInProgress_ = deviceInfo_.getSystemObserver().prefetchAdsParams(context,this);
         }
@@ -625,8 +621,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                 branchReferral_.linkCache_.clear();
                 branchReferral_.requestQueue_.clear();
             }
-            
-            branchReferral_.context_ = context.getApplicationContext();
+
             /* If {@link Application} is instantiated register for activity life cycle events. */
             if (context instanceof Application) {
                 isAutoSessionMode_ = true;
@@ -781,10 +776,6 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         // UniversalResourceAnalyser.shutDown();
 
         // Release these contexts immediately.
-        if (branchReferral_ != null) {
-            branchReferral_.context_ = null;
-            branchReferral_.currentActivityReference_ = null;
-        }
 
         // Reset all of the statics.
         branchReferral_ = null;
@@ -1632,6 +1623,23 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         latestParams = appendDebugParams(latestParams);
         getLatestReferringParamsLatch = null;
         return latestParams;
+    }
+
+    /**
+     * Add a Partner Parameter for Facebook.
+     * Once set, this parameter is attached to installs, opens and events until cleared or the app restarts.
+     *
+     * See Facebook's documentation for details on valid parameters
+     */
+    public void addFacebookPartnerParameterWithName(@NonNull String key, @NonNull String value) {
+
+    }
+
+    /**
+     * Clears all Partner Parameters
+     */
+    public void clearPartnerParameters() {
+
     }
     
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchPartnerParameters.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchPartnerParameters.java
@@ -1,0 +1,49 @@
+package io.branch.referral;
+
+import androidx.annotation.NonNull;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class BranchPartnerParameters {
+    private final ConcurrentHashMap<String, ConcurrentHashMap<String, String>> partnerParameters = new ConcurrentHashMap<>();
+
+    void clearAllParameters() {
+        partnerParameters.clear();
+    }
+
+    @NonNull ConcurrentHashMap<String, String> parametersForPartner(@NonNull String key) {
+        ConcurrentHashMap<String, String> res = partnerParameters.get(key);
+        if (res == null) {
+            res = new ConcurrentHashMap<>();
+            partnerParameters.put(key, res);
+        }
+        return res;
+    }
+
+    private void addParameterWithName(@NonNull String key, @NonNull String value, @NonNull String partnerName) {
+        parametersForPartner(partnerName).put(key, value);
+    }
+
+    void addFacebookParameter(@NonNull String key, @NonNull String value) {
+        if (isSha256Hashed(value)) {
+            addParameterWithName(key, value, "fb");
+        } else {
+            PrefHelper.Debug("Invalid partner parameter passed: " + value + ", must be hashed in sha 256.");
+        }
+    }
+
+    private boolean isSha256Hashed(@NonNull String value) {
+        return value.length() == 64 && isHexadecimal(value);
+    }
+
+    private static final Pattern HEXADECIMAL_PATTERN = Pattern.compile("\\p{XDigit}+");
+    private boolean isHexadecimal(String input) {
+        final Matcher matcher = HEXADECIMAL_PATTERN.matcher(input);
+        return matcher.matches();
+    }
+
+    ConcurrentHashMap<String, ConcurrentHashMap<String, String>> allParams() {
+        return partnerParameters;
+    }
+}

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchPartnerParameters.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchPartnerParameters.java
@@ -1,6 +1,8 @@
 package io.branch.referral;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -33,12 +35,14 @@ public class BranchPartnerParameters {
         }
     }
 
-    private boolean isSha256Hashed(@NonNull String value) {
-        return value.length() == 64 && isHexadecimal(value);
+    boolean isSha256Hashed(String value) {
+        return value != null && value.length() == 64 && isHexadecimal(value);
     }
 
     private static final Pattern HEXADECIMAL_PATTERN = Pattern.compile("\\p{XDigit}+");
-    private boolean isHexadecimal(String input) {
+    boolean isHexadecimal(String input) {
+        if (input == null) return false;
+        if (input.length() == 0) return true;
         final Matcher matcher = HEXADECIMAL_PATTERN.matcher(input);
         return matcher.matches();
     }

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -202,6 +202,7 @@ public class Defines {
         CreationTimestamp("$creation_timestamp"),
         TrackingDisabled("tracking_disabled"),
         DisableAdNetworkCallouts("disable_ad_network_callouts"),
+        PartnerData("partner_data"),
         Instant("instant");
         
         private final String key;

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -8,6 +8,8 @@ import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.webkit.WebSettings;
 
+import com.google.firebase.BuildConfig;
+
 import io.branch.referral.Defines.ModuleNameKeys;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -24,35 +26,18 @@ class DeviceInfo {
     private final SystemObserver systemObserver_;
     private final Context context_;
 
-    private static DeviceInfo thisInstance_ = null;
-
-    /**
-     * Initialize the singleton instance for deviceInfo class
-     *
-     * @return {@link DeviceInfo} global instance
-     */
-    static DeviceInfo initialize(Context context) {
-        if (thisInstance_ == null) {
-            thisInstance_ = new DeviceInfo(context);
-        }
-        return thisInstance_;
-    }
-
     /**
      * Get the singleton instance for this class
      *
      * @return {@link DeviceInfo} instance if already initialised or null
      */
     static DeviceInfo getInstance() {
-        return thisInstance_;
+        Branch b = Branch.getInstance();
+        if (b == null) return null;
+        return b.getDeviceInfo();
     }
 
-    // Package Private
-    static void shutDown() {
-        thisInstance_ = null;
-    }
-
-    private DeviceInfo(Context context) {
+    DeviceInfo(Context context) {
         context_ = context;
         systemObserver_ = new SystemObserverInstance();
     }
@@ -123,9 +108,7 @@ class DeviceInfo {
                     requestObj.put(ModuleNameKeys.imei.getKey(), imei);
                 }
             }
-        } catch (JSONException ignore) {
-
-        }
+        } catch (JSONException ignore) { }
     }
 
     /**
@@ -147,7 +130,7 @@ class DeviceInfo {
      *
      * @param requestObj JSON object for Branch server request
      */
-    void updateRequestWithV2Params(ServerRequest serverRequest, Context context, PrefHelper prefHelper, JSONObject requestObj) {
+    void updateRequestWithV2Params(ServerRequest serverRequest, PrefHelper prefHelper, JSONObject requestObj) {
         try {
             SystemObserver.UniqueId hardwareID = getHardwareID();
             if (!isNullOrEmptyOrBlank(hardwareID.getId()) && hardwareID.isReal()) {
@@ -221,14 +204,13 @@ class DeviceInfo {
             requestObj.put(Defines.Jsonkey.AppVersion.getKey(), getAppVersion());
             requestObj.put(Defines.Jsonkey.SDK.getKey(), "android");
             requestObj.put(Defines.Jsonkey.SdkVersion.getKey(), BuildConfig.VERSION_NAME);
-            requestObj.put(Defines.Jsonkey.UserAgent.getKey(), getDefaultBrowserAgent(context));
+            requestObj.put(Defines.Jsonkey.UserAgent.getKey(), getDefaultBrowserAgent(context_));
 
             if (serverRequest instanceof ServerRequestGetLATD) {
                 requestObj.put(Defines.Jsonkey.LATDAttributionWindow.getKey(),
                         ((ServerRequestGetLATD) serverRequest).getAttributionWindow());
             }
-        } catch (JSONException ignore) {
-        }
+        } catch (JSONException ignore) { }
     }
 
     private void maybeAddTuneFields(ServerRequest serverRequest, JSONObject requestObj) throws JSONException {

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -128,86 +128,86 @@ class DeviceInfo {
     /**
      * Update the given server request JSON with user data. Used for V2 events
      *
-     * @param requestObj JSON object for Branch server request
+     * @param userDataObj JSON object for Branch server request
      */
-    void updateRequestWithV2Params(ServerRequest serverRequest, PrefHelper prefHelper, JSONObject requestObj) {
+    void updateRequestWithV2Params(ServerRequest serverRequest, PrefHelper prefHelper, JSONObject userDataObj) {
         try {
             SystemObserver.UniqueId hardwareID = getHardwareID();
             if (!isNullOrEmptyOrBlank(hardwareID.getId()) && hardwareID.isReal()) {
-                requestObj.put(Defines.Jsonkey.AndroidID.getKey(), hardwareID.getId());
+                userDataObj.put(Defines.Jsonkey.AndroidID.getKey(), hardwareID.getId());
             } else {
-                requestObj.put(Defines.Jsonkey.UnidentifiedDevice.getKey(), true);
+                userDataObj.put(Defines.Jsonkey.UnidentifiedDevice.getKey(), true);
             }
 
             String brandName = SystemObserver.getPhoneBrand();
             if (!isNullOrEmptyOrBlank(brandName)) {
-                requestObj.put(Defines.Jsonkey.Brand.getKey(), brandName);
+                userDataObj.put(Defines.Jsonkey.Brand.getKey(), brandName);
             }
 
             String modelName = SystemObserver.getPhoneModel();
             if (!isNullOrEmptyOrBlank(modelName)) {
-                requestObj.put(Defines.Jsonkey.Model.getKey(), modelName);
+                userDataObj.put(Defines.Jsonkey.Model.getKey(), modelName);
             }
 
             DisplayMetrics displayMetrics = SystemObserver.getScreenDisplay(context_);
-            requestObj.put(Defines.Jsonkey.ScreenDpi.getKey(), displayMetrics.densityDpi);
-            requestObj.put(Defines.Jsonkey.ScreenHeight.getKey(), displayMetrics.heightPixels);
-            requestObj.put(Defines.Jsonkey.ScreenWidth.getKey(), displayMetrics.widthPixels);
-            requestObj.put(Defines.Jsonkey.UIMode.getKey(), SystemObserver.getUIMode(context_));
+            userDataObj.put(Defines.Jsonkey.ScreenDpi.getKey(), displayMetrics.densityDpi);
+            userDataObj.put(Defines.Jsonkey.ScreenHeight.getKey(), displayMetrics.heightPixels);
+            userDataObj.put(Defines.Jsonkey.ScreenWidth.getKey(), displayMetrics.widthPixels);
+            userDataObj.put(Defines.Jsonkey.UIMode.getKey(), SystemObserver.getUIMode(context_));
 
             String osName = SystemObserver.getOS(context_);
             if (!isNullOrEmptyOrBlank(osName)) {
-                requestObj.put(Defines.Jsonkey.OS.getKey(), osName);
+                userDataObj.put(Defines.Jsonkey.OS.getKey(), osName);
             }
 
-            requestObj.put(Defines.Jsonkey.APILevel.getKey(), SystemObserver.getAPILevel());
+            userDataObj.put(Defines.Jsonkey.APILevel.getKey(), SystemObserver.getAPILevel());
 
-            maybeAddTuneFields(serverRequest, requestObj);
+            maybeAddTuneFields(serverRequest, userDataObj);
 
             if (Branch.getPluginName() != null) {
-                requestObj.put(Defines.Jsonkey.PluginName.getKey(), Branch.getPluginName());
-                requestObj.put(Defines.Jsonkey.PluginVersion.getKey(), Branch.getPluginVersion());
+                userDataObj.put(Defines.Jsonkey.PluginName.getKey(), Branch.getPluginName());
+                userDataObj.put(Defines.Jsonkey.PluginVersion.getKey(), Branch.getPluginVersion());
             }
 
             String countryCode = SystemObserver.getISO2CountryCode();
             if (!TextUtils.isEmpty(countryCode)) {
-                requestObj.put(Defines.Jsonkey.Country.getKey(), countryCode);
+                userDataObj.put(Defines.Jsonkey.Country.getKey(), countryCode);
             }
 
             String languageCode = SystemObserver.getISO2LanguageCode();
             if (!TextUtils.isEmpty(languageCode)) {
-                requestObj.put(Defines.Jsonkey.Language.getKey(), languageCode);
+                userDataObj.put(Defines.Jsonkey.Language.getKey(), languageCode);
             }
 
             String localIpAddr = SystemObserver.getLocalIPAddress();
             if ((!TextUtils.isEmpty(localIpAddr))) {
-                requestObj.put(Defines.Jsonkey.LocalIP.getKey(), localIpAddr);
+                userDataObj.put(Defines.Jsonkey.LocalIP.getKey(), localIpAddr);
             }
 
             if (prefHelper != null) {
                 if (!isNullOrEmptyOrBlank(prefHelper.getDeviceFingerPrintID())) {
-                    requestObj.put(Defines.Jsonkey.DeviceFingerprintID.getKey(), prefHelper.getDeviceFingerPrintID());
+                    userDataObj.put(Defines.Jsonkey.DeviceFingerprintID.getKey(), prefHelper.getDeviceFingerPrintID());
                 }
                 String devId = prefHelper.getIdentity();
                 if (!isNullOrEmptyOrBlank(devId)) {
-                    requestObj.put(Defines.Jsonkey.DeveloperIdentity.getKey(), devId);
+                    userDataObj.put(Defines.Jsonkey.DeveloperIdentity.getKey(), devId);
                 }
             }
 
             if (prefHelper != null && prefHelper.shouldAddModules()) {
                 String imei = SystemObserver.getImei(context_);
                 if (!isNullOrEmptyOrBlank(imei)) {
-                    requestObj.put(ModuleNameKeys.imei.getKey(), imei);
+                    userDataObj.put(ModuleNameKeys.imei.getKey(), imei);
                 }
             }
 
-            requestObj.put(Defines.Jsonkey.AppVersion.getKey(), getAppVersion());
-            requestObj.put(Defines.Jsonkey.SDK.getKey(), "android");
-            requestObj.put(Defines.Jsonkey.SdkVersion.getKey(), BuildConfig.VERSION_NAME);
-            requestObj.put(Defines.Jsonkey.UserAgent.getKey(), getDefaultBrowserAgent(context_));
+            userDataObj.put(Defines.Jsonkey.AppVersion.getKey(), getAppVersion());
+            userDataObj.put(Defines.Jsonkey.SDK.getKey(), "android");
+            userDataObj.put(Defines.Jsonkey.SdkVersion.getKey(), BuildConfig.VERSION_NAME);
+            userDataObj.put(Defines.Jsonkey.UserAgent.getKey(), getDefaultBrowserAgent(context_));
 
             if (serverRequest instanceof ServerRequestGetLATD) {
-                requestObj.put(Defines.Jsonkey.LATDAttributionWindow.getKey(),
+                userDataObj.put(Defines.Jsonkey.LATDAttributionWindow.getKey(),
                         ((ServerRequestGetLATD) serverRequest).getAttributionWindow());
             }
         } catch (JSONException ignore) { }

--- a/Branch-SDK/src/main/java/io/branch/referral/GAdsPrefetchTask.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/GAdsPrefetchTask.java
@@ -39,7 +39,7 @@ public class GAdsPrefetchTask extends BranchAsyncTask<Void, Void, Void> {
                     Object adInfoObj = getAdInfoObject(context);
 
                     DeviceInfo di = DeviceInfo.getInstance();
-                    if (di == null) di = DeviceInfo.initialize(context);// some tests complete early and garbage collect DeviceInfo singleton before this point is reached
+                    if (di == null) di = new DeviceInfo(context);// some tests complete early and garbage collect DeviceInfo singleton before this point is reached
 
                     SystemObserver so = di.getSystemObserver();
                     if (so != null) {

--- a/Branch-SDK/src/main/java/io/branch/referral/HuaweiOAIDFetchTask.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/HuaweiOAIDFetchTask.java
@@ -85,7 +85,7 @@ public class HuaweiOAIDFetchTask extends BranchAsyncTask<Void, Void, Void> {
             Boolean HW_lat = (Boolean) HW_isLimitAdTrackingEnabled.invoke(HW_AdvertisingIdClient_Info);
 
             DeviceInfo di = DeviceInfo.getInstance();
-            if (di == null) di = DeviceInfo.initialize(context);// some tests complete early and garbage collect DeviceInfo singleton before this point is reached
+            if (di == null) di = new DeviceInfo(context);// some tests complete early and garbage collect DeviceInfo singleton before this point is reached
 
             SystemObserver so = di.getSystemObserver();
             so.setGAID(HW_id);

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -1320,17 +1320,4 @@ public class PrefHelper {
     boolean isValidBranchKey(String branchKey) {
         return branchKey != null && branchKey.startsWith(isTestModeEnabled() ? "key_test_" : "key_");
     }
-
-    void addPartnerParams(JSONObject body) throws JSONException {
-        if (body == null) return;
-        JSONObject partnerData = new JSONObject();
-        for (Map.Entry<String, ConcurrentHashMap<String, String>> e : partnerParams_.allParams().entrySet()) {
-            JSONObject individualPartnerParams = new JSONObject();
-            for (Map.Entry<String, String> p : e.getValue().entrySet()) {
-                individualPartnerParams.put(p.getKey(), p.getValue());
-            }
-            partnerData.put(e.getKey(), individualPartnerParams);
-        }
-        body.put(Defines.Jsonkey.PartnerData.getKey(), partnerData);
-    }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -17,6 +17,8 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static io.branch.referral.BranchUtil.isTestModeEnabled;
 
@@ -119,7 +121,7 @@ public class PrefHelper {
      * object for use whenever {@link SharedPreferences} values are read or written via this helper
      * class.
      */
-    private SharedPreferences appSharedPrefs_;
+    private final SharedPreferences appSharedPrefs_;
     
     /**
      * A single variable that holds a reference to an {@link Editor} object that is used by the
@@ -130,25 +132,17 @@ public class PrefHelper {
     /**
      * Arbitrary key values added to all requests.
      */
-    private final JSONObject requestMetadata;
+    private final JSONObject requestMetadata = new JSONObject();
 
     /**
      * Arbitrary key values added to Install requests.
      */
-    private final JSONObject installMetadata;
+    private final JSONObject installMetadata = new JSONObject();
 
     /**
      * Module injected key values added to all requests.
      */
-    private final JSONObject secondaryRequestMetadata;
-
-
-    //private final List<Module> factories = new ArrayList<>();
-
-    /**
-     * Branch Content discovery data
-     */
-    private static JSONObject savedAnalyticsData_;
+    private final JSONObject secondaryRequestMetadata = new JSONObject();
 
     /**
      * Branch Custom server url.  Used by clients that want to proxy all requests.
@@ -160,6 +154,10 @@ public class PrefHelper {
      */
     private static String customCDNBaseURL_ = null;
 
+    /**
+     * Branch partner parameters.
+     */
+    final BranchPartnerParameters partnerParams_ = new BranchPartnerParameters();
 
     /**
      * <p>Constructor with context passed from calling {@link Activity}.</p>
@@ -170,9 +168,6 @@ public class PrefHelper {
     private PrefHelper(Context context) {
         this.appSharedPrefs_ = context.getSharedPreferences(SHARED_PREF_FILE, Context.MODE_PRIVATE);
         this.prefsEditor_ = this.appSharedPrefs_.edit();
-        this.requestMetadata = new JSONObject();
-        this.installMetadata = new JSONObject();
-        this.secondaryRequestMetadata = new JSONObject();
     }
     
     /**
@@ -200,7 +195,6 @@ public class PrefHelper {
         // Reset all of the statics.
         enableLogging_ = false;
         Branch_Key = null;
-        savedAnalyticsData_ = null;
         prefHelper_ = null;
         customServerURL_ = null;
         customCDNBaseURL_ = null;
@@ -1325,5 +1319,18 @@ public class PrefHelper {
 
     boolean isValidBranchKey(String branchKey) {
         return branchKey != null && branchKey.startsWith(isTestModeEnabled() ? "key_test_" : "key_");
+    }
+
+    void addPartnerParams(JSONObject body) throws JSONException {
+        if (body == null) return;
+        JSONObject partnerData = new JSONObject();
+        for (Map.Entry<String, ConcurrentHashMap<String, String>> e : partnerParams_.allParams().entrySet()) {
+            JSONObject individualPartnerParams = new JSONObject();
+            for (Map.Entry<String, String> p : e.getValue().entrySet()) {
+                individualPartnerParams.put(p.getKey(), p.getValue());
+            }
+            partnerData.put(e.getKey(), individualPartnerParams);
+        }
+        body.put(Defines.Jsonkey.PartnerData.getKey(), partnerData);
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -157,7 +157,7 @@ public class PrefHelper {
     /**
      * Branch partner parameters.
      */
-    final BranchPartnerParameters partnerParams_ = new BranchPartnerParameters();
+    public final BranchPartnerParameters partnerParams_ = new BranchPartnerParameters();
 
     /**
      * <p>Constructor with context passed from calling {@link Activity}.</p>

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -13,6 +13,7 @@ import org.json.JSONObject;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -185,7 +186,7 @@ public abstract class ServerRequest {
     protected void setPost(JSONObject post) throws JSONException {
         params_ = post;
 
-        prefHelper_.addPartnerParams(params_);
+        addPartnerParams(params_, prefHelper_.partnerParams_);
         if (getBranchRemoteAPIVersion() == BRANCH_API_VERSION.V1) {
             DeviceInfo.getInstance().updateRequestWithV1Params(this, params_);
         } else {
@@ -671,5 +672,18 @@ public abstract class ServerRequest {
             if (item.equals(requestPath_)) return true;
         }
         return false;
+    }
+
+    static void addPartnerParams(JSONObject body, BranchPartnerParameters partnerParams) throws JSONException {
+        if (body == null) return;
+        JSONObject partnerData = new JSONObject();
+        for (Map.Entry<String, ConcurrentHashMap<String, String>> e : partnerParams.allParams().entrySet()) {
+            JSONObject individualPartnerParams = new JSONObject();
+            for (Map.Entry<String, String> p : e.getValue().entrySet()) {
+                individualPartnerParams.put(p.getKey(), p.getValue());
+            }
+            partnerData.put(e.getKey(), individualPartnerParams);
+        }
+        body.put(Defines.Jsonkey.PartnerData.getKey(), partnerData);
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -33,7 +33,7 @@ public abstract class ServerRequest {
     private static final String POST_PATH_KEY = "REQ_POST_PATH";
 
     private JSONObject params_;
-    private String requestPath_;
+    private final String requestPath_;
     protected final PrefHelper prefHelper_;
     private long queueWaitTime_ = 0;
     private final Context context_;
@@ -185,6 +185,7 @@ public abstract class ServerRequest {
     protected void setPost(JSONObject post) throws JSONException {
         params_ = post;
 
+        prefHelper_.addPartnerParams(params_);
         if (getBranchRemoteAPIVersion() == BRANCH_API_VERSION.V1) {
             DeviceInfo.getInstance().updateRequestWithV1Params(this, params_);
         } else {

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -191,7 +191,7 @@ public abstract class ServerRequest {
             try {
                 JSONObject userDataObj = new JSONObject();
                 params_.put(Defines.Jsonkey.UserData.getKey(), userDataObj);
-                DeviceInfo.getInstance().updateRequestWithV2Params(this, context_, prefHelper_, userDataObj);
+                DeviceInfo.getInstance().updateRequestWithV2Params(this, prefHelper_, userDataObj);
             } catch (JSONException ignored) {}
         }
     }

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -186,7 +186,6 @@ public abstract class ServerRequest {
     protected void setPost(JSONObject post) throws JSONException {
         params_ = post;
 
-        addPartnerParams(params_, prefHelper_.partnerParams_);
         if (getBranchRemoteAPIVersion() == BRANCH_API_VERSION.V1) {
             DeviceInfo.getInstance().updateRequestWithV1Params(this, params_);
         } else {
@@ -674,7 +673,7 @@ public abstract class ServerRequest {
         return false;
     }
 
-    static void addPartnerParams(JSONObject body, BranchPartnerParameters partnerParams) throws JSONException {
+    protected static void addPartnerParams(JSONObject body, BranchPartnerParameters partnerParams) throws JSONException {
         if (body == null) return;
         JSONObject partnerData = new JSONObject();
         for (Map.Entry<String, ConcurrentHashMap<String, String>> e : partnerParams.allParams().entrySet()) {

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -39,6 +39,9 @@ abstract class ServerRequestInitSession extends ServerRequest {
     @Override
     protected void setPost(JSONObject post) throws JSONException {
         super.setPost(post);
+
+        addPartnerParams(post, prefHelper_.partnerParams_);
+
         String appVersion = DeviceInfo.getInstance().getAppVersion();
         if (!DeviceInfo.isNullOrEmptyOrBlank(appVersion)) {
             post.put(Defines.Jsonkey.AppVersion.getKey(), appVersion);

--- a/Branch-SDK/src/main/java/io/branch/referral/util/BranchEvent.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/util/BranchEvent.java
@@ -291,6 +291,12 @@ public class BranchEvent {
         }
 
         @Override
+        protected void setPost(JSONObject post) throws JSONException {
+            super.setPost(post);
+            addPartnerParams(post, prefHelper_.partnerParams_);
+        }
+
+        @Override
         public boolean handleErrors(Context context) {
             return false;
         }

--- a/Branch-SDK/src/test/java/android/text/TextUtils.java
+++ b/Branch-SDK/src/test/java/android/text/TextUtils.java
@@ -1,0 +1,11 @@
+package android.text;
+
+/**
+ * All android methods don't exist when running unit tests, so we have to manually provide the
+ * implementation ourselves.
+ */
+public class TextUtils {
+    public static boolean isEmpty(CharSequence str) {
+        return str == null || str.length() == 0;
+    }
+}

--- a/Branch-SDK/src/test/java/io/branch/referral/BranchPartnerParametersTest.java
+++ b/Branch-SDK/src/test/java/io/branch/referral/BranchPartnerParametersTest.java
@@ -1,0 +1,181 @@
+package io.branch.referral;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import static io.branch.referral.Defines.Jsonkey.PartnerData;
+
+@RunWith(JUnit4.class)
+public class BranchPartnerParametersTest {
+    
+    BranchPartnerParameters partnerParams;
+
+    @Before
+    public void setUp() {
+        partnerParams = new BranchPartnerParameters();
+    }
+
+    @After
+    public void tearDown() {
+        partnerParams.clearAllParameters();;
+    }
+
+    @Test public void testStringHexNull() {
+        Assert.assertFalse(partnerParams.isHexadecimal(null));
+    }
+
+    @Test public void testStringHexEmpty() {
+        Assert.assertTrue(partnerParams.isHexadecimal(""));
+    }
+
+    @Test public void testStringHexDash() {
+        Assert.assertFalse(partnerParams.isHexadecimal("-1"));
+    }
+
+    @Test public void testStringHexDecimal() {
+        Assert.assertFalse(partnerParams.isHexadecimal("1.0"));
+    }
+
+    @Test public void testStringHexFraction() {
+        Assert.assertFalse(partnerParams.isHexadecimal("2/4"));
+    }
+    
+    @Test public void testStringHexAt() {
+        Assert.assertFalse(partnerParams.isHexadecimal("test@12345"));
+    }
+
+    @Test public void testStringHexUpperG() {
+        Assert.assertFalse(partnerParams.isHexadecimal("0123456789ABCDEFG"));
+    }
+
+    @Test public void testStringHexLowerG() {
+        Assert.assertFalse(partnerParams.isHexadecimal("0123456789abcdefg"));
+    }
+
+    @Test public void testStringHexUpperCase() {
+        Assert.assertTrue(partnerParams.isHexadecimal("0123456789ABCDEF"));
+    }
+
+    @Test public void testStringHexLowerCase() {
+        Assert.assertTrue(partnerParams.isHexadecimal("0123456789abcdef"));
+    }
+
+    @Test public void testSha256HashSanityCheckValueNull() {
+        Assert.assertFalse(partnerParams.isSha256Hashed(null));
+    }
+
+    @Test public void testSha256HashSanityCheckValueEmpty() {
+        Assert.assertFalse(partnerParams.isSha256Hashed(""));
+    }
+
+    @Test public void testSha256HashSanityCheckValueTooShort() {
+        // 63 char string
+        Assert.assertFalse(partnerParams.isSha256Hashed("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcde"));
+    }
+
+    @Test public void testSha256HashSanityCheckValueTooLong() {
+        // 65 char string
+        Assert.assertFalse(partnerParams.isSha256Hashed("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdeff"));
+    }
+
+    @Test public void testSha256HashSanityCheckValueLowerCase() {
+        // 64 char string
+        Assert.assertTrue(partnerParams.isSha256Hashed("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"));
+    }
+
+    @Test public void testSha256HashSanityCheckValueUpperCase() {
+        // 64 char string
+        Assert.assertTrue(partnerParams.isSha256Hashed("0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"));
+    }
+
+    @Test public void testSha256HashSanityCheckValueMixedCase() {
+        // 64 char string
+        Assert.assertTrue(partnerParams.isSha256Hashed("0123456789ABCDEF0123456789ABCDEF1234567890abcdef1234567890abcdef"));
+    }
+
+    @Test public void testJsonEmpty() throws JSONException {
+        JSONObject body = new JSONObject();
+        ServerRequest.addPartnerParams(body, partnerParams);
+
+        JSONAssert.assertEquals("{}", body.getJSONObject(PartnerData.getKey()).toString(), JSONCompareMode.LENIENT);
+    }
+
+    @Test public void testJsonFBParameterEmpty() throws JSONException {
+        partnerParams.addFacebookParameter("em", "");
+        JSONObject body = new JSONObject();
+        ServerRequest.addPartnerParams(body, partnerParams);
+
+        JSONAssert.assertEquals("{}", body.getJSONObject(PartnerData.getKey()).toString(), JSONCompareMode.LENIENT);
+    }
+
+    @Test public void testJsonFBParameterShort() throws JSONException {
+        partnerParams.addFacebookParameter("em", "0123456789ABCDEF0123456789ABCDEF1234567890abcdef1234567890abcde");
+        JSONObject body = new JSONObject();
+        ServerRequest.addPartnerParams(body, partnerParams);
+
+        JSONAssert.assertEquals("{}", body.getJSONObject(PartnerData.getKey()).toString(), JSONCompareMode.LENIENT);
+    }
+
+    @Test public void testJsonFBParameterPhoneNumberIsIgnored() throws JSONException {
+        partnerParams.addFacebookParameter("ph", "1-555-555-5555");
+        JSONObject body = new JSONObject();
+        ServerRequest.addPartnerParams(body, partnerParams);
+
+        JSONAssert.assertEquals("{}", body.getJSONObject(PartnerData.getKey()).toString(), JSONCompareMode.LENIENT);
+    }
+
+    @Test public void testJsonFBParameterEmailIsIgnored() throws JSONException {
+        partnerParams.addFacebookParameter("em", "test@branch.io");
+        JSONObject body = new JSONObject();
+        ServerRequest.addPartnerParams(body, partnerParams);
+
+        JSONAssert.assertEquals("{}", body.getJSONObject(PartnerData.getKey()).toString(), JSONCompareMode.LENIENT);
+    }
+
+    @Test public void testJsonFBParameterBase64EncodedIsIgnored() throws JSONException {
+        partnerParams.addFacebookParameter("em", "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4");
+        JSONObject body = new JSONObject();
+        ServerRequest.addPartnerParams(body, partnerParams);
+
+        JSONAssert.assertEquals("{}", body.getJSONObject(PartnerData.getKey()).toString(), JSONCompareMode.LENIENT);
+    }
+
+    @Test public void testJsonFBParameterHashedValue() throws JSONException {
+        partnerParams.addFacebookParameter("em", "11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088");
+        JSONObject body = new JSONObject();
+        ServerRequest.addPartnerParams(body, partnerParams);
+
+        JSONAssert.assertEquals(
+                "{\"fb\":{\"em\":\"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088\"}}",
+                body.getJSONObject(PartnerData.getKey()).toString(), JSONCompareMode.LENIENT);
+    }
+
+    @Test public void testJsonFBParameterExample() throws JSONException {
+        partnerParams.addFacebookParameter("em", "11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088");
+        partnerParams.addFacebookParameter("ph", "b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b");
+        JSONObject body = new JSONObject();
+        ServerRequest.addPartnerParams(body, partnerParams);
+
+        JSONAssert.assertEquals(
+                "{\"fb\":{\"ph\":\"b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b\",\"em\":\"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088\"}}",
+                body.getJSONObject(PartnerData.getKey()).toString(), JSONCompareMode.LENIENT);
+    }
+
+    @Test public void testJsonFBParameterClear() throws JSONException {
+        partnerParams.addFacebookParameter("em", "11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088");
+        partnerParams.addFacebookParameter("em", "b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b");
+        partnerParams.clearAllParameters();
+        JSONObject body = new JSONObject();
+        ServerRequest.addPartnerParams(body, partnerParams);
+
+        JSONAssert.assertEquals("{}", body.getJSONObject(PartnerData.getKey()).toString(), JSONCompareMode.LENIENT);
+    }
+}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,9 +1,13 @@
 # Branch Android SDK change log
+- v5.0.5
+  * _*Master Release*_ - January 21, 2020
+  * Add API to pass hashed partner parameters
+  
 - v5.0.4
-  * _*Master Release*_ - November 19, 2020
+  * _*Master Release*_ - December 9, 2020
   * Reduce calls to v1/close
   * Fix validator errors
-  * Fix setNetworkTimeoutApi(...) API
+  * Fix setNetworkTimeout(...) API
 
 - v5.0.3
   * _*Master Release*_ - August 10, 2020

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.0.4
-VERSION_CODE=050004
+VERSION_NAME=5.0.5
+VERSION_CODE=050005
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.


### PR DESCRIPTION
## Reference
https://branch.atlassian.net/browse/CORE-1588.

## Description
Tech spec https://docs.google.com/document/d/1IF6JN4NZenVdhTqSGwUe04yqp0GwmNpkoyOR5dHlLa8/edit#heading=h.16u1uxt2gltj
Android ticket is linked above but a little sparse, iOS ticket has a little more context https://branch.atlassian.net/browse/CORE-1521

Basically. I added two APIs
- addFacebookPartnerParameterWithName(@NonNull String key, @NonNull String value)
- clearPartnerParameters()
the APIs will attach the following blob to the top lelevel of the json response to all install/open and custom/standard event requests

```
  "partner_data": {
    "fb": {
      "em": "194b86d986ad041666822dad7602f1a7bac1d9e286273e86141666ffb4b1909b",
      "ph": "7cd2dfb0b893767d1b0a4cacd831f6f9cf0ace6b1fbfc616c313c672d08f6196"
    }
  }
```


## Testing Instructions
Run the testbed app, engage a bunch of APIs and ensure that only open/install/events contain the above blob. 

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [x] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [x] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [x] Mission critical pieces are documented in code and out of code as needed.
- [x] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
