### PR TITLE
SDK- 1339 Only utilize SSAID when GAID is unattainable

### DIFF
--- a/Branch-SDK/src/androidTest/java/io/branch/referral/DeviceInfoTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/DeviceInfoTest.java
@@ -52,6 +52,8 @@ public class DeviceInfoTest extends BranchTest {
         Assert.assertEquals(uniqueId1, uniqueId2);
     }
 
+    // TODO: Need to mock advertising ID providers
+    //  Tests are written to assume a valid AID is obtainable from the system
     @Test
     public void testGAIDFetch() throws InterruptedException {
         initBranchInstance();

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
@@ -7,6 +7,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.UUID;
+
 public class PrefHelperTest extends BranchTest {
     Context context;
     PrefHelper prefHelper;
@@ -100,5 +102,15 @@ public class PrefHelperTest extends BranchTest {
 
         int result = prefHelper.getTaskTimeout();
         Assert.assertEquals(TEST_TIMEOUT + TEST_CONNECT_TIMEOUT, result);
+    }
+
+    @Test
+    public void testSetRandomlyGeneratedUuid(){
+        String uuid = UUID.randomUUID().toString();
+
+        prefHelper.setRandomlyGeneratedUuid(uuid);
+        String result = prefHelper.getRandomlyGeneratedUuid();
+
+        Assert.assertEquals(uuid, result);
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2431,7 +2431,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                 thisReq_.handleFailure(status, serverResponse.getFailReason());
             }
 
-            boolean unretryableErrorCode = (400 <= status && status <= 451);
+            boolean unretryableErrorCode = (400 <= status && status <= 451) || status == BranchError.ERR_BRANCH_TRACKING_DISABLED;
             if (unretryableErrorCode || !thisReq_.shouldRetryOnFail()) {
                 requestQueue_.remove(thisReq_);
             } else {

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchPluginSupport.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchPluginSupport.java
@@ -37,8 +37,9 @@ public class BranchPluginSupport {
         deviceDataObj.put(Defines.Jsonkey.OSVersionAndroid.getKey(), SystemObserver.getOSVersion());
 
         SystemObserver.UniqueId hardwareID = getHardwareID();
-        if (!isNullOrEmptyOrBlank(hardwareID.getId()) && hardwareID.isReal()) {
+        if (!isNullOrEmptyOrBlank(hardwareID.getId())) {
             deviceDataObj.put(Defines.Jsonkey.AndroidID.getKey(), hardwareID.getId());
+            deviceDataObj.put(Defines.Jsonkey.IsHardwareIDReal.getKey(), hardwareID.isReal());
         } else {
             deviceDataObj.put(Defines.Jsonkey.UnidentifiedDevice.getKey(), true);
         }

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -131,10 +131,8 @@ class DeviceInfo {
     void updateRequestWithV2Params(ServerRequest serverRequest, PrefHelper prefHelper, JSONObject userDataObj) {
         try {
             SystemObserver.UniqueId hardwareID = getHardwareID();
-            if (!isNullOrEmptyOrBlank(hardwareID.getId()) && hardwareID.isReal()) {
+            if (!isNullOrEmptyOrBlank(hardwareID.getId())) {
                 userDataObj.put(Defines.Jsonkey.AndroidID.getKey(), hardwareID.getId());
-            } else {
-                userDataObj.put(Defines.Jsonkey.UnidentifiedDevice.getKey(), true);
             }
 
             String brandName = SystemObserver.getPhoneBrand();

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -111,6 +111,8 @@ public class PrefHelper {
     static final String KEY_INSTALL_BEGIN_TS = "bnc_install_begin_ts";
     static final String KEY_TRACKING_STATE = "bnc_tracking_state";
     static final String KEY_AD_NETWORK_CALLOUTS_DISABLED = "bnc_ad_network_callouts_disabled";
+
+    static final String KEY_RANDOMLY_GENERATED_UUID = "bnc_randomly_generated_uuid";
     
     /**
      * Internal static variable of own type {@link PrefHelper}. This variable holds the single
@@ -493,7 +495,21 @@ public class PrefHelper {
     public void setLinkClickID(String link_click_id) {
         setString(KEY_LINK_CLICK_ID, link_click_id);
     }
-    
+
+    /**
+     * Sets a new randomly generated UUID to be associated with the device.
+     * @param uuid
+     */
+    public void setRandomlyGeneratedUuid(String uuid){
+        setString(KEY_RANDOMLY_GENERATED_UUID, uuid);
+    }
+
+    /**
+     * Returns our own randomly generated UUID associated with the device
+     */
+    public String getRandomlyGeneratedUuid() {
+        return getString(KEY_RANDOMLY_GENERATED_UUID);
+    }
     
     /**
      * <p>Gets the {@link #KEY_LINK_CLICK_ID} {@link String} value that has been set via the Branch API.</p>

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -14,7 +14,6 @@ import org.json.JSONObject;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -395,7 +394,7 @@ public abstract class ServerRequest {
         if (!TextUtils.isEmpty(gaid)) {
             updateAdvertisingIdsObject(gaid);
             // gaid is put in the request body below, calling to remove hardware id from request now
-            removeHardwareIdOnValidAdvertisingId();
+            replaceHardwareIdOnValidAdvertisingId();
         }
         try {
             if (version == BRANCH_API_VERSION.V1) {
@@ -453,7 +452,7 @@ public abstract class ServerRequest {
      * Because params including hardware id are set on the request before the advertising ids are obtained,
      * remove the hardware ID and disable future calls from reading it
      */
-    private void removeHardwareIdOnValidAdvertisingId(){
+    private void replaceHardwareIdOnValidAdvertisingId(){
         try {
             //v1
             SystemObserver.UniqueId generatedHardwareID = DeviceInfo.getInstance().getHardwareID();


### PR DESCRIPTION
When we have a valid gaid, replace the real hardware id from the request with uuid. If we don't have a gaid, retain the hardware id.

## Reference
SDK-1339 -- Only utilize SSAID when GAID is unattainable.

## Description
When we have a valid gaid, replace the hardware id from the request. If we don't have a gaid, retain the hardware id. This is behavior that already exists on the service side, but ensuring that both values are not sent together in the same payload. This change should introduce no side effects or any other new behaviors.

## Testing Instructions
Manually tested on google and amazon device. Payloads and diffs shared internally.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [ ✅ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
