### PR TITLE
Updated retry policy for 400 status code

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/BranchPostTask.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchPostTask.java
@@ -1,6 +1,5 @@
 package io.branch.referral;
 
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchPostTask.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchPostTask.java
@@ -177,7 +177,8 @@ public class BranchPostTask extends BranchAsyncTask<Void, Void, ServerResponse> 
             thisReq_.handleFailure(status, serverResponse.getFailReason());
         }
 
-        if (status == 400 || !thisReq_.shouldRetryOnFail()) {
+        boolean unretryableErrorCode = (400 <= status && status <= 451);
+        if (unretryableErrorCode || !thisReq_.shouldRetryOnFail()) {
             branch.requestQueue_.remove(thisReq_);
         } else {
             // failure has already been handled

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchPostTask.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchPostTask.java
@@ -1,5 +1,7 @@
 package io.branch.referral;
 
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -177,7 +179,7 @@ public class BranchPostTask extends BranchAsyncTask<Void, Void, ServerResponse> 
             thisReq_.handleFailure(status, serverResponse.getFailReason());
         }
 
-        if (!thisReq_.shouldRetryOnFail()) {
+        if (status == 400 || !thisReq_.shouldRetryOnFail()) {
             branch.requestQueue_.remove(thisReq_);
         } else {
             // failure has already been handled

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchPostTask.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchPostTask.java
@@ -1,6 +1,5 @@
 package io.branch.referral;
 
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 


### PR DESCRIPTION
## Reference
[INTENG-12585 ](https://branch.atlassian.net/browse/INTENG-12585)- Android SDK infinitely sends event requests if the response code is 400

## Description
When an event is logged and if the server returns 400 we try to fire the event infinite time, to avoid this have changed the logic that whenever status is 400 and even if retry is set to true for the API we would not retry for that API.

## Testing Instructions
Step 1: Fire any event custom, commerce or content event which could cause server to return 400 error, for instance empty event name.
Step 2: Observer the logs server will return 400 response code 
Step 3: Once the server respond, API should not be fired again infinite times 

## Risk Assessment [`LOW`]

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
