### PR TITLE
CORE-2433 - String Resource not recognized by IntegrationValidator

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/ApkParser.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ApkParser.java
@@ -123,7 +123,7 @@ class ApkParser {
 
                         attrName = compXmlString(xml, sitOff, stOff, attrNameSi);
                         if ("scheme".equals(attrName)) {
-                            attrValue = attrValueSi != -1 ? compXmlString(xml, sitOff, stOff, attrValueSi) : "resourceID 0x" + Integer.toHexString(attrResId);
+                            attrValue = attrValueSi != -1 ? compXmlString(xml, sitOff, stOff, attrValueSi) : BranchUtil.encodeResourceId(attrResId);
                             if (validURI(attrValue)) {
                                 scheme = attrValue;
                                 if (!intentFilters.has(scheme)) {
@@ -142,7 +142,7 @@ class ApkParser {
                                 scheme = attrValue;
                             }
                         } else if ("host".equals(attrName)) {
-                            attrValue = attrValueSi != -1 ? compXmlString(xml, sitOff, stOff, attrValueSi) : "resourceID 0x" + Integer.toHexString(attrResId);
+                            attrValue = attrValueSi != -1 ? compXmlString(xml, sitOff, stOff, attrValueSi) : BranchUtil.encodeResourceId(attrResId);
                             JSONArray domainList;
                             if (intentFilters.has(scheme) && scheme != null
                                     && !"https".equals(scheme) && !"http".equals(scheme)) {
@@ -159,7 +159,7 @@ class ApkParser {
                             }
                         } else if ("name".equals(attrName)) {
                             //reset the scheme name
-                            attrValue = attrValueSi != -1 ? compXmlString(xml, sitOff, stOff, attrValueSi) : "resourceID 0x" + Integer.toHexString(attrResId);
+                            attrValue = attrValueSi != -1 ? compXmlString(xml, sitOff, stOff, attrValueSi) : BranchUtil.encodeResourceId(attrResId);
                             if ("android.intent.action.VIEW".equals(attrValue)) {
                                 scheme = null;
                             }

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
 import java.util.jar.JarFile;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Class for Branch utility methods
@@ -156,6 +158,56 @@ public class BranchUtil {
             e.printStackTrace();
         }
         return params;
+    }
+
+    /**
+     * Encodes resource identifier for passing around in json. Use {@link #decodeResourceId} to convert back to int.
+     *
+     * @param resourceId integer value to be encoded
+     * @return human readable string value converted to hex
+     */
+    public static String encodeResourceId(int resourceId) {
+        return "resourceID 0x" + Integer.toHexString(resourceId);
+    }
+
+    /**
+     * Reverse an encoded resource id from string back to int (from {@link #encodeResourceId}).
+     *
+     * @param value string encoded originally with encodeResourceId
+     * @return integer value of the resourceId
+     */
+    public static int decodeResourceId(String value) {
+        try {
+            Matcher matcher = Pattern.compile("resourceID 0x([a-fA-F0-9]+)").matcher(value);
+            if (matcher.find()) {
+                // Group 0 is the entire match, group 1 is the first matched pattern (inside the parentheses)
+                // We need to use Long.parseLong because Integer.toHexString is unsigned.
+                return (int) Long.parseLong(matcher.group(1), 16);
+            }
+        }
+        catch (Exception ignored) { }
+        return -1;
+    }
+
+    /**
+     * Renames a key of a child element in jsonObject from findKey to replaceKey in-place.
+     *
+     * @param jsonObject    json object containing the element to rename
+     * @param findKey       element name to be replaced
+     * @param replaceKey    the new name for the element
+     */
+    public static void replaceJsonKey(JSONObject jsonObject, String findKey, String replaceKey) {
+        Object findObj = jsonObject.opt(findKey);
+        Object replaceObj = jsonObject.opt(replaceKey);
+        if(findObj != null && replaceObj == null && !findKey.equals(replaceKey)) {
+            try {
+                jsonObject.putOpt(replaceKey, findObj);
+            } catch (JSONException e) {
+                // If there was a problem, don't do the remove.
+                return;
+            }
+            jsonObject.remove(findKey);
+        }
     }
 
     public static class JsonReader {

--- a/Branch-SDK/src/main/java/io/branch/referral/validators/BranchIntegrationModel.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/validators/BranchIntegrationModel.java
@@ -8,6 +8,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -54,13 +55,30 @@ class BranchIntegrationModel {
         } catch (Exception ignored) { }
         if (obj != null) {
             deeplinkUriScheme = obj.optJSONObject(Defines.Jsonkey.URIScheme.getKey());
+            for (Iterator<String> it = deeplinkUriScheme.keys(); it.hasNext(); ) {
+                String key = it.next();
+                BranchUtil.replaceJsonKey(deeplinkUriScheme, key, decodeResourceString(context, key));
+            }
             JSONArray hostArray = obj.optJSONArray(Defines.Jsonkey.AppLinks.getKey());
             if (hostArray != null) {
                 for (int i = 0; i < hostArray.length(); i++) {
-                    applinkScheme.add(hostArray.optString(i));
+                    applinkScheme.add(decodeResourceString(context, hostArray.optString(i)));
                 }
             }
         }
+    }
+
+    // In ApkParser, resource pointers are returned as `resourceID 0x00000000`.
+    // This will attempt to decode them.
+    private String decodeResourceString(Context context, String value) {
+        try {
+            int resourceId = BranchUtil.decodeResourceId(value);
+            if (resourceId != -1) {
+                return context.getResources().getString(resourceId);
+            }
+        }
+        catch (Exception ignored) { }
+        return value;
     }
 
     // Reading deep linked schemes involves decompressing of apk and parsing manifest. This can lead to a ANR if reading file is slower

--- a/Branch-SDK/src/test/java/io/branch/referral/BranchUtilTest.java
+++ b/Branch-SDK/src/test/java/io/branch/referral/BranchUtilTest.java
@@ -1,0 +1,102 @@
+package io.branch.referral;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class BranchUtilTest {
+
+    private final int[] resourceIds = new int[]{
+            0,
+            1,
+            32,
+            323429,
+            Integer.MAX_VALUE,
+            -1,
+            -50,
+            -476063,
+            Integer.MIN_VALUE
+    };
+
+    private final String[] encodedIds = new String[]{
+            "resourceID 0x0",
+            "resourceID 0x1",
+            "resourceID 0x20",
+            "resourceID 0x4ef65",
+            "resourceID 0x7fffffff",
+            "resourceID 0xffffffff",
+            "resourceID 0xffffffce",
+            "resourceID 0xfff8bc61",
+            "resourceID 0x80000000"
+    };
+
+    private final String[] replacePositiveJsonTests = new String[] {
+            //positive test cases
+            "{ \"field\": 1 }",
+            "{ \"field\": \"two\" }",
+            "{ \"field\": [] }",
+            "{ \"field\": [ 1, 2, \"three\", 4.0 ] }",
+            "{ \"field\": { \"field\": 5 } }",
+    };
+
+    private final String[] replaceNegativeJsonTests = new String[] {
+            "{}",
+            "{ \"replaced\": 0 }",
+            "{ \"field\": 1, \"replaced\": 2 }",
+            "{ \"field\": \"two\", \"replaced\": \"four\" }",
+            "{ \"field\": [], \"replaced\": [] }",
+            "{ \"field\": [ 1, 2, \"three\", 4.0 ], \"replaced\": [ 5, 6, \"seven\", 8.0 ] }",
+            "{ \"field\": { \"field\": 5 }, \"replaced\": { \"field\": 6 } }"
+    };
+
+    @Test
+    public void testEncodeResourceId() {
+        for (int i = 0; i < resourceIds.length; i++) {
+            Assert.assertEquals(encodedIds[i], BranchUtil.encodeResourceId(resourceIds[i]));
+        }
+    }
+
+    @Test
+    public void testDecodeResourceId() {
+        Assert.assertEquals(resourceIds[6], BranchUtil.decodeResourceId(encodedIds[6]));
+        for (int i = 0; i < encodedIds.length; i++) {
+            Assert.assertEquals(resourceIds[i], BranchUtil.decodeResourceId(encodedIds[i]));
+        }
+    }
+
+    @Test
+    public void testReplaceJsonKey() {
+        // Run all positive tests, verify that the old field is gone and new field is there and the value is retained
+        for (String replacePositiveJsonTest : replacePositiveJsonTests) {
+            try {
+                JSONObject jsonObject = new JSONObject(replacePositiveJsonTest);
+                Object value = jsonObject.opt("field");
+                Assert.assertNotNull(value);
+                Assert.assertNull(jsonObject.optJSONObject("replaced"));
+                BranchUtil.replaceJsonKey(jsonObject, "field", "replaced");
+                Assert.assertNull(jsonObject.opt("field"));
+                Assert.assertEquals(value, jsonObject.opt("replaced"));
+            } catch (JSONException e) {
+                e.printStackTrace();
+                Assert.fail();
+            }
+        }
+
+        // Run all negative tests, verify that the original json document is unchanged
+        for (String replaceNegativeJsonTest : replaceNegativeJsonTests) {
+            try {
+                JSONObject jsonObject1 = new JSONObject(replaceNegativeJsonTest);
+                JSONObject jsonObject2 = new JSONObject(replaceNegativeJsonTest);
+                BranchUtil.replaceJsonKey(jsonObject2, "field", "replaced");
+                Assert.assertEquals(jsonObject1.toString(), jsonObject2.toString());
+            } catch (JSONException e) {
+                e.printStackTrace();
+                Assert.fail();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Refactor the way ApkParser encodes resource ids and fix BranchIntegrationModel to property decode resource strings for scheme and applinks.

## Reference
CORE-2433 - [AndroidManifest] String Resource not recognized by IntegrationValidator

## Description
GitHub Issue #915

When using a string resource to define the custom scheme in the AndroidManifest.xml file (e.g. @string/custom_scheme). The IntegrationValidator doesn't recognize the setup correctly, as it doesn't resolve the actual associated resource, it only tries to compare the expected path with the id.

This caused quite some confusion on my end, as the custom scheme was validated to be working, yet branch refused to pass this integration test. Supporting string resources is especially useful when managing multiple app flavors.

## Testing Instructions
Repro steps:

1. Invoke IntegrationValidator.validate(this) within launcher activity (it should pass through 10 steps)
2. Change AndroidManifest.xml, move intent scheme to string resource: 
```
<!-- Branch URI Scheme -->
<intent-filter>
    <data
        android:host="open"
        android:scheme="@string/custom_scheme" />
    <action android:name="android.intent.action.VIEW" />

    <category android:name="android.intent.category.DEFAULT" />
    <category android:name="android.intent.category.BROWSABLE" />
</intent-filter>
```
3. Repeat step 1, note the following. (It should continue to pass through 10 steps.)
```
... snip ...
2021-09-30 14:03:28.893 17026-17026/com.example.helloworld D/BranchSDK_Doctor: 3. Verifying application package name ... 
2021-09-30 14:03:28.893 17026-17026/com.example.helloworld D/BranchSDK_Doctor: Passed
2021-09-30 14:03:28.893 17026-17026/com.example.helloworld D/BranchSDK_Doctor: 4. Checking Android Manifest for URI based deep link config ... 
2021-09-30 14:03:28.894 17026-17026/com.example.helloworld D/BranchSDK_Doctor: Passed
2021-09-30 14:03:28.894 17026-17026/com.example.helloworld D/BranchSDK_Doctor: 5. Verifying URI based deep link config with Branch dash board. ... 
2021-09-30 14:03:28.894 17026-17026/com.example.helloworld D/BranchSDK_Doctor: Passed
2021-09-30 14:03:28.894 17026-17026/com.example.helloworld D/BranchSDK_Doctor: 6. Verifying intent for receiving URI scheme. ... 
2021-09-30 14:03:28.895 17026-17026/com.example.helloworld D/BranchSDK_Doctor: Passed
2021-09-30 14:03:28.895 17026-17026/com.example.helloworld D/BranchSDK_Doctor: 7. Checking AndroidManifest for AppLink config. ... 
2021-09-30 14:03:28.895 17026-17026/com.example.helloworld D/BranchSDK_Doctor: Passed
2021-09-30 14:03:28.895 17026-17026/com.example.helloworld D/BranchSDK_Doctor: 8. Verifying any supported custom link domains. ... 
2021-09-30 14:03:28.895 17026-17026/com.example.helloworld D/BranchSDK_Doctor: Passed
2021-09-30 14:03:28.896 17026-17026/com.example.helloworld D/BranchSDK_Doctor: 9. Verifying default link domains integrations. ... 
2021-09-30 14:03:28.896 17026-17026/com.example.helloworld D/BranchSDK_Doctor: Passed
2021-09-30 14:03:28.896 17026-17026/com.example.helloworld D/BranchSDK_Doctor: 10. Verifying alternate link domains integrations. ... 
2021-09-30 14:03:28.896 17026-17026/com.example.helloworld D/BranchSDK_Doctor: Passed
2021-09-30 14:03:28.896 17026-17026/com.example.helloworld D/BranchSDK_Doctor: Passed
2021-09-30 14:03:28.896 17026-17026/com.example.helloworld D/BranchSDK_Doctor: --------------------------------------------
    Successfully completed Branch integration validation. Everything looks good!
```


## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
