### PR TITLE
Use DisplayManager instead of WindowManager

### DIFF
--- a/Branch-SDK/src/androidTest/java/io/branch/referral/DeviceInfoTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/DeviceInfoTest.java
@@ -1,5 +1,11 @@
 package io.branch.referral;
 
+import android.content.Context;
+import android.hardware.display.DisplayManager;
+import android.util.DisplayMetrics;
+import android.view.Display;
+import android.view.WindowManager;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Assert;
@@ -70,5 +76,22 @@ public class DeviceInfoTest extends BranchTest {
         Assert.assertTrue(latch.await(5000, TimeUnit.MILLISECONDS));
 
         Assert.assertFalse(DeviceInfo.isNullOrEmptyOrBlank(DeviceInfo.getInstance().getSystemObserver().getAID()));
+    }
+
+    @Test
+    public void windowManagerAndDisplayManagerSameMetrics(){
+        DisplayManager displayManager = (DisplayManager) getTestContext().getSystemService(Context.DISPLAY_SERVICE);
+        Display display1 = displayManager.getDisplay(Display.DEFAULT_DISPLAY);
+        DisplayMetrics displayMetrics1 = new DisplayMetrics();
+        display1.getMetrics(displayMetrics1);
+
+        WindowManager windowManager = (WindowManager) getTestContext().getSystemService(Context.WINDOW_SERVICE);
+        Display display2 = windowManager.getDefaultDisplay();
+        DisplayMetrics displayMetrics2 = new DisplayMetrics();
+        display2.getMetrics(displayMetrics2);
+
+        Assert.assertEquals(displayMetrics1.widthPixels, displayMetrics2.widthPixels);
+        Assert.assertEquals(displayMetrics1.heightPixels, displayMetrics2.heightPixels);
+        Assert.assertEquals(displayMetrics1.densityDpi, displayMetrics2.densityDpi);
     }
 }

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
@@ -172,6 +172,7 @@ public class PrefHelperTest extends BranchTest {
         String resultGclid = prefHelper.getReferrerGclid();
         Assert.assertEquals(testGclid, resultGclid);
         prefHelper.setReferrerGclidValidForWindow(PrefHelper.DEFAULT_VALID_WINDOW_FOR_REFERRER_GCLID);
+    }
 
     public void testSetRandomlyGeneratedUuid(){
         String uuid = UUID.randomUUID().toString();

--- a/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
@@ -378,7 +378,9 @@ abstract class SystemObserver {
             // Use DisplayManager instead of WindowManager as API 31 will log IncorrectContextUseViolation/IllegalAccessException
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1){
                 DisplayManager displayManager = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
-                display = displayManager.getDisplay(Display.DEFAULT_DISPLAY);
+                if(displayManager != null) {
+                    display = displayManager.getDisplay(Display.DEFAULT_DISPLAY);
+                }
             }
             else {
                 WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);

--- a/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
@@ -10,6 +10,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.content.res.Configuration;
+import android.hardware.display.DisplayManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Build;
@@ -370,15 +371,25 @@ abstract class SystemObserver {
      * @see DisplayMetrics
      */
     static DisplayMetrics getScreenDisplay(Context context) {
+        Display display = null;
         DisplayMetrics displayMetrics = new DisplayMetrics();
-        if (context != null) {
-            WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-            if (windowManager != null) {
-                Display display = windowManager.getDefaultDisplay();
-                if (display != null) {
-                    display.getMetrics(displayMetrics);
+        if(context != null) {
+            // DisplayManager is introduced in API 17, current sdk minimum is 16
+            // Use DisplayManager instead of WindowManager as API 31 will log IncorrectContextUseViolation/IllegalAccessException
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1){
+                DisplayManager displayManager = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
+                display = displayManager.getDisplay(Display.DEFAULT_DISPLAY);
+            }
+            else {
+                WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+                if (windowManager != null) {
+                    display = windowManager.getDefaultDisplay();
                 }
             }
+        }
+
+        if(display != null){
+            display.getMetrics(displayMetrics);
         }
         return displayMetrics;
     }


### PR DESCRIPTION
## Reference
SDK-1384 -- Android 12 - IllegalAccessException: Tried to access visual service WindowManager from a non-visual Context.

## Description
Use DisplayManager instead of WindowManager as API 31 will log IncorrectContextUseViolation/IllegalAccessException.

When accessing system information for screen display metrics for request params, we are using an Application context, by design. If a WindowManager is requested with an Application context, then as of API 31 it will log the above error. The resolution is to use DisplayManager introduced in API 17 instead. WindowManager.getDefaultDisplay() is deprecated as of API 30 and recommends to use DisplayManager.getDisplay() instead.

References:
https://developer.android.com/reference/android/os/StrictMode.VmPolicy.Builder#detectIncorrectContextUse()
https://developer.android.com/reference/android/hardware/display/DisplayManager
https://developer.android.com/reference/android/view/WindowManager#getDefaultDisplay()
https://developer.android.com/reference/android/content/Context#getDisplay()

## Testing Instructions
I've manually tested the change by following the repro steps in the issue and validating the absence of the error.

Devices tested:
Real Pixel 4a API 31
Emulator Pixel 4a API 31
Samsung S8 API 28

Unit test added to validate identical output between methods.

## Risk Assessment [`LOW`]

- [✅ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
