### PR TITLE
CORE-1888 avoid possibility of blocking ui thread

### DIFF
--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
@@ -109,10 +109,11 @@ public class MainActivity extends Activity {
                 Branch.getInstance().setIdentity("test_user_10", new BranchReferralInitListener() {
                     @Override
                     public void onInitFinished(JSONObject referringParams, BranchError error) {
+                        Log.e("BranchSDK_Tester", "install params = " + referringParams.toString());
                         if (error != null) {
-                            Log.i("BranchTestBed", "branch set Identity failed. Caused by -" + error.getMessage());
+                            Log.e("BranchSDK_Tester", "branch set Identity failed. Caused by -" + error.getMessage());
                         } else {
-                            Log.i("BranchTestBed", "install params = " + referringParams.toString());
+                            Log.e("BranchSDK_Tester", "install params = " + referringParams.toString());
                         }
                     }
                 });
@@ -125,7 +126,7 @@ public class MainActivity extends Activity {
                 Branch.getInstance().logout(new Branch.LogoutStatusListener() {
                     @Override
                     public void onLogoutFinished(boolean loggedOut, BranchError error) {
-                        Log.i("BranchTestBed", "onLogoutFinished " + loggedOut + " errorMessage " + error);
+                        Log.e("BranchSDK_Tester", "onLogoutFinished " + loggedOut + " errorMessage " + error);
                     }
                 });
 
@@ -138,7 +139,7 @@ public class MainActivity extends Activity {
             @Override
             public void onClick(View v) {
                 JSONObject obj = Branch.getInstance().getFirstReferringParams();
-                Log.i("BranchTestBed", "install params = " + obj.toString());
+                Log.e("BranchSDK_Tester", "install params = " + obj.toString());
             }
         });
 
@@ -180,9 +181,9 @@ public class MainActivity extends Activity {
                     @Override
                     public void onStateChanged(boolean changed, BranchError error) {
                         if (error != null) {
-                            Log.i("BranchTestBed", "branch load rewards failed. Caused by -" + error.getMessage());
+                            Log.e("BranchSDK_Tester", "branch load rewards failed. Caused by -" + error.getMessage());
                         } else {
-                            Log.i("BranchTestBed", "changed = " + changed);
+                            Log.e("BranchSDK_Tester", "changed = " + changed);
                             txtRewardBalance.setText(getString(R.string.rewards, Branch.getInstance().getCredits()));
                         }
                     }
@@ -197,13 +198,13 @@ public class MainActivity extends Activity {
                     @Override
                     public void onStateChanged(boolean changed, BranchError error) {
                         if (error != null) {
-                            Log.i("BranchTestBed", "branch redeem rewards failed. Caused by -" + error.getMessage());
+                            Log.e("BranchSDK_Tester", "branch redeem rewards failed. Caused by -" + error.getMessage());
                         } else {
                             if (changed) {
-                                Log.i("BranchTestBed", "redeemed rewards = " + true);
+                                Log.e("BranchSDK_Tester", "redeemed rewards = " + true);
                                 txtRewardBalance.setText(getString(R.string.rewards, Branch.getInstance().getCredits()));
                             } else {
-                                Log.i("BranchTestBed", "redeem rewards unknown error ");
+                                Log.e("BranchSDK_Tester", "redeem rewards unknown error ");
                             }
                         }
                     }
@@ -217,22 +218,22 @@ public class MainActivity extends Activity {
                 Branch.getInstance().userCompletedAction("buy", new BranchViewHandler.IBranchViewEvents() {
                     @Override
                     public void onBranchViewVisible(String action, String branchViewID) {
-                        Log.i("BranchTestBed", "onBranchViewVisible");
+                        Log.e("BranchSDK_Tester", "onBranchViewVisible");
                     }
 
                     @Override
                     public void onBranchViewAccepted(String action, String branchViewID) {
-                        Log.i("BranchTestBed", "onBranchViewAccepted");
+                        Log.e("BranchSDK_Tester", "onBranchViewAccepted");
                     }
 
                     @Override
                     public void onBranchViewCancelled(String action, String branchViewID) {
-                        Log.i("BranchTestBed", "onBranchViewCancelled");
+                        Log.e("BranchSDK_Tester", "onBranchViewCancelled");
                     }
 
                     @Override
                     public void onBranchViewError(int errorCode, String errorMsg, String action) {
-                        Log.i("BranchTestBed", "onBranchViewError " + errorMsg);
+                        Log.e("BranchSDK_Tester", "onBranchViewError " + errorMsg);
                     }
                 });
             }
@@ -259,7 +260,7 @@ public class MainActivity extends Activity {
         findViewById(R.id.cmdGetCreditHistory).setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                Log.i("BranchTestBed", "Getting credit history...");
+                Log.e("BranchSDK_Tester", "Getting credit history...");
                 Intent i = new Intent(getApplicationContext(), CreditHistoryActivity.class);
                 // Test for preventing second intent reading
                 i.setData(Uri.parse("https://testintentread.app.link?error_if_assigned_to_android_app_link"));
@@ -361,7 +362,7 @@ public class MainActivity extends Activity {
                 Intent intent = new Intent(MainActivity.this, MainActivity.class);
                 String shortURL = branchUniversalObject.getShortUrl(MainActivity.this, new LinkProperties().addControlParameter("key11", "value11"));
                 if (shortURL == null) {
-                    Log.i("BranchTestBed", "branchUniversalObject.getShortUrl = null");
+                    Log.e("BranchSDK_Tester", "branchUniversalObject.getShortUrl = null");
                     return;
                 }
 //                intent.setData(Uri.parse(shortURL));
@@ -471,22 +472,23 @@ public class MainActivity extends Activity {
         super.onStart();
         Branch.getInstance().addFacebookPartnerParameterWithName("em", getHashedValue("sdkadmin@branch.io"));
         Branch.getInstance().addFacebookPartnerParameterWithName("ph", getHashedValue("6516006060"));
+        Log.e("BranchSDK_Tester", "initSession");
         Branch.sessionBuilder(this).withCallback(new Branch.BranchUniversalReferralInitListener() {
             @Override
             public void onInitFinished(BranchUniversalObject branchUniversalObject, LinkProperties linkProperties, BranchError error) {
                 if (error != null) {
-                    Log.i("BranchTestBed", "branch init failed. Caused by -" + error.getMessage());
+                    Log.e("BranchSDK_Tester", "branch init failed. Caused by -" + error.getMessage());
                 } else {
-                    Log.i("BranchTestBed", "branch init complete!");
+                    Log.e("BranchSDK_Tester", "branch init complete!");
                     if (branchUniversalObject != null) {
-                        Log.i("BranchTestBed", "title " + branchUniversalObject.getTitle());
-                        Log.i("BranchTestBed", "CanonicalIdentifier " + branchUniversalObject.getCanonicalIdentifier());
-                        Log.i("ContentMetaData", "metadata " + branchUniversalObject.getContentMetadata().convertToJson());
+                        Log.e("BranchSDK_Tester", "title " + branchUniversalObject.getTitle());
+                        Log.e("BranchSDK_Tester", "CanonicalIdentifier " + branchUniversalObject.getCanonicalIdentifier());
+                        Log.e("BranchSDK_Tester", "metadata " + branchUniversalObject.getContentMetadata().convertToJson());
                     }
 
                     if (linkProperties != null) {
-                        Log.i("BranchTestBed", "Channel " + linkProperties.getChannel());
-                        Log.i("BranchTestBed", "control params " + linkProperties.getControlParams());
+                        Log.e("BranchSDK_Tester", "Channel " + linkProperties.getChannel());
+                        Log.e("BranchSDK_Tester", "control params " + linkProperties.getControlParams());
                     }
                 }
 
@@ -515,9 +517,9 @@ public class MainActivity extends Activity {
             @Override
             public void onInitFinished(JSONObject referringParams, BranchError error) {
                 if (error != null) {
-                    Log.i("BranchTestBed", error.getMessage());
+                    Log.e("BranchSDK_Tester", error.getMessage());
                 } else if (referringParams != null) {
-                    Log.i("BranchTestBed", referringParams.toString());
+                    Log.e("BranchSDK_Tester", referringParams.toString());
                 }
             }
         }).reInit();

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchActivityLifecycleObserver.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchActivityLifecycleObserver.java
@@ -70,7 +70,7 @@ class BranchActivityLifecycleObserver implements Application.ActivityLifecycleCa
                 // this is the only place where we self-initialize in case user opens the app from 'recent apps tray'
                 // and the entry Activity is not the launcher Activity where user placed initSession themselves.
                 PrefHelper.Debug("initializing session on user's behalf (onActivityResumed called but SESSION_STATE = UNINITIALISED)");
-                Branch.sessionBuilder(activity).init();
+                Branch.sessionBuilder(activity).isAutoInitialization(true).init();
             } else {
                 PrefHelper.Debug("onActivityResumed called and SESSION_STATE = UNINITIALISED, however this is a " + Branch.getPluginName() + " plugin, so we are NOT initializing session on user's behalf");
             }

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchPostTask.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchPostTask.java
@@ -61,9 +61,15 @@ public class BranchPostTask extends BranchAsyncTask<Void, Void, ServerResponse> 
     @Override
     protected void onPostExecute(ServerResponse serverResponse) {
         super.onPostExecute(serverResponse);
+        onPostExecuteInner(serverResponse);
+    }
+
+    void onPostExecuteInner(ServerResponse serverResponse) {
         if (latch_ != null) {
             latch_.countDown();
+            PrefHelper.Debug("latch_.countDown()");
         }
+        PrefHelper.Debug("onPostExecute, serverResponse = " + serverResponse);
         if (serverResponse == null) {
             thisReq_.handleFailure(BranchError.ERR_BRANCH_INVALID_REQUEST, "Null response.");
             return;
@@ -161,7 +167,7 @@ public class BranchPostTask extends BranchAsyncTask<Void, Void, ServerResponse> 
         }
     }
 
-    private void onRequestFailed(ServerResponse serverResponse, int status) {
+    void onRequestFailed(ServerResponse serverResponse, int status) {
         // If failed request is an initialisation request (but not in the intra-app linking scenario) then mark session as not initialised
         if (thisReq_ instanceof ServerRequestInitSession && PrefHelper.NO_STRING_VALUE.equals(branch.prefHelper_.getSessionParams())) {
             branch.setInitState(Branch.SESSION_STATE.UNINITIALISED);
@@ -185,11 +191,5 @@ public class BranchPostTask extends BranchAsyncTask<Void, Void, ServerResponse> 
             // todo does it make sense to retry the request without a callback? (e.g. CPID, LATD)
             thisReq_.clearCallbacks();
         }
-    }
-
-    @Override
-    protected void onCancelled(ServerResponse v) {
-        super.onCancelled();
-        onPostExecute(new ServerResponse(thisReq_.getRequestPath(), ERR_BRANCH_REQ_TIMED_OUT, ""));
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -5,8 +5,12 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.text.TextUtils;
 
+import androidx.annotation.CallSuper;
+
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.util.concurrent.locks.ReentrantLock;
 
 import io.branch.referral.validators.DeepLinkRoutingValidator;
 
@@ -25,15 +29,21 @@ abstract class ServerRequestInitSession extends ServerRequest {
     private static final int STATE_UPDATE = 2;
     private static final int STATE_TUNE_MIGRATION = 5;
 
+    static final String INITIATED_BY_CLIENT = "INITIATED_BY_CLIENT";
 
-    ServerRequestInitSession(Context context, Defines.RequestPath requestPath) {
+    Branch.BranchReferralInitListener callback_;
+    boolean initiatedByClient;
+
+    ServerRequestInitSession(Context context, Defines.RequestPath requestPath, boolean isAutoInitialization) {
         super(context, requestPath);
         context_ = context;
+        initiatedByClient = !isAutoInitialization;
     }
 
-    ServerRequestInitSession(Defines.RequestPath requestPath, JSONObject post, Context context) {
+    ServerRequestInitSession(Defines.RequestPath requestPath, JSONObject post, Context context, boolean isAutoInitialization) {
         super(requestPath, post, context);
         context_ = context;
+        initiatedByClient = !isAutoInitialization;
     }
 
     @Override
@@ -285,5 +295,16 @@ abstract class ServerRequestInitSession extends ServerRequest {
         } else {
             return super.prepareExecuteWithoutTracking();
         }
+    }
+
+    @Override
+    public JSONObject toJSON() {
+        JSONObject r = super.toJSON();
+        try {
+            r.put(INITIATED_BY_CLIENT, initiatedByClient);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        return r;
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestQueue.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestQueue.java
@@ -8,6 +8,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
@@ -263,15 +264,18 @@ class ServerRequestQueue {
      * install/register request. <i>True</i> if the queue contains a close request,
      * <i>False</i> if not.
      */
-    boolean containsInitRequest() {
+    ServerRequestInitSession getSelfInitRequest() {
         synchronized (reqQueueLockObject) {
             for (ServerRequest req : queue) {
                 if (req instanceof ServerRequestInitSession) {
-                    return true;
+                    ServerRequestInitSession r = (ServerRequestInitSession) req;
+                    if (r.initiatedByClient) {
+                        return r;
+                    }
                 }
             }
         }
-        return false;
+        return null;
     }
     
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterInstall.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterInstall.java
@@ -13,8 +13,6 @@ import org.json.JSONObject;
  */
 class ServerRequestRegisterInstall extends ServerRequestInitSession {
     
-    Branch.BranchReferralInitListener callback_;
-    
     /**
      * <p>Create an instance of {@link ServerRequestRegisterInstall} to notify Branch API on a new install.</p>
      *
@@ -22,8 +20,8 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
      * @param callback    A {@link Branch.BranchReferralInitListener} callback instance that will return
      *                    the data associated with new install registration.
      */
-    ServerRequestRegisterInstall(Context context, Branch.BranchReferralInitListener callback) {
-        super(context, Defines.RequestPath.RegisterInstall);
+    ServerRequestRegisterInstall(Context context, Branch.BranchReferralInitListener callback, boolean isAutoInitialization) {
+        super(context, Defines.RequestPath.RegisterInstall, isAutoInitialization);
         callback_ = callback;
         try {
             setPost(new JSONObject());
@@ -33,10 +31,10 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
         }
     }
     
-    ServerRequestRegisterInstall(Defines.RequestPath requestPath, JSONObject post, Context context) {
-        super(requestPath, post, context);
+    ServerRequestRegisterInstall(Defines.RequestPath requestPath, JSONObject post, Context context, boolean isAutoInitialization) {
+        super(requestPath, post, context, isAutoInitialization);
     }
-    
+
     @Override
     public void onPreExecute() {
         super.onPreExecute();

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterOpen.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterOpen.java
@@ -13,8 +13,6 @@ import org.json.JSONObject;
  */
 class ServerRequestRegisterOpen extends ServerRequestInitSession {
     
-    Branch.BranchReferralInitListener callback_;
-    
     /**
      * <p>Create an instance of {@link ServerRequestRegisterInstall} to notify Branch API on app open event.</p>
      *
@@ -22,8 +20,8 @@ class ServerRequestRegisterOpen extends ServerRequestInitSession {
      * @param callback    A {@link Branch.BranchReferralInitListener} callback instance that will return
      *                    the data associated with new install registration.
      */
-    ServerRequestRegisterOpen(Context context, Branch.BranchReferralInitListener callback) {
-        super(context, Defines.RequestPath.RegisterOpen);
+    ServerRequestRegisterOpen(Context context, Branch.BranchReferralInitListener callback, boolean isAutoInitialization) {
+        super(context, Defines.RequestPath.RegisterOpen, isAutoInitialization);
         callback_ = callback;
         JSONObject openPost = new JSONObject();
         try {
@@ -37,8 +35,8 @@ class ServerRequestRegisterOpen extends ServerRequestInitSession {
         
     }
     
-    ServerRequestRegisterOpen(Defines.RequestPath requestPath, JSONObject post, Context context) {
-        super(requestPath, post, context);
+    ServerRequestRegisterOpen(Defines.RequestPath requestPath, JSONObject post, Context context, boolean isAutoInitialization) {
+        super(requestPath, post, context, isAutoInitialization);
     }
 
     @Override

--- a/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
@@ -67,7 +67,7 @@ public class TrackingController {
     private void onTrackingEnabled() {
         Branch branch = Branch.getInstance();
         if (branch != null) {
-            branch.registerAppInit(branch.getInstallOrOpenRequest(null), true);
+            branch.registerAppInit(branch.getInstallOrOpenRequest(null, true), true);
         }
     }
 }

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,15 +1,20 @@
 # Branch Android SDK change log
+- v5.0.8
+  * _*Master Release*_ - April 29, 2021
+  * Fix bug can block UI thread
+  * Fix race condition between session initialization requests invoked by client and SDK
+  
 - v5.0.7
-  * _*Master Release*_ - March 1, 2020
+  * _*Master Release*_ - March 1, 2021
   * Patch: fix getSdkVersionNumber() API in v2 events as well
   
 - v5.0.6
-  * _*Master Release*_ - February 26, 2020
+  * _*Master Release*_ - February 26, 2021
   * Add INITIATE_STREAM and COMPLETE_STREAM standard events
   * Fix getSdkVersionNumber() API
   
 - v5.0.5
-  * _*Master Release*_ - February 17, 2020
+  * _*Master Release*_ - February 17, 2021
   * Add API to pass hashed partner parameters (Facebook integration)
   * Fix bugs in the networking pipeline of CPID and LATD requests
   * Fix bug preventing callback invocation when url creation request times out

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.0.7
-VERSION_CODE=050007
+VERSION_NAME=5.0.8
+VERSION_CODE=050008
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.


### PR DESCRIPTION
## Reference
CORE-1888 -- slow death of app when Branch servers fail to respond.

## Description
Bug slipped through such that SDK was blocking the UI thread (via countdownlatch.await) as we were awaiting for network requests to complete.
In addition, I was able to observe the long suspected race condition between self-init requests and client-invoked initSession requests, which caused callback to never be invoked. So I restored the old hack that assigns user-defined callback on the self-init request (if it's in flight) instead of ignoring client initiated request altogether and just printing a warning.

## Testing Instructions

- Run the emulator with very slow network speed e.g. `emulator -avd A_Pixel_3_XL_API_29 -netspeed 1:1 -netdelay 500`
- observe no UI thread blocking (by opening the tetsBed  app and immediately trying to navigate to the settings page (while initSession request is in flight))
- now change the method, `executeTimedBranchPostTask`,  to former implementation such that `awaitTimedBranchPostTask` is never invoked from a separate thread and observe the UI thread being blocked (by following the same technique that opens settings page).
- Finally, cancelling the AsyncTask was causing issues as well and network timeout was not being respected because of it, so I reworked that too.

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
HIGH

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [x] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [x] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [x] Mission critical pieces are documented in code and out of code as needed.
- [x] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
