### PR TITLE
[CORE-1951] Add initial_referrer for every session

### DIFF
--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
@@ -523,6 +523,8 @@ public class MainActivity extends Activity {
                 }
             }
         }).reInit();
+
+        
     }
 
     @Override
@@ -537,4 +539,6 @@ public class MainActivity extends Activity {
             startActivity(i);
         }
     }
+
+
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2862,7 +2862,6 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
          * and configuration variables, then initializes session.</p>
          */
         public void init() {
-
             final Branch branch = Branch.getInstance();
             if (branch == null) {
                 PrefHelper.LogAlways("Branch is not setup properly, make sure to call getAutoInstance" +
@@ -2876,7 +2875,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             Activity activity = branch.getCurrentActivity();
             Intent intent = activity != null ? activity.getIntent() : null;
 
-            if (activity.getReferrer()!=null){
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1 && activity.getReferrer() != null) {
                 PrefHelper.getInstance(activity).setInitialReferrer(activity.getReferrer().toString());
             }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -17,6 +17,7 @@ import android.content.pm.PackageManager;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -25,6 +26,7 @@ import androidx.annotation.StyleRes;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.View;
 
 import io.branch.referral.Defines.PreinstallKey;
@@ -2861,9 +2863,10 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
          * and configuration variables, then initializes session.</p>
          */
         public void init() {
+
             final Branch branch = Branch.getInstance();
             if (branch == null) {
-                PrefHelper.LogAlways("Branch is not setup properly, make sure to call getAutoInstance" +
+                PrefHelper.LogAlways    ("Branch is not setup properly, make sure to call getAutoInstance" +
                         " in your application class or declare BranchApp in your manifest.");
                 return;
             }
@@ -2873,6 +2876,11 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
 
             Activity activity = branch.getCurrentActivity();
             Intent intent = activity != null ? activity.getIntent() : null;
+
+            if(activity.getReferrer()!=null){
+                PrefHelper.getInstance(activity).setInitialReferrer(activity.getReferrer().toString());
+            }
+
             if (uri != null) {
                 branch.readAndStripParam(uri, activity);
             } else if (isReInitializing && branch.isRestartSessionRequested(intent)) {

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2865,7 +2865,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
 
             final Branch branch = Branch.getInstance();
             if (branch == null) {
-                PrefHelper.LogAlways    ("Branch is not setup properly, make sure to call getAutoInstance" +
+                PrefHelper.LogAlways("Branch is not setup properly, make sure to call getAutoInstance" +
                         " in your application class or declare BranchApp in your manifest.");
                 return;
             }
@@ -2876,7 +2876,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             Activity activity = branch.getCurrentActivity();
             Intent intent = activity != null ? activity.getIntent() : null;
 
-            if(activity.getReferrer()!=null){
+            if (activity.getReferrer()!=null){
                 PrefHelper.getInstance(activity).setInitialReferrer(activity.getReferrer().toString());
             }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -26,7 +26,6 @@ import androidx.annotation.StyleRes;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.View;
 
 import io.branch.referral.Defines.PreinstallKey;

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -28,6 +28,7 @@ import android.os.Looper;
 import android.text.TextUtils;
 import android.view.View;
 
+import androidx.core.app.ActivityCompat;
 import io.branch.referral.Defines.PreinstallKey;
 import io.branch.referral.ServerRequestGetLATD.BranchLastAttributedTouchDataListener;
 import org.json.JSONArray;
@@ -2875,8 +2876,8 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             Activity activity = branch.getCurrentActivity();
             Intent intent = activity != null ? activity.getIntent() : null;
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1 && activity.getReferrer() != null) {
-                PrefHelper.getInstance(activity).setInitialReferrer(activity.getReferrer().toString());
+            if (ActivityCompat.getReferrer(activity) != null) {
+                PrefHelper.getInstance(activity).setInitialReferrer(ActivityCompat.getReferrer(activity).toString());
             }
 
             if (uri != null) {

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -357,6 +357,10 @@ public class Defines {
         BranchLinkUsed("branch_used"),
         BranchURI("branch");
 
+        // The below intent keys are also used to extract data from the intent (via ActivityCompact.getReferrer())
+        // public static final String EXTRA_REFERRER = "android.intent.extra.REFERRER";
+        // public static final String EXTRA_REFERRER_NAME = "android.intent.extra.REFERRER_NAME";
+
         private final String key;
 
         IntentKeys(String key) {

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -27,6 +27,7 @@ public class Defines {
         PlayAutoInstalls("play-auto-installs"),             //UTM_Source set by Xiaomi
         UTMCampaign("utm_campaign"),
         UTMMedium("utm_medium"),
+        InitialReferrer("initial_referrer"),
 
         Bucket("bucket"),
         DefaultBucket("default"),

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -75,7 +75,7 @@ public class PrefHelper {
     private static final String KEY_INSTALL_PARAMS = "bnc_install_params";
     private static final String KEY_USER_URL = "bnc_user_url";
     private static final String KEY_LATD_ATTRIBUTION_WINDOW = "bnc_latd_attributon_window";
-    private static final String KEY_INITIAL_REFERRER = "initial_referrer";
+    private static final String KEY_INITIAL_REFERRER = "bnc_initial_referrer";
 
     private static final String KEY_BUCKETS = "bnc_buckets";
     private static final String KEY_CREDIT_BASE = "bnc_credit_base_";
@@ -941,7 +941,7 @@ public class PrefHelper {
     }
 
     /**
-     * Sets the android.intent.extra.REFERRER to the pref
+     * Persist the android.intent.extra.REFERRER value
      *
      * @param initialReferrer android.intent.extra.REFERRER
      */
@@ -950,7 +950,7 @@ public class PrefHelper {
     }
 
     /**
-     * Gets the android.intent.extra.REFERRER
+     * Get the persisted android.intent.extra.REFERRER value
      *
      * @return {@link String} android.intent.extra.REFERRER
      */

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -75,6 +75,7 @@ public class PrefHelper {
     private static final String KEY_INSTALL_PARAMS = "bnc_install_params";
     private static final String KEY_USER_URL = "bnc_user_url";
     private static final String KEY_LATD_ATTRIBUTION_WINDOW = "bnc_latd_attributon_window";
+    private static final String KEY_INITIAL_REFERRER = "initial_referrer";
 
     private static final String KEY_BUCKETS = "bnc_buckets";
     private static final String KEY_CREDIT_BASE = "bnc_credit_base_";
@@ -938,7 +939,26 @@ public class PrefHelper {
         return getInteger(KEY_LATD_ATTRIBUTION_WINDOW,
                 ServerRequestGetLATD.defaultAttributionWindow);
     }
-    
+
+    /**
+     * Sets the android.intent.extra.REFERRER to the pref
+     *
+     * @param initialReferrer android.intent.extra.REFERRER
+     */
+    public void setInitialReferrer(String initialReferrer) {
+        setString(KEY_INITIAL_REFERRER, initialReferrer);
+    }
+
+    /**
+     * Gets the android.intent.extra.REFERRER
+     *
+     * @return {@link String} android.intent.extra.REFERRER
+     */
+    public String getInitialReferrer() {
+        return getString(KEY_INITIAL_REFERRER);
+    }
+
+
     // ALL GENERIC CALLS
     
     private String serializeArrayList(ArrayList<String> strings) {

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -52,7 +52,7 @@ abstract class ServerRequestInitSession extends ServerRequest {
         if (!DeviceInfo.isNullOrEmptyOrBlank(appVersion)) {
             post.put(Defines.Jsonkey.AppVersion.getKey(), appVersion);
         }
-        if(prefHelper_.getInitialReferrer() != null && prefHelper_.getInitialReferrer().equals(PrefHelper.NO_STRING_VALUE)) {
+        if(prefHelper_.getInitialReferrer() != null && !prefHelper_.getInitialReferrer().equals(PrefHelper.NO_STRING_VALUE)) {
             post.put(Defines.Jsonkey.InitialReferrer.getKey(), prefHelper_.getInitialReferrer());
         }
         post.put(Defines.Jsonkey.FaceBookAppLinkChecked.getKey(), prefHelper_.getIsAppLinkTriggeredInit());

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -11,6 +11,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Logger;
 
 import io.branch.referral.validators.DeepLinkRoutingValidator;
 
@@ -49,6 +50,7 @@ abstract class ServerRequestInitSession extends ServerRequest {
     @Override
     protected void setPost(JSONObject post) throws JSONException {
         super.setPost(post);
+
         prefHelper_.loadPartnerParams(post);
 
         String appVersion = DeviceInfo.getInstance().getAppVersion();
@@ -57,6 +59,7 @@ abstract class ServerRequestInitSession extends ServerRequest {
         }
         post.put(Defines.Jsonkey.FaceBookAppLinkChecked.getKey(), prefHelper_.getIsAppLinkTriggeredInit());
         post.put(Defines.Jsonkey.Debug.getKey(), Branch.isDeviceIDFetchDisabled());
+        post.put(Defines.Jsonkey.InitialReferrer.getKey(),prefHelper_.getInitialReferrer());
 
         updateInstallStateAndTimestamps(post);
         updateEnvironment(context_, post);
@@ -117,6 +120,7 @@ abstract class ServerRequestInitSession extends ServerRequest {
         prefHelper_.setIsAppLinkTriggeredInit(false);
         prefHelper_.setInstallReferrerParams(PrefHelper.NO_STRING_VALUE);
         prefHelper_.setIsFullAppConversion(false);
+        prefHelper_.setInitialReferrer(PrefHelper.NO_STRING_VALUE);
 
         if (prefHelper_.getLong(PrefHelper.KEY_PREVIOUS_UPDATE_TIME) == 0) {
             prefHelper_.setLong(PrefHelper.KEY_PREVIOUS_UPDATE_TIME, prefHelper_.getLong(PrefHelper.KEY_LAST_KNOWN_UPDATE_TIME));

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -52,7 +52,7 @@ abstract class ServerRequestInitSession extends ServerRequest {
         if (!DeviceInfo.isNullOrEmptyOrBlank(appVersion)) {
             post.put(Defines.Jsonkey.AppVersion.getKey(), appVersion);
         }
-        if(prefHelper_.getInitialReferrer() != null && !prefHelper_.getInitialReferrer().equals(PrefHelper.NO_STRING_VALUE)) {
+        if(!TextUtils.isEmpty(prefHelper_.getInitialReferrer()) && !prefHelper_.getInitialReferrer().equals(PrefHelper.NO_STRING_VALUE)) {
             post.put(Defines.Jsonkey.InitialReferrer.getKey(), prefHelper_.getInitialReferrer());
         }
         post.put(Defines.Jsonkey.FaceBookAppLinkChecked.getKey(), prefHelper_.getIsAppLinkTriggeredInit());

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -5,13 +5,9 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.text.TextUtils;
 
-import androidx.annotation.CallSuper;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.logging.Logger;
 
 import io.branch.referral.validators.DeepLinkRoutingValidator;
 
@@ -50,16 +46,17 @@ abstract class ServerRequestInitSession extends ServerRequest {
     @Override
     protected void setPost(JSONObject post) throws JSONException {
         super.setPost(post);
-
         prefHelper_.loadPartnerParams(post);
 
         String appVersion = DeviceInfo.getInstance().getAppVersion();
         if (!DeviceInfo.isNullOrEmptyOrBlank(appVersion)) {
             post.put(Defines.Jsonkey.AppVersion.getKey(), appVersion);
         }
+        if(prefHelper_.getInitialReferrer() != null && prefHelper_.getInitialReferrer().equals(PrefHelper.NO_STRING_VALUE)) {
+            post.put(Defines.Jsonkey.InitialReferrer.getKey(), prefHelper_.getInitialReferrer());
+        }
         post.put(Defines.Jsonkey.FaceBookAppLinkChecked.getKey(), prefHelper_.getIsAppLinkTriggeredInit());
         post.put(Defines.Jsonkey.Debug.getKey(), Branch.isDeviceIDFetchDisabled());
-        post.put(Defines.Jsonkey.InitialReferrer.getKey(),prefHelper_.getInitialReferrer());
 
         updateInstallStateAndTimestamps(post);
         updateEnvironment(context_, post);

--- a/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
@@ -58,6 +58,7 @@ public class TrackingController {
         prefHelper.setInstallReferrerParams(PrefHelper.NO_STRING_VALUE);
         prefHelper.setGooglePlayReferrer(PrefHelper.NO_STRING_VALUE);
         prefHelper.setGoogleSearchInstallIdentifier(PrefHelper.NO_STRING_VALUE);
+        prefHelper.setInitialReferrer(PrefHelper.NO_STRING_VALUE);
         prefHelper.setExternalIntentUri(PrefHelper.NO_STRING_VALUE);
         prefHelper.setExternalIntentExtra(PrefHelper.NO_STRING_VALUE);
         prefHelper.setSessionParams(PrefHelper.NO_STRING_VALUE);


### PR DESCRIPTION

## Reference
[CORE-1951](https://branch.atlassian.net/browse/CORE-1951) -- Collect initial_referrer from Android SDK.

## Description
Added initial_referrer-> EXTRA_REFERRER to every OPEN/INSTALL session request.

## Testing Instructions
Step 1: Click on branch link from sms app 
Step 2: INSTALL/OPEN the app 
Step 3: Under logcat observe that v1/install or v1/open has new param called initial_referrer with the package name of referring app which is SMS app here(android-app:\/\/com.google.android.apps.messaging)
Step 4: Without click on any link try opening the app in which case EXTRA_REFERRER will be null and will have default value bnc_no_value



## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
