### PR TITLE
INTENG-12653 avoid potential NPE in session builder

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1,6 +1,7 @@
 package io.branch.referral;
 
 import static io.branch.referral.BranchError.ERR_BRANCH_REQ_TIMED_OUT;
+import static io.branch.referral.BranchError.ERR_IMPROPER_REINITIALIZATION;
 import static io.branch.referral.BranchPreinstall.getPreinstallSystemData;
 import static io.branch.referral.BranchUtil.isTestModeEnabled;
 import static io.branch.referral.PrefHelper.isValidBranchKey;
@@ -2879,6 +2880,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             } else if (isReInitializing) {
                 // User called reInit but isRestartSessionRequested = false, meaning the new intent was
                 // not initiated by Branch and should not be considered a "new session", return early
+                if (callback != null) callback.onInitFinished(null, new BranchError("", ERR_IMPROPER_REINITIALIZATION));
                 return;
             }
 
@@ -2888,12 +2890,12 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                 branch.isInstantDeepLinkPossible = false;
                 // invoke callback returning LatestReferringParams, which were parsed out inside readAndStripParam
                 // from either intent extra "branch_data", or as parameters attached to the referring app link
-                callback.onInitFinished(branch.getLatestReferringParams(), null);
+                if (callback != null) callback.onInitFinished(branch.getLatestReferringParams(), null);
                 // mark this session as IDL session
                 branch.addExtraInstrumentationData(Defines.Jsonkey.InstantDeepLinkSession.getKey(), "true");
                 // potentially routes the user to the Activity configured to consume this particular link
                 branch.checkForAutoDeepLinkConfiguration();
-                // we already invoked the callback for let's set it to null, make will still make the
+                // we already invoked the callback for let's set it to null, we will still make the
                 // init session request but for analytics purposes only
                 callback = null;
             }

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchError.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchError.java
@@ -44,6 +44,8 @@ public class BranchError {
     public static final int ERR_BRANCH_TRACKING_DISABLED = -117;
     /* Branch session is already initialized */
     public static final int ERR_BRANCH_ALREADY_INITIALIZED = -118;
+    /* Reinitializing session without the flag, IntentKey.ForceNewBranchSession */
+    public static final int ERR_IMPROPER_REINITIALIZATION = -119;
     
     /**
      * <p>Returns the message explaining the error.</p>
@@ -143,6 +145,9 @@ public class BranchError {
         } else if (statusCode >= 400 || statusCode == ERR_BRANCH_INVALID_REQUEST) {
             errorCode_ = ERR_BRANCH_INVALID_REQUEST;
             errMsg = " The request was invalid.";
+        } else if (statusCode == ERR_IMPROPER_REINITIALIZATION) {
+            errorCode_ = ERR_IMPROPER_REINITIALIZATION;
+            errMsg = "Intra-app linking (i.e. session reinitialization) requires an intent flag, \"branch_force_new_session\".";
         } else {
             errorCode_ = ERR_BRANCH_NO_CONNECTIVITY;
             errMsg = " Check network connectivity and that you properly initialized.";

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchPostTask.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchPostTask.java
@@ -6,11 +6,7 @@ import androidx.annotation.Nullable;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.concurrent.CountDownLatch;
-
-import static io.branch.referral.BranchError.ERR_BRANCH_REQ_TIMED_OUT;
 
 /**
  * Asynchronous task handling execution of server requests. Execute the network task on background
@@ -67,9 +63,7 @@ public class BranchPostTask extends BranchAsyncTask<Void, Void, ServerResponse> 
     void onPostExecuteInner(ServerResponse serverResponse) {
         if (latch_ != null) {
             latch_.countDown();
-            PrefHelper.Debug("latch_.countDown()");
         }
-        PrefHelper.Debug("onPostExecute, serverResponse = " + serverResponse);
         if (serverResponse == null) {
             thisReq_.handleFailure(BranchError.ERR_BRANCH_INVALID_REQUEST, "Null response.");
             return;

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,9 @@
 # Branch Android SDK change log
+- v5.0.9
+  * _*Master Release*_ - April 29, 2021
+  * Avoid potential NPE
+  * When reinitializing session without an expected intent flag, invoke callback with error rather than ignoring it.
+
 - v5.0.8
   * _*Master Release*_ - April 29, 2021
   * Fix bug can block UI thread

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.0.8
-VERSION_CODE=050008
+VERSION_NAME=5.0.9
+VERSION_CODE=050009
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.


### PR DESCRIPTION
## Reference
INTENG-12653 -- NPE in session builder.

## Description
Not sure how this NPE went by without being noticed for a such a long time. To be fair though, I couldn't repro it either, my guess is there is a race condition since the crashing session initialization is started by the SDK itself. In either case, callback invocation should always be preceded by checking for null, so I didn't bother to fully repro the bug.

Also, double-checked other places where callback is invoked, we do check for null everywhere else.

Additionally, I added `ERR_IMPROPER_REINITIALIZATION` to handle an error case that used to be quietly ignored.


## Testing Instructions
n/a

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW
- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [x] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [x] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [x] Mission critical pieces are documented in code and out of code as needed.
- [x] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
