### PR TITLE
[INTENG-13319] IntegrationValidator should read value from String Resource

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/validators/BranchIntegrationModel.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/validators/BranchIntegrationModel.java
@@ -22,6 +22,7 @@ class BranchIntegrationModel {
     final List<String> applinkScheme;
     final String packageName;
     boolean appSettingsAvailable = false;
+    private Context context;
 
 
     public BranchIntegrationModel(Context context) {
@@ -29,7 +30,7 @@ class BranchIntegrationModel {
         ApplicationInfo appInfo;
         applinkScheme = new ArrayList<>();
         packageName = context.getPackageName();
-
+        this.context = context;
         try {
             appInfo = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
             if (appInfo.metaData != null) {
@@ -61,6 +62,17 @@ class BranchIntegrationModel {
                 }
             }
         }
+    }
+
+    //Function to get value from string resource
+    public String getStringResource(String stringWithIdValue){
+        if(stringWithIdValue.contains("resourceID")){
+            String resourceIdArr[] = stringWithIdValue.split(" ");
+            if(context!=null && resourceIdArr!=null && resourceIdArr.length==2){
+                return context.getResources().getString(Integer.parseInt(resourceIdArr[1].replace("0x",""),16));
+            }
+        }
+        return stringWithIdValue;
     }
 
     // Reading deep linked schemes involves decompressing of apk and parsing manifest. This can lead to a ANR if reading file is slower

--- a/Branch-SDK/src/main/java/io/branch/referral/validators/IntegrationValidator.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/validators/IntegrationValidator.java
@@ -198,7 +198,7 @@ public class IntegrationValidator implements ServerRequestGetAppConfig.IGetAppCo
                     JSONArray hosts = integrationModel.deeplinkUriScheme.optJSONArray(key);
                     if (hosts != null && hosts.length() > 0) {
                         for (int i = 0; i < hosts.length(); ++i) {
-                            if (uriPath != null && uriPath.equals(hosts.optString(i))) {
+                            if (uriPath != null && uriPath.equals(integrationModel.getStringResource(hosts.optString(i)))) {
                                 foundMatchingUri = true;
                                 break;
                             }
@@ -217,7 +217,7 @@ public class IntegrationValidator implements ServerRequestGetAppConfig.IGetAppCo
         boolean foundIntentFilterMatchingDomainName = false;
         if (!TextUtils.isEmpty(domainName) && integrationModel.applinkScheme != null) {
             for (String host : integrationModel.applinkScheme) {
-                if (domainName.equals(host)) {
+                if (domainName.equals(integrationModel.getStringResource(host))) {
                     foundIntentFilterMatchingDomainName = true;
                     break;
                 }


### PR DESCRIPTION


## Reference
[INTENG-13319](https://branch.atlassian.net/browse/INTENG-13319) String Resource not recognised by IntegrationValidator

## Description
When uri scheme or app.link are placed under string resource IntegrationValidator failed to validate integration, have made created helper function to fetch resource based on resource id and pass this value to the validator.

## Testing Instructions
Step 1: Go to the manifest file and replaace URI scheme/app links string to string resource id
Step 2: Under MainActivity->Enable validator  `IntegrationValidator.validate(MainActivity.this);`
Step 3: Observe that IntegrationValidator should pass URI/app link test


## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
