### PR TITLE
[CORE-2294] Handled NPE while fetching initialReferrer

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2873,7 +2873,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             Activity activity = branch.getCurrentActivity();
             Intent intent = activity != null ? activity.getIntent() : null;
 
-            if (ActivityCompat.getReferrer(activity) != null) {
+            if (activity != null && ActivityCompat.getReferrer(activity) != null) {
                 PrefHelper.getInstance(activity).setInitialReferrer(ActivityCompat.getReferrer(activity).toString());
             }
 


### PR DESCRIPTION
## Reference
CORE-2294 -- Android - NPE in install referrer code, 5.0.10

## Description
While we fetch InitialReferrer we make use of activity instance at some point there was chances that activity can be null which lead to NPE error. Have updated the validation for the null check.

## Testing Instructions
There is no concrete step to reproduce the issue as this is occurring during run time. 

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
