### PR TITLE
CORE-1694 replace all catch Throwable with catch Exception

### DIFF
--- a/Branch-SDK-TestBed/src/androidTest/java/io/branch/branchandroiddemo/BUOTestRoutines.java
+++ b/Branch-SDK-TestBed/src/androidTest/java/io/branch/branchandroiddemo/BUOTestRoutines.java
@@ -179,7 +179,7 @@ public class BUOTestRoutines {
                         respObject = new JSONObject(rd.readLine());
                     }
                 }
-            } catch (Throwable ignore) {
+            } catch (Exception ignore) {
             } finally {
                 if (connection != null) {
                     connection.disconnect();

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchCPIDTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchCPIDTest.java
@@ -16,7 +16,7 @@ import org.junit.runner.RunWith;
 public class BranchCPIDTest extends BranchTest {
 
     @Test
-    public void testGetCPID() throws Throwable{
+    public void testGetCPID() {
         initBranchInstance();
         branch.getCrossPlatformIds(null);
 
@@ -29,7 +29,7 @@ public class BranchCPIDTest extends BranchTest {
     }
 
     @Test
-    public void testGetLATD() throws Throwable{
+    public void testGetLATD() {
         initBranchInstance();
         branch.getLastAttributedTouchData(null);
 
@@ -42,7 +42,7 @@ public class BranchCPIDTest extends BranchTest {
     }
 
     @Test
-    public void testGetLATDAttributionWindowDefault() throws Throwable {
+    public void testGetLATDAttributionWindowDefault() {
         initBranchInstance();
         PrefHelper prefHelper = PrefHelper.getInstance(getTestContext());
 
@@ -57,7 +57,7 @@ public class BranchCPIDTest extends BranchTest {
     }
 
     @Test
-    public void testGetLATDAttributionWindowSetting() throws Throwable {
+    public void testGetLATDAttributionWindowSetting() {
         //setup
         initBranchInstance();
         PrefHelper prefHelper = PrefHelper.getInstance(getTestContext());

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchEventTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchEventTest.java
@@ -16,7 +16,7 @@ import io.branch.referral.util.CurrencyType;
 public class BranchEventTest extends BranchTest {
 
     @Test
-    public void testStandardEvent() throws Throwable {
+    public void testStandardEvent() throws Exception {
         BRANCH_STANDARD_EVENT eventType = BRANCH_STANDARD_EVENT.PURCHASE;
         Assert.assertEquals("PURCHASE", eventType.getName());
 
@@ -25,13 +25,13 @@ public class BranchEventTest extends BranchTest {
     }
 
     @Test
-    public void testCustomEvent() throws Throwable {
+    public void testCustomEvent() throws Exception {
         BranchEvent branchEvent = new BranchEvent("CustomEvent");
         Assert.assertFalse(isStandardEvent(branchEvent));
     }
 
     @Test
-    public void testCustomEventWithStandardName() throws Throwable {
+    public void testCustomEventWithStandardName() throws Exception {
         // We assert that creating an event using a String *will be considered a custom event*
         BRANCH_STANDARD_EVENT eventType = BRANCH_STANDARD_EVENT.PURCHASE;
         BranchEvent branchEvent = new BranchEvent(eventType.getName());
@@ -39,7 +39,7 @@ public class BranchEventTest extends BranchTest {
     }
 
     @Test
-    public void testAllStandardEvents() throws Throwable {
+    public void testAllStandardEvents() throws Exception {
         for (BRANCH_STANDARD_EVENT eventType : BRANCH_STANDARD_EVENT.values()) {
             BranchEvent branchEvent = new BranchEvent(eventType);
             Assert.assertTrue(isStandardEvent(branchEvent));
@@ -73,7 +73,7 @@ public class BranchEventTest extends BranchTest {
     }
 
     @Test
-    public void testLogEvent() throws InterruptedException {
+    public void testLogEvent() {
         initBranchInstance(TEST_KEY);
 
         new BranchEvent(BRANCH_STANDARD_EVENT.PURCHASE).logEvent(getTestContext());
@@ -93,7 +93,7 @@ public class BranchEventTest extends BranchTest {
     }
 
     @Test
-    public void testLogEvent_queue() throws Throwable {
+    public void testLogEvent_queue() throws Exception {
         initBranchInstance(TEST_KEY);
 
         ServerRequest serverRequest = logEvent(getTestContext(), new BranchEvent(BRANCH_STANDARD_EVENT.PURCHASE));
@@ -103,7 +103,7 @@ public class BranchEventTest extends BranchTest {
     }
 
     @Test
-    public void testAdType() throws Throwable {
+    public void testAdType() throws Exception {
         initBranchInstance(TEST_KEY);
 
         BranchEvent branchEvent = new BranchEvent(BRANCH_STANDARD_EVENT.VIEW_AD);

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchGAIDTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchGAIDTest.java
@@ -35,7 +35,7 @@ public class BranchGAIDTest extends BranchTest {
     private static final String TAG = "BranchGAIDTest";
 
     @Test
-    public void testInitSession_hasGAIDv1() throws Throwable {
+    public void testInitSession_hasGAIDv1() {
         initBranchInstance();
         final ServerRequestQueue queue = ServerRequestQueue.getInstance(getTestContext());
         initSessionResumeActivity(new Runnable() {
@@ -55,7 +55,7 @@ public class BranchGAIDTest extends BranchTest {
     }
 
     @Test
-    public void testActionCompleted_hasGAIDv1() throws InterruptedException, JSONException {
+    public void testActionCompleted_hasGAIDv1() {
         initBranchInstance();
         initSessionResumeActivity(new Runnable() {
             @Override
@@ -87,7 +87,7 @@ public class BranchGAIDTest extends BranchTest {
     }
 
     @Test
-    public void testCommerceEvent_hasGAIDv1() throws InterruptedException {
+    public void testCommerceEvent_hasGAIDv1() {
         initBranchInstance(TEST_KEY);
         initSessionResumeActivity(new Runnable() {
             @Override
@@ -117,12 +117,12 @@ public class BranchGAIDTest extends BranchTest {
     }
 
     @Test
-    public void testLoadRewards_hasGAIDv1() throws Throwable {
+    public void testLoadRewards_hasGAIDv1() {
         // TODO:  loadRewards() puts an empty JSON object on the queue
     }
 
     @Test
-    public void testRedeemAwards_hasGAIDv1() throws Throwable {
+    public void testRedeemAwards_hasGAIDv1() {
         initBranchInstance(TEST_KEY);
         initSessionResumeActivity(new Runnable() {
             @Override
@@ -150,7 +150,7 @@ public class BranchGAIDTest extends BranchTest {
     }
 
     @Test
-    public void testCreditHistory_hasGAIDv1() throws Throwable {
+    public void testCreditHistory_hasGAIDv1() {
         initBranchInstance(TEST_KEY);
         initSessionResumeActivity(new Runnable() {
             @Override
@@ -174,7 +174,7 @@ public class BranchGAIDTest extends BranchTest {
     }
 
     @Test
-    public void testIdentity_hasGAIDv1() throws Throwable {
+    public void testIdentity_hasGAIDv1() {
         initBranchInstance(TEST_KEY);
         initSessionResumeActivity(new Runnable() {
             @Override
@@ -198,23 +198,23 @@ public class BranchGAIDTest extends BranchTest {
     }
 
     @Test
-    public void testLogout_hasGAIDv1() throws Throwable {
+    public void testLogout_hasGAIDv1() {
         // TODO: initSession needed first
     }
 
     @Test
-    public void testPing_hasGAIDv1() throws Throwable {
+    public void testPing_hasGAIDv1() {
         // TODO: Ping does not get enqueued
     }
 
     @Test
-    public void testClose_hasGAIDv1() throws Throwable {
+    public void testClose_hasGAIDv1() {
         // TODO: Close happens in a Session context
         // Note that closeSessionInternal cannot be run on a non-UI thread
     }
 
     @Test
-    public void testStandardEvent_hasGAIDv2() throws Throwable {
+    public void testStandardEvent_hasGAIDv2() {
         initBranchInstance(TEST_KEY);
         initSessionResumeActivity(new Runnable() {
             @Override

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchModuleInjectionTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchModuleInjectionTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 public class BranchModuleInjectionTest extends BranchTest {
 
     @Test
-    public void testResultSuccess() throws Throwable {
+    public void testResultSuccess() throws Exception {
         initBranchInstance();
         JSONObject branchFileJson = new JSONObject("{\"imei\":\"1234567890\"}");
         branch.addModule(branchFileJson);
@@ -35,7 +35,7 @@ public class BranchModuleInjectionTest extends BranchTest {
     }
 
     @Test
-    public void testNoModuleAddedWhenModuleNameMismatch() throws Throwable {
+    public void testNoModuleAddedWhenModuleNameMismatch() throws Exception {
         initBranchInstance();
         JSONObject branchFileJson = new JSONObject("{\"imei_rouge\":\"1234567890\"}");
         branch.addModule(branchFileJson);
@@ -57,7 +57,7 @@ public class BranchModuleInjectionTest extends BranchTest {
     }
 
     @Test
-    public void testCommerceEventHasImeiData() throws Throwable {
+    public void testCommerceEventHasImeiData() throws Exception {
         initBranchInstance();
         JSONObject branchFileJson = new JSONObject("{\"imei\":\"1234567890\"}");
         branch.addModule(branchFileJson);

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchPreinstallFileTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchPreinstallFileTest.java
@@ -14,7 +14,7 @@ import org.junit.runner.RunWith;
 public class BranchPreinstallFileTest extends BranchTest {
 
     @Test
-    public void testResultSuccess() throws Throwable {
+    public void testResultSuccess() {
         initBranchInstance();
 
         final ServerRequestQueue queue = ServerRequestQueue.getInstance(getTestContext());
@@ -39,7 +39,7 @@ public class BranchPreinstallFileTest extends BranchTest {
                     Assert.assertTrue(hasV1InstallPreinstallCampaign(initRequest));
                     Assert.assertTrue(hasV1InstallPreinstallPartner(initRequest));
                     Assert.assertTrue(hasV1InstallPreinstallCustomData(initRequest));
-                } catch (Throwable e) {
+                } catch (Exception e) {
                     Assert.fail("parsing of test resources failed");
                 }
             }
@@ -47,14 +47,14 @@ public class BranchPreinstallFileTest extends BranchTest {
     }
 
     @Test
-    public void testResultNullFile() throws Throwable {
+    public void testResultNullFile() {
         String branchFileData = AssetUtils
                 .readJsonFile(getTestContext(), "pre_install_apps_null.branch");
         Assert.assertFalse(branchFileData.length() > 0);
     }
 
     @Test
-    public void testResultPackageNameNotPresent() throws Throwable {
+    public void testResultPackageNameNotPresent() {
         initBranchInstance();
 
         final ServerRequestQueue queue = ServerRequestQueue.getInstance(getTestContext());
@@ -93,7 +93,7 @@ public class BranchPreinstallFileTest extends BranchTest {
     }
 
     @Test
-    public void testAppLevelDataOverride() throws InterruptedException {
+    public void testAppLevelDataOverride() {
         initBranchInstance();
         branch.setPreinstallPartner("partner1");
         branch.setPreinstallCampaign("campaign1");

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchTestRequestUtil.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchTestRequestUtil.java
@@ -23,7 +23,7 @@ abstract class BranchTestRequestUtil {
     public static final int TEST_INIT_SESSION_TIMEOUT = 5000;
 
     // Dig out the variable for isStandardEvent from the BranchEvent object.
-    protected boolean isStandardEvent(BranchEvent event) throws Throwable {
+    protected boolean isStandardEvent(BranchEvent event) throws Exception {
         // Use Reflection to find if it is considered a "Standard Event"
         Field f = event.getClass().getDeclaredField("isStandardEvent"); //NoSuchFieldException
         f.setAccessible(true);

--- a/Branch-SDK/src/main/java/io/branch/indexing/AppIndexingHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/indexing/AppIndexingHelper.java
@@ -36,7 +36,7 @@ class AppIndexingHelper {
                 } catch (NoClassDefFoundError ignore) {
                     // Expected when Firebase app indexing dependency is not available
                     PrefHelper.Debug("Firebase app indexing is not available. Please consider enabling Firebase app indexing for your app for better indexing experience with Google.");
-                } catch (Throwable ignore) {
+                } catch (Exception ignore) {
                     // unexpected exception
                     PrefHelper.Debug("Failed to index your contents using Firebase. Please make sure Firebase  is enabled and initialised in your app");
                 }
@@ -55,7 +55,7 @@ class AppIndexingHelper {
                             //noinspection deprecation
                             listOnGoogleSearch(contentUrl, context, buo);
                         }
-                    } catch (Throwable e) {
+                    } catch (Exception e) {
                         PrefHelper.Debug("Warning: Unable to list your content in Google search. Please make sure you have added latest Firebase app indexing SDK to your project dependencies.");
                     }
                 }
@@ -79,7 +79,7 @@ class AppIndexingHelper {
                 } catch (NoClassDefFoundError ignore) {
                     // Expected when Firebase app indexing dependency is not available
                     PrefHelper.Debug("Failed to remove the BranchUniversalObject from Firebase local indexing. Please make sure Firebase is enabled and initialised in your app");
-                } catch (Throwable ignore) {
+                } catch (Exception ignore) {
                     // unexpected exception
                     PrefHelper.Debug("Failed to index your contents using Firebase. Please make sure Firebase is enabled and initialised in your app");
                 }

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchAsyncTask.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchAsyncTask.java
@@ -19,7 +19,7 @@ public abstract class BranchAsyncTask<Params, Progress, Result> extends AsyncTas
     public final AsyncTask<Params, Progress, Result> executeTask(Params... params) {
         try {
             return executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, params);
-        } catch (Throwable t) {
+        } catch (Exception t) {
             return execute(params);
         }
     }

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchStrongMatchHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchStrongMatchHelper.java
@@ -46,7 +46,7 @@ class BranchStrongMatchHelper {
             CustomTabsCallbackClass = Class.forName("android.support.customtabs.CustomTabsCallback");
             CustomTabsSessionClass = Class.forName("android.support.customtabs.CustomTabsSession");
             ICustomTabsServiceClass = Class.forName("android.support.customtabs.ICustomTabsService");
-        } catch (Throwable t) {
+        } catch (Exception t) {
             isCustomTabsAvailable_ = false;
         }
     }
@@ -109,7 +109,7 @@ class BranchStrongMatchHelper {
                                             prefHelper.saveLastStrongMatchTime(System.currentTimeMillis());
                                             isStrongMatchUrlLaunched = true;
                                         }
-                                    } catch (Throwable t) {
+                                    } catch (Exception t) {
                                         mClient_ = null;
                                         updateStrongMatchCheckFinished(callback, isStrongMatchUrlLaunched);
                                     }
@@ -130,7 +130,7 @@ class BranchStrongMatchHelper {
                     updateStrongMatchCheckFinished(callback, isStrongMatchUrlLaunched);
                     PrefHelper.Debug("Cannot use cookie-based matching since device id is not available");
                 }
-            } catch (Throwable ignore) {
+            } catch (Exception ignore) {
                 updateStrongMatchCheckFinished(callback, isStrongMatchUrlLaunched);
             }
         }
@@ -209,7 +209,7 @@ class BranchStrongMatchHelper {
 
                 Object customTabClientObject = customTabClientConstructor.newInstance(asInterfaceMethod.invoke(null, service), name);
                 this.onCustomTabsServiceConnected(name, customTabClientObject);
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 this.onCustomTabsServiceConnected(null, null);
             }
         }

--- a/Branch-SDK/src/main/java/io/branch/referral/DeferredAppLinkDataHandler.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeferredAppLinkDataHandler.java
@@ -29,7 +29,7 @@ class DeferredAppLinkDataHandler {
 
             InvocationHandler ALDataCompletionHandler = new InvocationHandler() {
                 @Override
-                public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                public Object invoke(Object proxy, Method method, Object[] args) throws Exception {
                     if (method.getName().equals("onDeferredAppLinkDataFetched") && args[0] != null) {
                         String appLinkUrl = null;
                         Object appLinkDataClass = AppLinkDataClass.cast(args[0]);
@@ -64,7 +64,7 @@ class DeferredAppLinkDataHandler {
                 fetchDeferredAppLinkDataMethod.invoke(null, context, fbAppID, completionListenerInterface);
             }
 
-        } catch (Throwable ex) {
+        } catch (Exception ex) {
             isRequestSucceeded = false;
         }
         return isRequestSucceeded;

--- a/Branch-SDK/src/main/java/io/branch/referral/GAdsPrefetchTask.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/GAdsPrefetchTask.java
@@ -88,7 +88,7 @@ public class GAdsPrefetchTask extends BranchAsyncTask<Void, Void, Void> {
                 Class<?> advertisingIdClientClass = Class.forName("com.google.android.gms.ads.identifier.AdvertisingIdClient");
                 Method getAdvertisingIdInfoMethod = advertisingIdClientClass.getMethod("getAdvertisingIdInfo", Context.class);
                 adInfoObj = getAdvertisingIdInfoMethod.invoke(null, context);
-            } catch (Throwable ignore) {
+            } catch (Exception ignore) {
                 PrefHelper.Debug("Either class com.google.android.gms.ads.identifier.AdvertisingIdClient " +
                         "or its method, getAdvertisingIdInfo, was not found");
             }

--- a/Branch-SDK/src/main/java/io/branch/referral/GooglePlayStoreAttribution.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/GooglePlayStoreAttribution.java
@@ -79,7 +79,7 @@ class GooglePlayStoreAttribution {
                     PrefHelper.Debug("onInstallReferrerServiceDisconnected()");
                 }
             });
-        } catch (Throwable ex) {
+        } catch (Exception ex) {
             PrefHelper.Debug("ReferrerClientWrapper Exception: " + ex.getMessage());
         }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/HuaweiOAIDFetchTask.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/HuaweiOAIDFetchTask.java
@@ -94,7 +94,7 @@ public class HuaweiOAIDFetchTask extends BranchAsyncTask<Void, Void, Void> {
             if (TextUtils.isEmpty(HW_id) || HW_id.equals(UUID_EMPTY) || HW_lat) {
                 so.setGAID(null);
             }
-        } catch (Throwable e) {
+        } catch (Exception e) {
             PrefHelper.Debug("failed to retrieve OAID, error = " + e);
         }
     }

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -1255,7 +1255,7 @@ public class PrefHelper {
         }
     }
 
-    public static void LogException(String message, Throwable t) {
+    public static void LogException(String message, Exception t) {
         if (!TextUtils.isEmpty(message)) {
             Log.e(TAG, message, t);
         }

--- a/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
@@ -469,8 +469,7 @@ abstract class SystemObserver {
                     }
                 }
             }
-        } catch (Throwable ignore) {
-        }
+        } catch (Exception ignore) { }
 
         return ipAddress;
     }

--- a/Branch-SDK/src/main/java/io/branch/referral/UniversalResourceAnalyser.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/UniversalResourceAnalyser.java
@@ -105,8 +105,7 @@ class UniversalResourceAnalyser {
     void checkAndUpdateSkipURLFormats(Context context) {
         try {
             new UrlSkipListUpdateTask(context).executeTask();
-        } catch (Throwable ignore) {
-        }
+        } catch (Exception ignore) { }
     }
     
     String getStrippedURL(String url) {
@@ -172,7 +171,7 @@ class UniversalResourceAnalyser {
                         respObject = new JSONObject(rd.readLine());
                     }
                 }
-            } catch (Throwable ignore) {
+            } catch (Exception ignore) {
             } finally {
                 if (connection != null) {
                     connection.disconnect();

--- a/Branch-SDK/src/main/java/io/branch/referral/validators/BranchIntegrationModel.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/validators/BranchIntegrationModel.java
@@ -51,8 +51,7 @@ class BranchIntegrationModel {
             // Avoid ANRs on reading and parsing manifest with a timeout
             obj = new getDeepLinkSchemeTasks().executeTask(context).get(2500, TimeUnit.MILLISECONDS);
             appSettingsAvailable = true;
-        } catch (Throwable t) {
-        }
+        } catch (Exception ignored) { }
         if (obj != null) {
             deeplinkUriScheme = obj.optJSONObject(Defines.Jsonkey.URIScheme.getKey());
             JSONArray hostArray = obj.optJSONArray(Defines.Jsonkey.AppLinks.getKey());


### PR DESCRIPTION
## Reference
https://branch.atlassian.net/browse/CORE-1694 -- Don't catch Throwables in Android SDK

## Description
replace all catch Throwable with catch Exception

## Testing Instructions
not really possible or needed, `Throwable` includes OS level errors that shouldn't be caught because if we do catch them, it makes it appear that the bug is coming from our SDK (in client's crashlytics).

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
