### PR TITLE
reset Session Params on closing session even when v1/close is not called

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1006,9 +1006,11 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                     requestQueue_.dequeue();
                 }
             } else {
-                if (!requestQueue_.containsClose() && closeRequestNeeded) {
-                    ServerRequest req = new ServerRequestRegisterClose(context_);
+                ServerRequest req = new ServerRequestRegisterClose(context_);
+                if (closeRequestNeeded) {
                     handleNewRequest(req);
+                } else {
+                    req.onRequestSucceeded(null, null);
                 }
             }
             setInitState(SESSION_STATE.UNINITIALISED);

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestQueue.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestQueue.java
@@ -280,25 +280,6 @@ class ServerRequestQueue {
     }
     
     /**
-     * <p>Determines whether the queue contains a session/app close request.</p>
-     *
-     * @return A {@link Boolean} value indicating whether or not the queue contains a
-     * session close request. <i>True</i> if the queue contains a close request,
-     * <i>False</i> if not.
-     */
-    boolean containsClose() {
-        synchronized (reqQueueLockObject) {
-            for (ServerRequest req : queue) {
-                if (req != null &&
-                        req.getRequestPath().equals(Defines.RequestPath.RegisterClose.getPath())) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-    
-    /**
      * <p>Determines whether the queue contains an install/register request.</p>
      *
      * @return A {@link Boolean} value indicating whether or not the queue contains an


### PR DESCRIPTION
## Reference
CORE-1663 -- Fix getLatestReferringParams
https://branch.atlassian.net/browse/CORE-1663

## Description
since 5.0.4 we only call v1/close endpoint optionally and not by default, however the success network request callback needs to be invoked in order to reset that sessions referring params.

https://app.getguru.com/card/ce6rp57i/When-implementing-Branch-initSession-in-a-nonLauncher-Activity-what-is-the-recommended-way-to-handle-retrieving-deeplink-params-for-a-Deferred-Deeplinked-user

## Testing Instructions
call getLatestReferringParams before session initialization and retrieve the last session's params, in this PR you won't be able to.

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
