### PR TITLE
Inteng 11862 no callback on timeout

### DIFF
--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchTest.java
@@ -110,7 +110,7 @@ abstract public class BranchTest extends BranchTestRequestUtil {
         }
         // activityScenario.moveToState is async, so we stop the test's thread for Activity to complete the
         // lifecycle transitions (and session initialization)
-        Thread.sleep(TEST_REQUEST_TIMEOUT * 3);
+        Thread.sleep(4000);
         Log.d(TAG, "initSessionResumeActivity completed");
     }
 

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/ServerRequestTests.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/ServerRequestTests.java
@@ -1,0 +1,138 @@
+package io.branch.referral;
+
+import android.os.Handler;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Calendar;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import io.branch.indexing.BranchUniversalObject;
+import io.branch.referral.mock.MockActivity;
+import io.branch.referral.util.BranchCPID;
+import io.branch.referral.util.ContentMetadata;
+import io.branch.referral.util.LinkProperties;
+
+@RunWith(AndroidJUnit4.class)
+public class ServerRequestTests extends BranchTest{
+
+    @Before
+    public void setUp() {
+        super.setUp();
+        initBranchInstance();
+    }
+    @After
+    public void tearDown() throws InterruptedException {
+        branch.setNetworkTimeout(PrefHelper.TIMEOUT);
+        super.tearDown();
+    }
+
+    @Test
+    public void testTimedOutInitSessionCallbackInvoked() throws InterruptedException {
+        branch.setNetworkTimeout(10);// forces timeouts
+        initSessionResumeActivity();
+        activityScenario.onActivity(new ActivityScenario.ActivityAction<MockActivity>() {
+            @Override
+            public void perform(final MockActivity activity) {
+                new Handler().postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        Assert.assertTrue(activity.initSessionCallbackInvoked);
+                    }
+                }, 200);
+            }
+        });
+    }
+
+    @Test
+    public void testTimedOutCrossPlatformIdsCallbackInvoked() throws InterruptedException {
+        initSessionResumeActivity();
+        branch.setNetworkTimeout(10);// forces timeouts
+
+        final CountDownLatch lock = new CountDownLatch(1);
+        Branch.getInstance().getCrossPlatformIds(new ServerRequestGetCPID.BranchCrossPlatformIdListener() {
+            @Override
+            public void onDataFetched(BranchCPID branchCPID, BranchError error) {
+                lock.countDown();
+                Assert.assertEquals(BranchError.ERR_BRANCH_REQ_TIMED_OUT, error.getErrorCode());
+            }
+        });
+        Assert.assertTrue(lock.getCount() != 0 || lock.await(TEST_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testTimedOutLastAttributedTouchDataCallbackInvoked() throws InterruptedException {
+        initSessionResumeActivity();
+        branch.setNetworkTimeout(10);// forces timeouts
+
+        final CountDownLatch lock1 = new CountDownLatch(1);
+        Branch.getInstance().getLastAttributedTouchData(new ServerRequestGetLATD.BranchLastAttributedTouchDataListener() {
+            @Override
+            public void onDataFetched(JSONObject jsonObject, BranchError error) {
+                Assert.assertEquals(BranchError.ERR_BRANCH_REQ_TIMED_OUT, error.getErrorCode());
+                lock1.countDown();
+            }
+        });
+
+        Assert.assertTrue(lock1.getCount() != 0 || lock1.await(TEST_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testTimedOutCreditHistoryCallbackInvoked() throws InterruptedException {
+        initSessionResumeActivity();
+        branch.setNetworkTimeout(10);// forces timeouts
+
+        final CountDownLatch lock2 = new CountDownLatch(1);
+        Branch.getInstance().getCreditHistory(new Branch.BranchListResponseListener() {
+            @Override
+            public void onReceivingResponse(JSONArray list, BranchError error) {
+                Assert.assertEquals(BranchError.ERR_BRANCH_REQ_TIMED_OUT, error.getErrorCode());
+                lock2.countDown();
+            }
+        });
+        Assert.assertTrue(lock2.getCount() != 0 || lock2.await(TEST_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testTimedOutGenerateShortUrlCallbackInvoked() throws InterruptedException {
+        initSessionResumeActivity();
+        branch.setNetworkTimeout(10);// forces timeouts
+
+        final CountDownLatch lock3 = new CountDownLatch(1);
+        BranchUniversalObject buo = new BranchUniversalObject()
+                .setCanonicalIdentifier("content/12345")
+                .setTitle("My Content Title")
+                .setContentDescription("My Content Description")
+                .setContentImageUrl("https://lorempixel.com/400/400")
+                .setContentIndexingMode(BranchUniversalObject.CONTENT_INDEX_MODE.PUBLIC)
+                .setLocalIndexMode(BranchUniversalObject.CONTENT_INDEX_MODE.PUBLIC)
+                .setContentMetadata(new ContentMetadata().addCustomMetadata("key1", "value1"));
+        LinkProperties linkProperties = new LinkProperties()
+                .setChannel("facebook")
+                .setFeature("sharing")
+                .setCampaign("content 123 launch")
+                .setStage("new user")
+                .addControlParameter("$web_only", "true")
+                .addControlParameter("$desktop_url", "http://example.com/home")
+                .addControlParameter("custom", "data")
+                .addControlParameter("custom_random", java.lang.Long.toString(Calendar.getInstance().getTimeInMillis()));
+        buo.generateShortUrl(getTestContext(), linkProperties, new Branch.BranchLinkCreateListener() {
+            @Override
+            public void onLinkCreate(String url, BranchError error) {
+                Assert.assertEquals(BranchError.ERR_BRANCH_REQ_TIMED_OUT, error.getErrorCode());
+                lock3.countDown();
+            }
+        });
+        Assert.assertTrue(lock3.getCount() != 0 || lock3.await(TEST_REQUEST_TIMEOUT, TimeUnit.MILLISECONDS));
+    }
+}

--- a/Branch-SDK/src/main/java/io/branch/indexing/BranchUniversalObject.java
+++ b/Branch-SDK/src/main/java/io/branch/indexing/BranchUniversalObject.java
@@ -7,6 +7,7 @@ import android.os.Parcelable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.text.TextUtils;
+import android.webkit.TracingController;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -24,6 +25,7 @@ import io.branch.referral.BranchShortLinkBuilder;
 import io.branch.referral.BranchUtil;
 import io.branch.referral.Defines;
 import io.branch.referral.PrefHelper;
+import io.branch.referral.TrackingController;
 import io.branch.referral.util.BRANCH_STANDARD_EVENT;
 import io.branch.referral.util.BranchEvent;
 import io.branch.referral.util.ContentMetadata;
@@ -620,7 +622,7 @@ public class BranchUniversalObject implements Parcelable {
      * @param callback       An instance of {@link io.branch.referral.Branch.BranchLinkCreateListener} to receive the results
      */
     public void generateShortUrl(@NonNull Context context, @NonNull LinkProperties linkProperties, @Nullable Branch.BranchLinkCreateListener callback) {
-        if (Branch.getInstance().isTrackingDisabled()) {
+        if (TrackingController.isTrackingDisabled(context) && callback != null) {
             callback.onLinkCreate(getLinkBuilder(context, linkProperties).getShortUrl(), null);
         } else {
             getLinkBuilder(context, linkProperties).generateShortUrl(callback);

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1667,12 +1667,12 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                         if (!(req instanceof ServerRequestRegisterInstall) && !hasUser()) {
                             PrefHelper.Debug("Branch Error: User session has not been initialized!");
                             networkCount_ = 0;
-                            handleFailure(requestQueue_.getSize() - 1, BranchError.ERR_NO_SESSION);
+                            handleFailure(req, BranchError.ERR_NO_SESSION);
                         }
                         // Determine if a session is needed to execute (SDK-271)
                         else if (requestNeedsSession(req) && !isSessionAvailableForRequest()) {
                             networkCount_ = 0;
-                            handleFailure(requestQueue_.getSize() - 1, BranchError.ERR_NO_SESSION);
+                            handleFailure(req, BranchError.ERR_NO_SESSION);
                         } else {
                             executeTimedBranchPostTask(req, prefHelper_.getTimeout());
                         }
@@ -1721,19 +1721,8 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         return (hasSession() && hasDeviceFingerPrint());
     }
     
-    private void handleFailure(int index, int statusCode) {
-        ServerRequest req;
-        if (index >= requestQueue_.getSize()) {
-            req = requestQueue_.peekAt(requestQueue_.getSize() - 1);
-        } else {
-            req = requestQueue_.peekAt(index);
-        }
-        handleFailure(req, statusCode);
-    }
-    
     private void handleFailure(final ServerRequest req, int statusCode) {
-        if (req == null)
-            return;
+        if (req == null) return;
         req.handleFailure(statusCode, "");
     }
     
@@ -2318,7 +2307,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                                 ((ServerRequestCreateUrl) thisReq_).handleDuplicateURLError();
                             } else {
                                 PrefHelper.LogAlways("Branch API Error: Conflicting resource error code from API");
-                                handleFailure(0, status);
+                                handleFailure(thisReq_, status);
                             }
                         }
                         //On Network error or Branch is down fail all the pending requests in the queue except

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -54,7 +54,7 @@ public class PrefHelper {
      */
     private static final int MAX_RETRIES = 3; // Default retry count is 3
 
-    private static final int TIMEOUT = 5500; // Default timeout id 5.5 sec
+    static final int TIMEOUT = 5500; // Default timeout id 5.5 sec
 
     private static final String SHARED_PREF_FILE = "branch_referral_shared_pref";
     

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestGetCPID.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestGetCPID.java
@@ -51,9 +51,7 @@ public class ServerRequestGetCPID extends ServerRequest {
             return;
         }
 
-        callback.onDataFetched(null,
-                new BranchError("Failed to get the Cross Platform IDs",
-                        BranchError.ERR_BRANCH_INVALID_REQUEST));
+        callback.onDataFetched(null, new BranchError("Failed to get the Cross Platform IDs", statusCode));
     }
 
     @Override

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestGetLATD.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestGetLATD.java
@@ -55,8 +55,7 @@ public class ServerRequestGetLATD extends ServerRequest {
     @Override
     public void handleFailure(int statusCode, String causeMsg) {
         if (callback != null) {
-            callback.onDataFetched(null, new BranchError("Failed to get last attributed touch data",
-                            BranchError.ERR_BRANCH_INVALID_REQUEST));
+            callback.onDataFetched(null, new BranchError("Failed to get last attributed touch data", statusCode));
         }
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
@@ -2,6 +2,8 @@ package io.branch.referral;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+
 /**
  * Created by sojanpr on 3/7/18.
  * <p>
@@ -11,7 +13,7 @@ import android.content.Context;
  * </p>
  */
 
-class TrackingController {
+public class TrackingController {
     /* Flag for controlling the user data tracking state. If disabled SDK will not track any user data or state. SDK will not send any network calls when tracking is disabled*/
     private boolean trackingDisabled = true;
     
@@ -33,6 +35,10 @@ class TrackingController {
     
     boolean isTrackingDisabled() {
         return trackingDisabled;
+    }
+
+    public static boolean isTrackingDisabled(@NonNull Context context) {
+        return PrefHelper.getInstance(context).getBool(PrefHelper.KEY_TRACKING_STATE);
     }
     
     void updateTrackingState(Context context) {


### PR DESCRIPTION
## Reference
Real title: **Timed out requests are cancelled without proper cleanup that would invoke callbacks with an error** 

INTENG-11862 -- Android SDK - Unable to generate deep link intermittently.
https://branch.atlassian.net/browse/INTENG-11862

## Description
Somehow wasn't enough 
```
postTask.thisReq_.handleFailure(ERR_BRANCH_REQ_TIMED_OUT,  "Timed out: " + postTask.thisReq_.getRequestUrl());
```

## Testing Instructions
Use `v5.0.4`, place a breakpoint in the callback of create url api. See how it does get invoked under normal conditions. Now set a ridiculously low network timeout in millis, like 10, right after `getAutoInstance` in the `Application` class (i.e. `setNetworkTimeout(...)`) and see that breakpoint/callback never get invoked.

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
MEDIUM

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
