### PR TITLE
CORE-2446 - Improper Resource Shutdown or Release

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
@@ -227,7 +227,13 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
         if (inputStream != null) {
             BufferedReader rd = new BufferedReader(new InputStreamReader(inputStream));
             try {
-                responseString = rd.readLine();
+                StringBuilder sb = new StringBuilder();
+                String line;
+                while ((line = rd.readLine()) != null) {
+                    sb.append(line);
+                }
+                rd.close();
+                responseString = sb.toString();
             } catch (IOException ignore) {
             }
         }


### PR DESCRIPTION
BufferedReader needs to be closed. Also fixed a bug where it was only reading the first line of the response. This would result in JSONException if the response was split across multiple lines.

## Reference
CORE-2446 - Improper Resource Shutdown or Release

## Description
Issue with BufferedReader identified in BranchRemoteInterfaceUrlConnection.java lines 225-237.
See: https://cwe.mitre.org/data/definitions/404.html

## Testing Instructions
Added a breakpoint and verified that the resource was closed. For the readline issue, calling an endpoint that responds on multiple lines is required. v1/credithistory is one:

<img width="1049" alt="Screen Shot 2021-10-05 at 4 07 05 PM" src="https://user-images.githubusercontent.com/90417909/136116498-dbc95cb4-ad29-4fe0-b8f5-b27a51e13d7a.png">

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
