### PR TITLE
SDK-1120 Fix getSdkVersionNumber in v/2 events, release new patch (5.0.7)

### DIFF
--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchApiTests.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchApiTests.java
@@ -427,7 +427,7 @@ public class BranchApiTests extends BranchTest {
     @Test
     public void testSdkVersion() {
         Assert.assertNotNull(Branch.getSdkVersionNumber());
-        Assert.assertEquals(BuildConfig.VERSION_NAME, Branch.getSdkVersionNumber());
+        Assert.assertEquals(io.branch.referral.BuildConfig.VERSION_NAME, Branch.getSdkVersionNumber());
     }
 
     private void getFBUrl(final FBUrl res) throws InterruptedException {

--- a/Branch-SDK/src/main/java/io/branch/referral/Base64.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Base64.java
@@ -534,7 +534,7 @@ class Base64 {
         encoder.output = new byte[output_len];
         encoder.process(input, offset, len, true);
 
-        if (BuildConfig.DEBUG && (encoder.op != output_len))
+        if (io.branch.referral.BuildConfig.DEBUG && (encoder.op != output_len))
             throw new AssertionError();
 
         return encoder.output;
@@ -717,7 +717,7 @@ class Base64 {
                     output[op++] = '\n';
                 }
 
-                if (BuildConfig.DEBUG && (tailLen != 0 || p != len))
+                if (io.branch.referral.BuildConfig.DEBUG && (tailLen != 0 || p != len))
                     throw new AssertionError();
             } else {
                 // Save the leftovers in tail to be consumed on the next

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -25,8 +25,6 @@ import android.os.Handler;
 import android.text.TextUtils;
 import android.view.View;
 
-import io.branch.referral.BuildConfig;
-
 import io.branch.referral.Defines.PreinstallKey;
 import io.branch.referral.ServerRequestGetLATD.BranchLastAttributedTouchDataListener;
 import org.json.JSONArray;
@@ -2929,7 +2927,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      * @return String value representing the current SDK version number (e.g. 4.3.2)
      */
     public static String getSdkVersionNumber() {
-        return BuildConfig.VERSION_NAME;
+        return io.branch.referral.BuildConfig.VERSION_NAME;
     }
 
     //-------------------------- DEPRECATED --------------------------------------//

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -8,8 +8,6 @@ import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.webkit.WebSettings;
 
-import com.google.firebase.BuildConfig;
-
 import io.branch.referral.Defines.ModuleNameKeys;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -203,7 +201,7 @@ class DeviceInfo {
 
             userDataObj.put(Defines.Jsonkey.AppVersion.getKey(), getAppVersion());
             userDataObj.put(Defines.Jsonkey.SDK.getKey(), "android");
-            userDataObj.put(Defines.Jsonkey.SdkVersion.getKey(), BuildConfig.VERSION_NAME);
+            userDataObj.put(Defines.Jsonkey.SdkVersion.getKey(), Branch.getSdkVersionNumber());
             userDataObj.put(Defines.Jsonkey.UserAgent.getKey(), getDefaultBrowserAgent(context_));
 
             if (serverRequest instanceof ServerRequestGetLATD) {

--- a/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterface.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterface.java
@@ -11,7 +11,6 @@ import java.util.Locale;
 
 import io.branch.referral.Branch;
 import io.branch.referral.BranchError;
-import io.branch.referral.BuildConfig;
 import io.branch.referral.Defines;
 import io.branch.referral.PrefHelper;
 import io.branch.referral.ServerResponse;

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,8 @@
 # Branch Android SDK change log
+- v5.0.7
+  * _*Master Release*_ - March 1, 2020
+  * Patch: fix getSdkVersionNumber() API in v2 events as well
+  
 - v5.0.6
   * _*Master Release*_ - February 26, 2020
   * Add INITIATE_STREAM and COMPLETE_STREAM standard events

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.0.6
-VERSION_CODE=050006
+VERSION_NAME=5.0.7
+VERSION_CODE=050007
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.


### PR DESCRIPTION
## Reference
SDK-1120 -- Fix getSdkVersionNumber in v/2 events, release new patch (5.0.7).

## Description
The  getSdkVersionNumber API was fixed in 5.0.6 but we were not using it internally in v2 events. I grep'ed for BuildConfig across the project now to make sure that we don't have any more bugs like this. The first time around I must have looked for _usages of BuildConfig_ file and, in reality, what that did was checking for usages of specifically `io.branch.referral.BuildConfig`, so that didn't fix the bug completely.

## Testing Instructions
Fire both v1 and v2 events and observe the correct sdk version.

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
