### PR TITLE
CORE-2447 - Crash on start with liveKey / testKey / useTestInstance in branch.json

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/BranchJsonConfig.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchJsonConfig.java
@@ -158,7 +158,7 @@ public class BranchJsonConfig {
     }
 
     public @Nullable Boolean getUseTestInstance() {
-        if (isValid(BranchJsonKey.useTestInstance)) return null;
+        if (!isValid(BranchJsonKey.useTestInstance)) return null;
 
         try {
             return mConfiguration.getBoolean(BranchJsonKey.useTestInstance.toString());


### PR DESCRIPTION
Validation logic for "useTestInstance" was backwards.

## Reference
CORE-2447 - Crash on start with liveKey / testKey / useTestInstance in branch.json
GitHub Issue: #912 

## Description
The logic around useTestInstance has a bug. The getUseTestInstance() returns null and the return type is Boolean, so can't be unboxed in the conditional.

## Testing Instructions

1. Add /assets/branch.json file and populate as follows:
```
{
  //Note: Omit "branckKey" value, as this will bypass the bug
  "testKey":"key_test_XXXXXXXXXXXXXXXXXXXXXXXXX", //substitute with app's value
  "liveKey":"key_live_YYYYYYYYYYYYYYYYYYYYYYYYY", //substitute with app's value
  "useTestInstance": true //or false, the actual value doesn't matter
}
```
2. Launch app, note crash
3. Update SDK changes from this PR
4. Launch app, note it doesn't crash

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
