### PR TITLE
INTENG-12240 fix wrong sdk version number

### DIFF
--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchApiTests.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchApiTests.java
@@ -427,6 +427,7 @@ public class BranchApiTests extends BranchTest {
     @Test
     public void testSdkVersion() {
         Assert.assertNotNull(Branch.getSdkVersionNumber());
+        Assert.assertEquals(BuildConfig.VERSION_NAME, Branch.getSdkVersionNumber());
     }
 
     private void getFBUrl(final FBUrl res) throws InterruptedException {

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -75,7 +75,7 @@ import io.branch.referral.util.LinkProperties;
  */
 public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserver.AdsParamsFetchEvents, GooglePlayStoreAttribution.IInstallReferrerEvents {
     
-    private static final String BRANCH_LIBRARY_VERSION = "io.branch.sdk.android:library:" + BuildConfig.VERSION_NAME;
+    private static final String BRANCH_LIBRARY_VERSION = "io.branch.sdk.android:library:" + Branch.getSdkVersionNumber();
     private static final String GOOGLE_VERSION_TAG = "!SDK-VERSION-STRING!" + ":" + BRANCH_LIBRARY_VERSION;
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -25,7 +25,7 @@ import android.os.Handler;
 import android.text.TextUtils;
 import android.view.View;
 
-import com.google.firebase.BuildConfig;
+import io.branch.referral.BuildConfig;
 
 import io.branch.referral.Defines.PreinstallKey;
 import io.branch.referral.ServerRequestGetLATD.BranchLastAttributedTouchDataListener;

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchStrongMatchHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchStrongMatchHelper.java
@@ -180,7 +180,7 @@ class BranchStrongMatchHelper {
                 uriString += "&" + Defines.Jsonkey.BranchKey.getKey() + "=" + prefHelper.getBranchKey();
             }
             //Add SDK version
-            uriString += "&sdk=android" + BuildConfig.VERSION_NAME;
+            uriString += "&sdk=android" + Branch.getSdkVersionNumber();
 
             strongMatchUri = Uri.parse(uriString);
 

--- a/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterface.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterface.java
@@ -198,7 +198,7 @@ public abstract class BranchRemoteInterface {
     private boolean addCommonParams(JSONObject post, String branch_key) {
         try {
             if (!post.has(Defines.Jsonkey.UserData.getKey())) { // user data already has the sdk in it as part of v2 request
-                post.put(Defines.Jsonkey.SDK.getKey(), "android" + BuildConfig.VERSION_NAME);
+                post.put(Defines.Jsonkey.SDK.getKey(), "android" + Branch.getSdkVersionNumber());
             }
             if (!branch_key.equals(PrefHelper.NO_STRING_VALUE)) {
                 post.put(Defines.Jsonkey.BranchKey.getKey(), branch_key);


### PR DESCRIPTION
## Reference
https://branch.atlassian.net/browse/INTENG-12240
INTENG-12240 -- Android Latest SDK 5.0.5 returning incorrect SDK version 17.0.0 in live view.

## Description
Automatic import resolution accidentally pulled Firebase's `BuildConfig` file making our `getSdkVersionNumber()` method return the wrong value and I didn't notice. Broke this in the latest release only (5.0.5).

## Testing Instructions
use the method `getSdkVersionNumber()` and confirm that you get the correct value

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
