### PR TITLE
Resolve Timeout Issues

### DIFF
--- a/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
@@ -4,20 +4,27 @@ import android.content.Context;
 import android.os.Build;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class PrefHelperTest extends BranchTest {
+    Context context;
+    PrefHelper prefHelper;
 
     void assertDefaultURL() {
-        Context context = getTestContext();
-        PrefHelper helper = PrefHelper.getInstance(context);
-        String actual = helper.getAPIBaseUrl();
+        String actual = prefHelper.getAPIBaseUrl();
 
         if (Build.VERSION.SDK_INT >= 20) {
             Assert.assertEquals(PrefHelper.BRANCH_BASE_URL_V2, actual);
         } else {
             Assert.assertEquals(PrefHelper.BRANCH_BASE_URL_V1, actual);
         }
+    }
+
+    @Before
+    public void init(){
+        context = getTestContext();
+        prefHelper = PrefHelper.getInstance(context);
     }
 
     @Test
@@ -28,10 +35,7 @@ public class PrefHelperTest extends BranchTest {
     @Test
     public void testSetAPIUrl_Example() {
         PrefHelper.setAPIUrl("https://www.example.com/");
-
-        Context context = getTestContext();
-        PrefHelper helper = PrefHelper.getInstance(context);
-        String actual = helper.getAPIBaseUrl();
+        String actual = prefHelper.getAPIBaseUrl();
         Assert.assertEquals("https://www.example.com/", actual);
     }
 
@@ -55,8 +59,6 @@ public class PrefHelperTest extends BranchTest {
 
     @Test
     public void testSetAdNetworkCalloutsDisabled() {
-        Context context = getTestContext();
-        PrefHelper prefHelper = PrefHelper.getInstance(context);
         prefHelper.setAdNetworkCalloutsDisabled(true);
 
         Assert.assertTrue(prefHelper.getAdNetworkCalloutsDisabled());
@@ -64,10 +66,35 @@ public class PrefHelperTest extends BranchTest {
 
     @Test
     public void testSetAdNetworkCalloutsEnabled() {
-        Context context = getTestContext();
-        PrefHelper prefHelper = PrefHelper.getInstance(context);
         prefHelper.setAdNetworkCalloutsDisabled(false);
 
         Assert.assertFalse(prefHelper.getAdNetworkCalloutsDisabled());
+    }
+
+    @Test
+    public void testSetTimeout(){
+        int TEST_TIMEOUT = 1;
+        prefHelper.setTimeout(TEST_TIMEOUT);
+
+        int result = prefHelper.getTimeout();
+        Assert.assertEquals(TEST_TIMEOUT, result);
+    }
+
+    @Test
+    public void testSetConnectTimeout(){
+        int TEST_CONNECT_TIMEOUT = 2;
+        prefHelper.setConnectTimeout(TEST_CONNECT_TIMEOUT);
+
+        int result = prefHelper.getConnectTimeout();
+        Assert.assertEquals(TEST_CONNECT_TIMEOUT, result);
+    }
+
+    @Test
+    public void testSetTaskTimeout(){
+        int TEST_TASK_TIMEOUT = 3;
+        prefHelper.setTaskTimeout(TEST_TASK_TIMEOUT);
+
+        int result = prefHelper.getTaskTimeout();
+        Assert.assertEquals(TEST_TASK_TIMEOUT, result);
     }
 }

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
@@ -91,10 +91,14 @@ public class PrefHelperTest extends BranchTest {
 
     @Test
     public void testSetTaskTimeout(){
-        int TEST_TASK_TIMEOUT = 3;
-        prefHelper.setTaskTimeout(TEST_TASK_TIMEOUT);
+        int TEST_TIMEOUT = 3;
+        int TEST_CONNECT_TIMEOUT = 4;
+
+        prefHelper.setTimeout(TEST_TIMEOUT);
+        prefHelper.setConnectTimeout(TEST_CONNECT_TIMEOUT);
+
 
         int result = prefHelper.getTaskTimeout();
-        Assert.assertEquals(TEST_TASK_TIMEOUT, result);
+        Assert.assertEquals(TEST_TIMEOUT + TEST_CONNECT_TIMEOUT, result);
     }
 }

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/ServerRequestTests.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/ServerRequestTests.java
@@ -1,8 +1,5 @@
 package io.branch.referral;
 
-import android.os.Handler;
-
-import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.json.JSONArray;
@@ -18,7 +15,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import io.branch.indexing.BranchUniversalObject;
-import io.branch.referral.mock.MockActivity;
 import io.branch.referral.util.BranchCPID;
 import io.branch.referral.util.ContentMetadata;
 import io.branch.referral.util.LinkProperties;
@@ -33,13 +29,13 @@ public class ServerRequestTests extends BranchTest {
     }
     @After
     public void tearDown() throws InterruptedException {
-        branch.setNetworkTimeout(PrefHelper.TIMEOUT);
+        setTimeouts(PrefHelper.TIMEOUT, PrefHelper.CONNECT_TIMEOUT, PrefHelper.TASK_TIMEOUT);
         super.tearDown();
     }
 
     @Test
     public void testTimedOutInitSessionCallbackInvoked() throws InterruptedException {
-        branch.setNetworkTimeout(10);// forces timeouts
+        setTimeouts(10,10,10000);
         initSessionResumeActivity(null, new Runnable() {
             @Override
             public void run() {
@@ -54,7 +50,7 @@ public class ServerRequestTests extends BranchTest {
         initSessionResumeActivity(null, new Runnable() {
             @Override
             public void run() {
-                branch.setNetworkTimeout(10);// forces timeouts
+                setTimeouts(10,10,10);
 
                 final CountDownLatch lock = new CountDownLatch(1);
                 branch.getCrossPlatformIds(new ServerRequestGetCPID.BranchCrossPlatformIdListener() {
@@ -63,7 +59,7 @@ public class ServerRequestTests extends BranchTest {
                         PrefHelper.Debug("branchCPID = " + branchCPID + ", error: " + error);
                         lock.countDown();
                         Assert.assertNotNull(error);
-                        Assert.assertEquals(BranchError.ERR_BRANCH_REQ_TIMED_OUT, error.getErrorCode());
+                        Assert.assertEquals(BranchError.ERR_BRANCH_TASK_TIMEOUT, error.getErrorCode());
                     }
                 });
                 try {
@@ -80,13 +76,13 @@ public class ServerRequestTests extends BranchTest {
         initSessionResumeActivity(null, new Runnable() {
             @Override
             public void run() {
-                branch.setNetworkTimeout(10);// forces timeouts
+                setTimeouts(10,10,10);
 
                 final CountDownLatch lock1 = new CountDownLatch(1);
                 Branch.getInstance().getLastAttributedTouchData(new ServerRequestGetLATD.BranchLastAttributedTouchDataListener() {
                     @Override
                     public void onDataFetched(JSONObject jsonObject, BranchError error) {
-                        Assert.assertEquals(BranchError.ERR_BRANCH_REQ_TIMED_OUT, error.getErrorCode());
+                        Assert.assertEquals(BranchError.ERR_BRANCH_TASK_TIMEOUT, error.getErrorCode());
                         lock1.countDown();
                     }
                 });
@@ -105,13 +101,13 @@ public class ServerRequestTests extends BranchTest {
         initSessionResumeActivity(null, new Runnable() {
             @Override
             public void run() {
-                branch.setNetworkTimeout(10);// forces timeouts
+                setTimeouts(10,10,10);
 
                 final CountDownLatch lock2 = new CountDownLatch(1);
                 Branch.getInstance().getCreditHistory(new Branch.BranchListResponseListener() {
                     @Override
                     public void onReceivingResponse(JSONArray list, BranchError error) {
-                        Assert.assertEquals(BranchError.ERR_BRANCH_REQ_TIMED_OUT, error.getErrorCode());
+                        Assert.assertEquals(BranchError.ERR_BRANCH_TASK_TIMEOUT, error.getErrorCode());
                         lock2.countDown();
                     }
                 });
@@ -129,7 +125,7 @@ public class ServerRequestTests extends BranchTest {
         initSessionResumeActivity(null, new Runnable() {
             @Override
             public void run() {
-                branch.setNetworkTimeout(10);// forces timeouts
+                setTimeouts(10,10,10);
 
                 final CountDownLatch lock3 = new CountDownLatch(1);
                 BranchUniversalObject buo = new BranchUniversalObject()
@@ -152,7 +148,8 @@ public class ServerRequestTests extends BranchTest {
                 buo.generateShortUrl(getTestContext(), linkProperties, new Branch.BranchLinkCreateListener() {
                     @Override
                     public void onLinkCreate(String url, BranchError error) {
-                        Assert.assertEquals(BranchError.ERR_BRANCH_REQ_TIMED_OUT, error.getErrorCode());
+                        PrefHelper.Debug("error is " + error);
+                        Assert.assertEquals(BranchError.ERR_BRANCH_TASK_TIMEOUT, error.getErrorCode());
                         lock3.countDown();
                     }
                 });
@@ -163,5 +160,11 @@ public class ServerRequestTests extends BranchTest {
                 }
             }
         });
+    }
+
+    private void setTimeouts(int timeout, int connectTimeout, int taskTimeout){
+        branch.setNetworkTimeout(timeout);
+        branch.setNetworkConnectTimeout(connectTimeout);
+        branch.setTaskTimeout(taskTimeout);
     }
 }

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/ServerRequestTests.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/ServerRequestTests.java
@@ -29,13 +29,13 @@ public class ServerRequestTests extends BranchTest {
     }
     @After
     public void tearDown() throws InterruptedException {
-        setTimeouts(PrefHelper.TIMEOUT, PrefHelper.CONNECT_TIMEOUT, PrefHelper.TASK_TIMEOUT);
+        setTimeouts(PrefHelper.TIMEOUT, PrefHelper.CONNECT_TIMEOUT);
         super.tearDown();
     }
 
     @Test
     public void testTimedOutInitSessionCallbackInvoked() throws InterruptedException {
-        setTimeouts(10,10,10000);
+        setTimeouts(10,10000);
         initSessionResumeActivity(null, new Runnable() {
             @Override
             public void run() {
@@ -50,7 +50,7 @@ public class ServerRequestTests extends BranchTest {
         initSessionResumeActivity(null, new Runnable() {
             @Override
             public void run() {
-                setTimeouts(10,10,10);
+                setTimeouts(10,10);
 
                 final CountDownLatch lock = new CountDownLatch(1);
                 branch.getCrossPlatformIds(new ServerRequestGetCPID.BranchCrossPlatformIdListener() {
@@ -76,7 +76,7 @@ public class ServerRequestTests extends BranchTest {
         initSessionResumeActivity(null, new Runnable() {
             @Override
             public void run() {
-                setTimeouts(10,10,10);
+                setTimeouts(10,10);
 
                 final CountDownLatch lock1 = new CountDownLatch(1);
                 Branch.getInstance().getLastAttributedTouchData(new ServerRequestGetLATD.BranchLastAttributedTouchDataListener() {
@@ -101,7 +101,7 @@ public class ServerRequestTests extends BranchTest {
         initSessionResumeActivity(null, new Runnable() {
             @Override
             public void run() {
-                setTimeouts(10,10,10);
+                setTimeouts(10,10);
 
                 final CountDownLatch lock2 = new CountDownLatch(1);
                 Branch.getInstance().getCreditHistory(new Branch.BranchListResponseListener() {
@@ -125,7 +125,7 @@ public class ServerRequestTests extends BranchTest {
         initSessionResumeActivity(null, new Runnable() {
             @Override
             public void run() {
-                setTimeouts(10,10,10);
+                setTimeouts(10,10);
 
                 final CountDownLatch lock3 = new CountDownLatch(1);
                 BranchUniversalObject buo = new BranchUniversalObject()
@@ -162,9 +162,8 @@ public class ServerRequestTests extends BranchTest {
         });
     }
 
-    private void setTimeouts(int timeout, int connectTimeout, int taskTimeout){
+    private void setTimeouts(int timeout, int connectTimeout){
         branch.setNetworkTimeout(timeout);
         branch.setNetworkConnectTimeout(connectTimeout);
-        branch.setTaskTimeout(taskTimeout);
     }
 }

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/mock/MockRemoteInterface.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/mock/MockRemoteInterface.java
@@ -20,6 +20,7 @@ import static io.branch.referral.Defines.RequestPath.RegisterOpen;
 public class MockRemoteInterface extends BranchRemoteInterface {
     private final static String TAG = "MockRemoteInterface";
 
+    // TODO: Revisit with MockWebServer and mock out different response codes
     // since most tests use TEST_TIMEOUT to await network requests, lower it here, so TEST_TIMEOUT
     // ends up including a little bit of a buffer for scheduling network requests.
     private final long networkRequestDuration = BranchTest.TEST_REQUEST_TIMEOUT / 2;

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -721,18 +721,6 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             prefHelper_.setConnectTimeout(connectTimeout);
         }
     }
-
-    /**
-     * <p>Sets the duration in milliseconds that the system should wait for tasks to complete</p>
-     *
-     * @param taskTimeout An {@link Integer} value specifying the number of milliseconds to wait before
-     *                considering the task to have timed out.
-     */
-    public void setTaskTimeout(int taskTimeout) {
-        if (prefHelper_ != null && taskTimeout > 0) {
-            prefHelper_.setTaskTimeout(taskTimeout);
-        }
-    }
     
     /**
      * Method to control reading Android ID from device. Set this to true to disable reading the device id.

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -707,6 +707,20 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             prefHelper_.setTimeout(timeout);
         }
     }
+
+    // TODO: Test
+    /**
+     * <p>Sets the duration in milliseconds that the system should wait for initializing a network
+     * * request.</p>
+     *
+     * @param connectTimeout An {@link Integer} value specifying the number of milliseconds to wait before
+     *                considering the initialization to have timed out.
+     */
+    public void setNetworkConnectTimeout(int connectTimeout) {
+        if (prefHelper_ != null && connectTimeout > 0) {
+            prefHelper_.setConnectTimeout(connectTimeout);
+        }
+    }
     
     /**
      * Method to control reading Android ID from device. Set this to true to disable reading the device id.

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1,6 +1,7 @@
 package io.branch.referral;
 
 import static io.branch.referral.BranchError.ERR_BRANCH_REQ_TIMED_OUT;
+import static io.branch.referral.BranchError.ERR_BRANCH_TASK_TIMEOUT;
 import static io.branch.referral.BranchError.ERR_IMPROPER_REINITIALIZATION;
 import static io.branch.referral.BranchPreinstall.getPreinstallSystemData;
 import static io.branch.referral.BranchUtil.isTestModeEnabled;
@@ -708,7 +709,6 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         }
     }
 
-    // TODO: Test
     /**
      * <p>Sets the duration in milliseconds that the system should wait for initializing a network
      * * request.</p>
@@ -722,7 +722,6 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         }
     }
 
-    // TODO: Test
     /**
      * <p>Sets the duration in milliseconds that the system should wait for tasks to complete</p>
      *
@@ -1729,11 +1728,11 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         try {
             if (!latch.await(timeout, TimeUnit.MILLISECONDS)) {
                 postTask.cancel(true);
-                postTask.onPostExecuteInner(new ServerResponse(postTask.thisReq_.getRequestPath(), ERR_BRANCH_REQ_TIMED_OUT, ""));
+                postTask.onPostExecuteInner(new ServerResponse(postTask.thisReq_.getRequestPath(), ERR_BRANCH_TASK_TIMEOUT, ""));
             }
         } catch (InterruptedException e) {
             postTask.cancel(true);
-            postTask.onPostExecuteInner(new ServerResponse(postTask.thisReq_.getRequestPath(), ERR_BRANCH_REQ_TIMED_OUT, ""));
+            postTask.onPostExecuteInner(new ServerResponse(postTask.thisReq_.getRequestPath(), ERR_BRANCH_TASK_TIMEOUT, ""));
         }
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -721,6 +721,19 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             prefHelper_.setConnectTimeout(connectTimeout);
         }
     }
+
+    // TODO: Test
+    /**
+     * <p>Sets the duration in milliseconds that the system should wait for tasks to complete</p>
+     *
+     * @param taskTimeout An {@link Integer} value specifying the number of milliseconds to wait before
+     *                considering the task to have timed out.
+     */
+    public void setTaskTimeout(int taskTimeout) {
+        if (prefHelper_ != null && taskTimeout > 0) {
+            prefHelper_.setTaskTimeout(taskTimeout);
+        }
+    }
     
     /**
      * Method to control reading Android ID from device. Set this to true to disable reading the device id.
@@ -1680,7 +1693,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                             networkCount_ = 0;
                             req.handleFailure(BranchError.ERR_NO_SESSION, "");
                         } else {
-                            executeTimedBranchPostTask(req, prefHelper_.getTimeout());
+                            executeTimedBranchPostTask(req, prefHelper_.getTaskTimeout());
                         }
                     } else {
                         networkCount_ = 0;

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchError.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchError.java
@@ -46,8 +46,8 @@ public class BranchError {
     public static final int ERR_BRANCH_ALREADY_INITIALIZED = -118;
     /* Reinitializing session without the flag, IntentKey.ForceNewBranchSession */
     public static final int ERR_IMPROPER_REINITIALIZATION = -119;
-    /* Request thread timed out before contacting Branch servers */
-    public static final int ERR_BRANCH_THREAD_TIMEOUT = -120;
+    /* Request task timed out before completing*/
+    public static final int ERR_BRANCH_TASK_TIMEOUT = -120;
 
     /**
      * <p>Returns the message explaining the error.</p>

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchError.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchError.java
@@ -150,6 +150,9 @@ public class BranchError {
         } else if (statusCode == ERR_IMPROPER_REINITIALIZATION) {
             errorCode_ = ERR_IMPROPER_REINITIALIZATION;
             errMsg = "Intra-app linking (i.e. session reinitialization) requires an intent flag, \"branch_force_new_session\".";
+        } else if (statusCode == ERR_BRANCH_TASK_TIMEOUT) {
+            errorCode_ = ERR_BRANCH_TASK_TIMEOUT;
+            errMsg = " Task exceeded timeout.";
         } else {
             errorCode_ = ERR_BRANCH_NO_CONNECTIVITY;
             errMsg = " Check network connectivity and that you properly initialized.";

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchError.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchError.java
@@ -46,7 +46,9 @@ public class BranchError {
     public static final int ERR_BRANCH_ALREADY_INITIALIZED = -118;
     /* Reinitializing session without the flag, IntentKey.ForceNewBranchSession */
     public static final int ERR_IMPROPER_REINITIALIZATION = -119;
-    
+    /* Request thread timed out before contacting Branch servers */
+    public static final int ERR_BRANCH_THREAD_TIMEOUT = -120;
+
     /**
      * <p>Returns the message explaining the error.</p>
      *

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -54,7 +54,8 @@ public class PrefHelper {
      */
     private static final int MAX_RETRIES = 3; // Default retry count is 3
 
-    static final int TIMEOUT = 5500; // Default timeout id 5.5 sec
+    static final int TIMEOUT = 5500; // Default timeout is 5.5 sec
+    static final int CONNECT_TIMEOUT = 1000; // Default timeout is 10 seconds
 
     private static final String SHARED_PREF_FILE = "branch_referral_shared_pref";
     
@@ -87,7 +88,8 @@ public class PrefHelper {
     private static final String KEY_RETRY_COUNT = "bnc_retry_count";
     private static final String KEY_RETRY_INTERVAL = "bnc_retry_interval";
     private static final String KEY_TIMEOUT = "bnc_timeout";
-    
+    private static final String KEY_CONNECT_TIMEOUT = "bnc_connect_timeout";
+
     private static final String KEY_LAST_READ_SYSTEM = "bnc_system_read_date";
     
     private static final String KEY_EXTERNAL_INTENT_URI = "bnc_external_intent_uri";
@@ -265,6 +267,27 @@ public class PrefHelper {
      */
     public int getTimeout() {
         return getInteger(KEY_TIMEOUT, TIMEOUT);
+    }
+
+    /**
+     * <p>Sets the duration in milliseconds to override the timeout value for initiating requests.</p>
+     *
+     * @param connectTimeout The {@link Integer} value of the connect timeout setting in milliseconds.
+     */
+    public void setConnectTimeout(int connectTimeout) {
+        setInteger(KEY_CONNECT_TIMEOUT, connectTimeout);
+    }
+
+
+    /**
+     * <p>Returns the currently set timeout value for opening a communication channel with a remote
+     * resource. This may take longer on older devices with lower memory and threading capabilities.</p>
+     *
+     * @return An {@link Integer} value containing the currently set timeout value in
+     * milliseconds.
+     */
+    public int getConnectTimeout() {
+        return getInteger(KEY_CONNECT_TIMEOUT, CONNECT_TIMEOUT);
     }
     
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -272,24 +272,13 @@ public class PrefHelper {
     }
 
     /**
-     * <p>Sets the duration in milliseconds to override the timeout value for tasks</p>
-     *
-     * @param taskTimeout The {@link Integer} value of the timeout setting in milliseconds.
-     */
-    public void setTaskTimeout(int taskTimeout) {
-        setInteger(KEY_TASK_TIMEOUT, taskTimeout);
-    }
-
-    /**
-     * <p>Returns the currently set timeout value for tasks. This will be the default
-     * SDK setting unless it has been overridden manually between Branch object instantiation and
-     * this call.</p>
+     * <p>Returns the computed value of the connect and read timeout for web requests</p>
      *
      * @return An {@link Integer} value containing the currently set timeout value in
      * milliseconds.
      */
     public int getTaskTimeout() {
-        return getInteger(KEY_TASK_TIMEOUT, TASK_TIMEOUT);
+        return getInteger(KEY_TIMEOUT, TIMEOUT) + getInteger(KEY_CONNECT_TIMEOUT, CONNECT_TIMEOUT);
     }
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -55,7 +55,8 @@ public class PrefHelper {
     private static final int MAX_RETRIES = 3; // Default retry count is 3
 
     static final int TIMEOUT = 5500; // Default timeout is 5.5 sec
-    static final int CONNECT_TIMEOUT = 1000; // Default timeout is 10 seconds
+    static final int CONNECT_TIMEOUT = 10000; // Default timeout is 10 seconds
+    static final int TASK_TIMEOUT = TIMEOUT+CONNECT_TIMEOUT; // Default timeout is 15.5 seconds
 
     private static final String SHARED_PREF_FILE = "branch_referral_shared_pref";
     
@@ -88,6 +89,7 @@ public class PrefHelper {
     private static final String KEY_RETRY_COUNT = "bnc_retry_count";
     private static final String KEY_RETRY_INTERVAL = "bnc_retry_interval";
     private static final String KEY_TIMEOUT = "bnc_timeout";
+    private static final String KEY_TASK_TIMEOUT = "bnc_task_timeout";
     private static final String KEY_CONNECT_TIMEOUT = "bnc_connect_timeout";
 
     private static final String KEY_LAST_READ_SYSTEM = "bnc_system_read_date";
@@ -270,6 +272,27 @@ public class PrefHelper {
     }
 
     /**
+     * <p>Sets the duration in milliseconds to override the timeout value for tasks</p>
+     *
+     * @param taskTimeout The {@link Integer} value of the timeout setting in milliseconds.
+     */
+    public void setTaskTimeout(int taskTimeout) {
+        setInteger(KEY_TASK_TIMEOUT, taskTimeout);
+    }
+
+    /**
+     * <p>Returns the currently set timeout value for tasks. This will be the default
+     * SDK setting unless it has been overridden manually between Branch object instantiation and
+     * this call.</p>
+     *
+     * @return An {@link Integer} value containing the currently set timeout value in
+     * milliseconds.
+     */
+    public int getTaskTimeout() {
+        return getInteger(KEY_TASK_TIMEOUT, TASK_TIMEOUT);
+    }
+
+    /**
      * <p>Sets the duration in milliseconds to override the timeout value for initiating requests.</p>
      *
      * @param connectTimeout The {@link Integer} value of the connect timeout setting in milliseconds.
@@ -281,7 +304,7 @@ public class PrefHelper {
 
     /**
      * <p>Returns the currently set timeout value for opening a communication channel with a remote
-     * resource. This may take longer on older devices with lower memory and threading capabilities.</p>
+     * resource.</p>
      *
      * @return An {@link Integer} value containing the currently set timeout value in
      * milliseconds.

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterInstall.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterInstall.java
@@ -138,4 +138,9 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
     public String getRequestActionName() {
         return ACTION_INSTALL;
     }
+
+    @Override
+    public boolean shouldRetryOnFail() {
+        return true;   //Install request needs to retry on failure.
+    }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterOpen.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterOpen.java
@@ -121,5 +121,9 @@ class ServerRequestRegisterOpen extends ServerRequestInitSession {
     public String getRequestActionName() {
         return ACTION_OPEN;
     }
-    
+
+    @Override
+    public boolean shouldRetryOnFail() {
+        return true;   //Open request needs to retry on failure.
+    }
 }


### PR DESCRIPTION
## Reference
INTENG-14315 -- Resolve timeout issues

## Description

The problem appears to be the first network request (open/install) is prematurely cancelled and not retried. The exception that is being thrown is InterruptedIOException which is not handled but falls through to the IOException catch block, and is not retried. They are not placed back on the request queue because they do not override shouldRetryOnFail to true. Thus the sdk is in a state of no recovery.

I verified that

Setting the[ connect timeout](https://github.com/BranchMetrics/android-branch-deep-linking-attribution/blob/f8966bc81f910171ccc4e29798e150066ef5a07a/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java#L138) to 100ms throws SocketTimeoutException
	- Already handled with retries in the caught exception block

Setting the [read timeout ](https://github.com/BranchMetrics/android-branch-deep-linking-attribution/blob/f8966bc81f910171ccc4e29798e150066ef5a07a/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java#L139)to 100ms throws SocketTimeoutException
	- Also handled as above

Setting the countdown latch timeout in [executeTimedBranchPostTask(req, prefHelper_.getTimeout());](https://github.com/BranchMetrics/android-branch-deep-linking-attribution/blob/de0667f6988ba720040e1ed3125418d2b9352d97/Branch-SDK/src/main/java/io/branch/referral/Branch.java#L1669) to 100ms throws InterruptedIOException


Possible root cause:
	The countdown latch is timed against the entire task of constructing and interfacing with the HttpsURLConnection object and other calls. It seems likely that an older device with less resources would take more time executing before getting to the network IO, which also may take longer.


Proposed changes:

- 	Split out ConnectTimeout, ReadTimeout, TaskTimeout (for countdown latch)
         - These values are each used for different purposes and should be configurable to the customers’ needs
         - For back compat, I could leave ReadTimeout as “Timeout” but that might be confusing
	

- Catch InterruptedIOException explicitly and retry
         - If there were a thread timeout, or a failure not due to network, a subsequent retry proved to be much more likely to succeed because the [underlying connection may be reused ](https://docs.oracle.com/javase/8/docs/api/java/net/HttpURLConnection.html)and the task is overall faster to complete.
         
- Override shouldRetryOnFail for ServerRequestRegisterInstall and ServerRequestRegisterOpen to be true
        - Unless other requests imply an initialization request, this seems necessary for recovery

Follow up
	- When shouldRetryOnFail == true; it will forever be placed back on the queue if it did not fail with an unretryableErrorCode. Should there be a limit or an extended retry interval?
	- Should the request’s onPostExecuteInner be calling latch_.countDown() when doInBackground already does so before returning?

Added unit tests, modified existing tests to catch task timeout.

After feedback, task timeout is now computed from the connect and read timeouts

## Testing Instructions
Manual testing with test app using locally built package referenced in old device(KFMUWI) and emulators.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.
## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
