### PR TITLE
INTENG-13599 - Return to the main thread to kick off the next queue item

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2302,7 +2302,16 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             }
             networkCount_ = 0;
 
-            processNextQueueItem();
+            // In rare cases where this method is called directly (eg. when network calls time out),
+            // starting the next queue item can lead to stack over flow. Ensuring that this is
+            // queued back to the main thread mitigates this.
+            Handler handler = new Handler(Looper.getMainLooper());
+            handler.post(new Runnable() {
+                @Override
+                public void run() {
+                    processNextQueueItem();
+                }
+            });
         }
 
         private void onRequestSuccess(ServerResponse serverResponse) {


### PR DESCRIPTION
In rare cases where this method is called directly (eg. when network calls time out), starting the next queue item can lead to stack over flow. Ensuring that this is queued back to the main thread mitigates this.

## Reference
INTENG-13599
Hibobi | App crashes due to Stackoverflow error

## Description
What makes this an edge case is that the process (thread) that is processing the queue needs to be different than the main thread AND have its own Looper attached. Even then, it is only an issue when events (network calls) TIMES OUT. If an event does NOT time out, this issue does not occur. The reason for this is the way the Branch SDK was designed. If the async task (BranchPostTask) completes, the post-execute methods both run on the async thread. If they fail, the calling process runs one of the post-execute methods on its own thread (thus, adding to the call stack) which then recursively calls itself again. Again, this only happens when the async task times out.

## Testing Instructions
1. Change the ServerRequestQueue to allow more than 25 queued up events.
2. Kick of an event in a new thread that has its own Android Looper
3. Spam the event queue until stack over flow occurs
4. Update Branch object with the fix
5. Repeat step 3, stack over flow should no longer occur

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.
Note: 1 test fails, but was previously failing prior to this change: testStandardEvent_hasGAIDv2()

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
