### PR TITLE
[INTENG-14372] Handled NPE

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -3079,7 +3079,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             Activity activity = branch.getCurrentActivity();
             Intent intent = activity != null ? activity.getIntent() : null;
 
-            if (activity != null && ActivityCompat.getReferrer(activity) != null) {
+            if (activity != null && intent != null && ActivityCompat.getReferrer(activity) != null) {
                 PrefHelper.getInstance(activity).setInitialReferrer(ActivityCompat.getReferrer(activity).toString());
             }
 


### PR DESCRIPTION

## Reference
[INTENG-14372](https://branch.atlassian.net/browse/INTENG-14372) -- Android SDK Crash on SDK>5.0.10 with NPE


## Description
At some instance when getReferrer is being triggered incase if intent is null it leads to NPE, hence have added a null check.

## Testing Instructions
Unable to replicate this at our end, but looking at crash report null check should solve the issue.

## Risk Assessment [`LOW`]


- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
