### PR TITLE
[SDK-1202][SDK-1206] Updated variable naming

### DIFF
--- a/Branch-SDK/doc/index-files/index-17.html
+++ b/Branch-SDK/doc/index-files/index-17.html
@@ -148,9 +148,9 @@ complete.</div>
 <div class="block">Enable debugging, by setting the <code>Boolean</code> debug flags <a href="../io/branch/referral/PrefHelper.html#BNC_Debug"><code>PrefHelper.BNC_Debug</code></a> and 
  <a href="../io/branch/referral/PrefHelper.html#BNC_Debug_Connecting"><code>PrefHelper.BNC_Debug_Connecting</code></a> to true.</div>
 </dd>
-<dt><span class="memberNameLink"><a href="../io/branch/referral/PrefHelper.html#setDeviceFingerPrintID-java.lang.String-">setDeviceFingerPrintID(String)</a></span> - Method in class io.branch.referral.<a href="../io/branch/referral/PrefHelper.html" title="class in io.branch.referral">PrefHelper</a></dt>
+<dt><span class="memberNameLink"><a href="../io/branch/referral/PrefHelper.html#setRandomizedDeviceToken-java.lang.String-">setRandomizedDeviceToken(String)</a></span> - Method in class io.branch.referral.<a href="../io/branch/referral/PrefHelper.html" title="class in io.branch.referral">PrefHelper</a></dt>
 <dd>
-<div class="block">Sets the <code>android.os.Build#FINGERPRINT</code> value of the current OS build, on the current device,
+<div class="block">Sets the <code>android.os.Build#RANDOMIZEDDEVICETOKEN</code> value of the current OS build, on the current device,
  as a <code>String</code> in preferences.</div>
 </dd>
 <dt><span class="memberNameLink"><a href="../io/branch/referral/PrefHelper.html#setExternDebug--">setExternDebug()</a></span> - Method in class io.branch.referral.<a href="../io/branch/referral/PrefHelper.html" title="class in io.branch.referral">PrefHelper</a></dt>
@@ -176,9 +176,9 @@ complete.</div>
 <dd>
 <div class="block">Sets the <code>KEY_IDENTITY</code> <code>String</code> value that has been set via the Branch API.</div>
 </dd>
-<dt><span class="memberNameLink"><a href="../io/branch/referral/PrefHelper.html#setIdentityID-java.lang.String-">setIdentityID(String)</a></span> - Method in class io.branch.referral.<a href="../io/branch/referral/PrefHelper.html" title="class in io.branch.referral">PrefHelper</a></dt>
+<dt><span class="memberNameLink"><a href="../io/branch/referral/PrefHelper.html#setRandomizedBundleToken-java.lang.String-">setRandomizedBundleToken(String)</a></span> - Method in class io.branch.referral.<a href="../io/branch/referral/PrefHelper.html" title="class in io.branch.referral">PrefHelper</a></dt>
 <dd>
-<div class="block">Sets the <code>KEY_IDENTITY_ID</code> <code>String</code> value that has been set via the Branch API.</div>
+<div class="block">Sets the <code>KEY_RANDOMIZED_BUNDLE_TOKEN</code> <code>String</code> value that has been set via the Branch API.</div>
 </dd>
 <dt><span class="memberNameLink"><a href="../io/branch/referral/PrefHelper.html#setInstallParams-java.lang.String-">setInstallParams(String)</a></span> - Method in class io.branch.referral.<a href="../io/branch/referral/PrefHelper.html" title="class in io.branch.referral">PrefHelper</a></dt>
 <dd>

--- a/Branch-SDK/doc/index-files/index-7.html
+++ b/Branch-SDK/doc/index-files/index-7.html
@@ -193,9 +193,9 @@
 <div class="block">Returns an <code>Integer</code> of the number of credits available for use within the supplied 
  bucket name.</div>
 </dd>
-<dt><span class="memberNameLink"><a href="../io/branch/referral/PrefHelper.html#getDeviceFingerPrintID--">getDeviceFingerPrintID()</a></span> - Method in class io.branch.referral.<a href="../io/branch/referral/PrefHelper.html" title="class in io.branch.referral">PrefHelper</a></dt>
+<dt><span class="memberNameLink"><a href="../io/branch/referral/PrefHelper.html#getRandomizedDeviceToken--">getRandomizedDeviceToken()</a></span> - Method in class io.branch.referral.<a href="../io/branch/referral/PrefHelper.html" title="class in io.branch.referral">PrefHelper</a></dt>
 <dd>
-<div class="block">Gets the <code>android.os.Build#FINGERPRINT</code> value of the current OS build, on the current device,
+<div class="block">Gets the <code>android.os.Build#RANDOMIZEDDEVICETOKEN</code> value of the current OS build, on the current device,
  as a <code>String</code> from preferences.</div>
 </dd>
 <dt><span class="memberNameLink"><a href="../io/branch/referral/PrefHelper.html#getExternAppListing--">getExternAppListing()</a></span> - Method in class io.branch.referral.<a href="../io/branch/referral/PrefHelper.html" title="class in io.branch.referral">PrefHelper</a></dt>
@@ -220,9 +220,9 @@
 <dd>
 <div class="block">Gets the <a href="../io/branch/referral/PrefHelper.html#KEY_IDENTITY"><code>PrefHelper.KEY_IDENTITY</code></a> <code>String</code> value that has been set via the Branch API.</div>
 </dd>
-<dt><span class="memberNameLink"><a href="../io/branch/referral/PrefHelper.html#getIdentityID--">getIdentityID()</a></span> - Method in class io.branch.referral.<a href="../io/branch/referral/PrefHelper.html" title="class in io.branch.referral">PrefHelper</a></dt>
+<dt><span class="memberNameLink"><a href="../io/branch/referral/PrefHelper.html#getRandomizedBundleToken--">getRandomizedBundleToken()</a></span> - Method in class io.branch.referral.<a href="../io/branch/referral/PrefHelper.html" title="class in io.branch.referral">PrefHelper</a></dt>
 <dd>
-<div class="block">Gets the <code>KEY_IDENTITY_ID</code> <code>String</code> value that has been set via the Branch API.</div>
+<div class="block">Gets the <code>KEY_RANDOMIZED_BUNDLE_TOKEN</code> <code>String</code> value that has been set via the Branch API.</div>
 </dd>
 <dt><span class="memberNameLink"><a href="../io/branch/referral/PrefHelper.html#getInstallParams--">getInstallParams()</a></span> - Method in class io.branch.referral.<a href="../io/branch/referral/PrefHelper.html" title="class in io.branch.referral">PrefHelper</a></dt>
 <dd>

--- a/Branch-SDK/doc/io/branch/referral/PrefHelper.html
+++ b/Branch-SDK/doc/io/branch/referral/PrefHelper.html
@@ -327,8 +327,8 @@ extends java.lang.Object</pre>
 </tr>
 <tr id="i15" class="rowColor">
 <td class="colFirst"><code>java.lang.String</code></td>
-<td class="colLast"><code><span class="memberNameLink"><a href="../../../io/branch/referral/PrefHelper.html#getDeviceFingerPrintID--">getDeviceFingerPrintID</a></span>()</code>
-<div class="block">Gets the <code>android.os.Build#FINGERPRINT</code> value of the current OS build, on the current device,
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../io/branch/referral/PrefHelper.html#getRandomizedDeviceToken--">getRandomizedDeviceToken</a></span>()</code>
+<div class="block">Gets the <code>android.os.Build#RANDOMIZEDDEVICETOKEN</code> value of the current OS build, on the current device,
  as a <code>String</code> from preferences.</div>
 </td>
 </tr>
@@ -358,8 +358,8 @@ extends java.lang.Object</pre>
 </tr>
 <tr id="i20" class="altColor">
 <td class="colFirst"><code>java.lang.String</code></td>
-<td class="colLast"><code><span class="memberNameLink"><a href="../../../io/branch/referral/PrefHelper.html#getIdentityID--">getIdentityID</a></span>()</code>
-<div class="block">Gets the <code>KEY_IDENTITY_ID</code> <code>String</code> value that has been set via the Branch API.</div>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../io/branch/referral/PrefHelper.html#getRandomizedBundleToken--">getRandomizedBundleToken</a></span>()</code>
+<div class="block">Gets the <code>KEY_RANDOMIZED_BUNDLE_TOKEN</code> <code>String</code> value that has been set via the Branch API.</div>
 </td>
 </tr>
 <tr id="i21" class="rowColor">
@@ -541,8 +541,8 @@ extends java.lang.Object</pre>
 </tr>
 <tr id="i48" class="altColor">
 <td class="colFirst"><code>void</code></td>
-<td class="colLast"><code><span class="memberNameLink"><a href="../../../io/branch/referral/PrefHelper.html#setDeviceFingerPrintID-java.lang.String-">setDeviceFingerPrintID</a></span>(java.lang.String&nbsp;device_fingerprint_id)</code>
-<div class="block">Sets the <code>android.os.Build#FINGERPRINT</code> value of the current OS build, on the current device,
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../io/branch/referral/PrefHelper.html#setRandomizedDeviceToken-java.lang.String-">setRandomizedDeviceToken</a></span>(java.lang.String&nbsp;randomized_device_token)</code>
+<div class="block">Sets the <code>android.os.Build#RANDOMIZEDDEVICETOKEN</code> value of the current OS build, on the current device,
  as a <code>String</code> in preferences.</div>
 </td>
 </tr>
@@ -567,8 +567,8 @@ extends java.lang.Object</pre>
 </tr>
 <tr id="i52" class="altColor">
 <td class="colFirst"><code>void</code></td>
-<td class="colLast"><code><span class="memberNameLink"><a href="../../../io/branch/referral/PrefHelper.html#setIdentityID-java.lang.String-">setIdentityID</a></span>(java.lang.String&nbsp;identity_id)</code>
-<div class="block">Sets the <code>KEY_IDENTITY_ID</code> <code>String</code> value that has been set via the Branch API.</div>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../io/branch/referral/PrefHelper.html#setRandomizedBundleToken-java.lang.String-">setRandomizedBundleToken</a></span>(java.lang.String&nbsp;randomized_bundle_token)</code>
+<div class="block">Sets the <code>KEY_RANDOMIZED_BUNDLE_TOKEN</code> <code>String</code> value that has been set via the Branch API.</div>
 </td>
 </tr>
 <tr id="i53" class="rowColor">
@@ -1024,31 +1024,31 @@ public&nbsp;void&nbsp;setAppKey(java.lang.String&nbsp;key)</pre>
 </dl>
 </li>
 </ul>
-<a name="setDeviceFingerPrintID-java.lang.String-">
+<a name="setRandomizedDeviceToken-java.lang.String-">
 <!--   -->
 </a>
 <ul class="blockList">
 <li class="blockList">
-<h4>setDeviceFingerPrintID</h4>
-<pre>public&nbsp;void&nbsp;setDeviceFingerPrintID(java.lang.String&nbsp;device_fingerprint_id)</pre>
-<div class="block"><p>Sets the <code>android.os.Build#FINGERPRINT</code> value of the current OS build, on the current device,
+<h4>setRandomizedDeviceToken</h4>
+<pre>public&nbsp;void&nbsp;setRandomizedDeviceToken(java.lang.String&nbsp;randomized_device_token)</pre>
+<div class="block"><p>Sets the <code>android.os.Build#RANDOMIZEDDEVICETOKEN</code> value of the current OS build, on the current device,
  as a <code>String</code> in preferences.</p></div>
 <dl>
 <dt><span class="paramLabel">Parameters:</span></dt>
-<dd><code>device_fingerprint_id</code> - A <code>String</code> that uniquely identifies this build.</dd>
+<dd><code>randomized_device_token</code> - A <code>String</code> that uniquely identifies this build.</dd>
 <dt><span class="seeLabel">See Also:</span></dt>
-<dd><code>android.os.Build#FINGERPRINT}</code></dd>
+<dd><code>android.os.Build#RANDOMIZEDDEVICETOKEN}</code></dd>
 </dl>
 </li>
 </ul>
-<a name="getDeviceFingerPrintID--">
+<a name="getRandomizedDeviceToken--">
 <!--   -->
 </a>
 <ul class="blockList">
 <li class="blockList">
-<h4>getDeviceFingerPrintID</h4>
-<pre>public&nbsp;java.lang.String&nbsp;getDeviceFingerPrintID()</pre>
-<div class="block"><p>Gets the <code>android.os.Build#FINGERPRINT</code> value of the current OS build, on the current device,
+<h4>getRandomizedDeviceToken</h4>
+<pre>public&nbsp;java.lang.String&nbsp;getRandomizedDeviceToken()</pre>
+<div class="block"><p>Gets the <code>android.os.Build#RANDOMIZEDDEVICETOKEN</code> value of the current OS build, on the current device,
  as a <code>String</code> from preferences.</p></div>
 <dl>
 <dt><span class="returnLabel">Returns:</span></dt>
@@ -1090,14 +1090,14 @@ public&nbsp;void&nbsp;setAppKey(java.lang.String&nbsp;key)</pre>
 </dl>
 </li>
 </ul>
-<a name="setIdentityID-java.lang.String-">
+<a name="setRandomizedBundleToken-java.lang.String-">
 <!--   -->
 </a>
 <ul class="blockList">
 <li class="blockList">
-<h4>setIdentityID</h4>
-<pre>public&nbsp;void&nbsp;setIdentityID(java.lang.String&nbsp;identity_id)</pre>
-<div class="block"><p>Sets the <code>KEY_IDENTITY_ID</code> <code>String</code> value that has been set via the Branch API.</p>
+<h4>setRandomizedBundleToken</h4>
+<pre>public&nbsp;void&nbsp;setRandomizedBundleToken(java.lang.String&nbsp;randomized_bundle_token)</pre>
+<div class="block"><p>Sets the <code>KEY_RANDOMIZED_BUNDLE_TOKEN</code> <code>String</code> value that has been set via the Branch API.</p>
  
  <p>This is used to identify a specific <b>user ID</b> and link that to a current session. Useful both 
  for analytics and debugging purposes.</p>
@@ -1105,21 +1105,21 @@ public&nbsp;void&nbsp;setAppKey(java.lang.String&nbsp;key)</pre>
  <p><b>Note: </b> Not to be confused with <a href="../../../io/branch/referral/PrefHelper.html#setIdentity-java.lang.String-"><code>setIdentity(String)</code></a> - the name of the user</p></div>
 <dl>
 <dt><span class="paramLabel">Parameters:</span></dt>
-<dd><code>identity_id</code> - A <code>String</code> value containing the currently configured identity 
+<dd><code>randomized_bundle_token</code> - A <code>String</code> value containing the currently configured identity
                                                         within preferences.</dd>
 <dt><span class="seeLabel">See Also:</span></dt>
 <dd><code>Branch}</code></dd>
 </dl>
 </li>
 </ul>
-<a name="getIdentityID--">
+<a name="getRandomizedBundleToken--">
 <!--   -->
 </a>
 <ul class="blockList">
 <li class="blockList">
-<h4>getIdentityID</h4>
-<pre>public&nbsp;java.lang.String&nbsp;getIdentityID()</pre>
-<div class="block"><p>Gets the <code>KEY_IDENTITY_ID</code> <code>String</code> value that has been set via the Branch API.</p></div>
+<h4>getRandomizedBundleToken</h4>
+<pre>public&nbsp;java.lang.String&nbsp;getRandomizedBundleToken()</pre>
+<div class="block"><p>Gets the <code>KEY_RANDOMIZED_BUNDLE_TOKEN</code> <code>String</code> value that has been set via the Branch API.</p></div>
 <dl>
 <dt><span class="returnLabel">Returns:</span></dt>
 <dd>A <code>String</code> value containing the currently configured user id within 
@@ -1141,7 +1141,7 @@ public&nbsp;void&nbsp;setAppKey(java.lang.String&nbsp;key)</pre>
  <p>This is used to identify a specific <b>user identity</b> and link that to a current session. Useful both 
  for analytics and debugging purposes.</p>
  
- <p><b>Note: </b> Not to be confused with <a href="../../../io/branch/referral/PrefHelper.html#setIdentityID-java.lang.String-"><code>setIdentityID(String)</code></a> - the UID reference of the user</p></div>
+ <p><b>Note: </b> Not to be confused with <a href="../../../io/branch/referral/PrefHelper.html#setRandomizedBundleToken-java.lang.String-"><code>setRandomizedBundleToken(String)</code></a> - the UID reference of the user</p></div>
 <dl>
 <dt><span class="paramLabel">Parameters:</span></dt>
 <dd><code>identity</code> - A <code>String</code> value containing the currently configured identity 
@@ -1163,7 +1163,7 @@ public&nbsp;void&nbsp;setAppKey(java.lang.String&nbsp;key)</pre>
  <p>This is used to identify a specific <b>user identity</b> and link that to a current session. Useful both 
  for analytics and debugging purposes.</p>
  
- <p><b>Note: </b> Not to be confused with <code>#getIdentityID(String)</code> - the UID reference of the user</p></div>
+ <p><b>Note: </b> Not to be confused with <code>#getRandomizedBundleToken(String)</code> - the UID reference of the user</p></div>
 <dl>
 <dt><span class="returnLabel">Returns:</span></dt>
 <dd>A <code>String</code> value containing the username assigned to the currentuser ID.</dd>

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchApiTests.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchApiTests.java
@@ -283,7 +283,7 @@ public class BranchApiTests extends BranchTest {
                     public void onInitFinished(JSONObject referringParams, BranchError error) {
                         Assert.assertNull(error);
                         Assert.assertNotNull(referringParams);
-                        Assert.assertEquals(prefHelper.getIdentityID(), "880938553226608667");
+                        Assert.assertEquals(prefHelper.getRandomizedBundleToken(), "880938553226608667");
 
                         JSONObject installParams = branch.getFirstReferringParams();
                         try {

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
@@ -172,6 +172,7 @@ public class PrefHelperTest extends BranchTest {
         String resultGclid = prefHelper.getReferrerGclid();
         Assert.assertEquals(testGclid, resultGclid);
         prefHelper.setReferrerGclidValidForWindow(PrefHelper.DEFAULT_VALID_WINDOW_FOR_REFERRER_GCLID);
+    }
 
     public void testSetRandomlyGeneratedUuid(){
         String uuid = UUID.randomUUID().toString();

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/mock/MockRemoteInterface.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/mock/MockRemoteInterface.java
@@ -51,9 +51,9 @@ public class MockRemoteInterface extends BranchRemoteInterface {
         if (url.contains(GetURL.getPath())) {
             return "{\"url\":\"https://bnc.lt/l/randomized_test_route_" + UUID.randomUUID().toString() + "\"}";
         } else if (url.contains(IdentifyUser.getPath())) {
-            return "{\"session_id\":\"880938553235373649\",\"identity_id\":\"880938553226608667\",\"link\":\"https://branchster.test-app.link?%24identity_id=880938553226608667\",\"data\":\"{\\\"+clicked_branch_link\\\":false,\\\"+is_first_session\\\":false}\",\"device_fingerprint_id\":\"867130134518497054\"}";
+            return "{\"session_id\":\"880938553235373649\",\"randomized_bundle_token\":\"880938553226608667\",\"link\":\"https://branchster.test-app.link?%24randomized_bundle_token=880938553226608667\",\"data\":\"{\\\"+clicked_branch_link\\\":false,\\\"+is_first_session\\\":false}\",\"randomized_device_token\":\"867130134518497054\"}";
         } else if (url.contains(RegisterInstall.getPath()) || url.contains(RegisterOpen.getPath())) {
-            return "{\"session_id\":\"880938553235373649\",\"identity_id\":\"880938553226608667\",\"link\":\"https://branchster.test-app.link?%24identity_id=880938553226608667\",\"data\":\"{\\\"+clicked_branch_link\\\":false,\\\"+is_first_session\\\":false}\",\"device_fingerprint_id\":\"867130134518497054\"}";
+            return "{\"session_id\":\"880938553235373649\",\"randomized_bundle_token\":\"880938553226608667\",\"link\":\"https://branchster.test-app.link?%24randomized_bundle_token=880938553226608667\",\"data\":\"{\\\"+clicked_branch_link\\\":false,\\\"+is_first_session\\\":false}\",\"randomized_device_token\":\"867130134518497054\"}";
         } else if (url.contains(GetCPID.getPath())) {
             return "{\"user_data\":{\"cross_platform_id\":\"afb3e7f98b18dc6c90ebaeade4dbc6cac67fbb8e3f34e9cd8217490bf8f24b1f\",\"past_cross_platform_ids\":[],\"prob_cross_platform_ids\":[],\"developer_identity\":\"880938553226608667\"}}";
         } else {

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1582,7 +1582,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                 if (req != null) {
                     PrefHelper.Debug("processNextQueueItem, req " + req.getClass().getSimpleName());
                     if (!req.isWaitingOnProcessToFinish()) {
-                        // All request except Install request need a valid IdentityID
+                        // All request except Install request need a valid RandomizedBundleToken
                         if (!(req instanceof ServerRequestRegisterInstall) && !hasUser()) {
                             PrefHelper.Debug("Branch Error: User session has not been initialized!");
                             networkCount_ = 0;
@@ -1651,7 +1651,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
 
     // Determine if a Session is available for a Request to proceed.
     private boolean isSessionAvailableForRequest() {
-        return (hasSession() && hasDeviceFingerPrint());
+        return (hasSession() && hasRandomizedDeviceToken());
     }
     
     void updateAllRequestsInQueue() {
@@ -1664,11 +1664,11 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                         if (reqJson.has(Defines.Jsonkey.SessionID.getKey())) {
                             req.getPost().put(Defines.Jsonkey.SessionID.getKey(), prefHelper_.getSessionID());
                         }
-                        if (reqJson.has(Defines.Jsonkey.IdentityID.getKey())) {
-                            req.getPost().put(Defines.Jsonkey.IdentityID.getKey(), prefHelper_.getIdentityID());
+                        if (reqJson.has(Defines.Jsonkey.RandomizedBundleToken.getKey())) {
+                            req.getPost().put(Defines.Jsonkey.RandomizedBundleToken.getKey(), prefHelper_.getRandomizedBundleToken());
                         }
-                        if (reqJson.has(Defines.Jsonkey.DeviceFingerprintID.getKey())) {
-                            req.getPost().put(Defines.Jsonkey.DeviceFingerprintID.getKey(), prefHelper_.getDeviceFingerPrintID());
+                        if (reqJson.has(Defines.Jsonkey.RandomizedDeviceToken.getKey())) {
+                            req.getPost().put(Defines.Jsonkey.RandomizedDeviceToken.getKey(), prefHelper_.getRandomizedDeviceToken());
                         }
                     }
                 }
@@ -1730,12 +1730,12 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         return isInstantDeepLinkPossible;
     }
     
-    private boolean hasDeviceFingerPrint() {
-        return !prefHelper_.getDeviceFingerPrintID().equals(PrefHelper.NO_STRING_VALUE);
+    private boolean hasRandomizedDeviceToken() {
+        return !prefHelper_.getRandomizedDeviceToken().equals(PrefHelper.NO_STRING_VALUE);
     }
     
     private boolean hasUser() {
-        return !prefHelper_.getIdentityID().equals(PrefHelper.NO_STRING_VALUE);
+        return !prefHelper_.getRandomizedBundleToken().equals(PrefHelper.NO_STRING_VALUE);
     }
     
     private void insertRequestAtFront(ServerRequest req) {
@@ -2278,17 +2278,17 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                             prefHelper_.setSessionID(respJson.getString(Defines.Jsonkey.SessionID.getKey()));
                             updateRequestsInQueue = true;
                         }
-                        if (respJson.has(Defines.Jsonkey.IdentityID.getKey())) {
-                            String new_Identity_Id = respJson.getString(Defines.Jsonkey.IdentityID.getKey());
-                            if (!prefHelper_.getIdentityID().equals(new_Identity_Id)) {
-                                //On setting a new identity Id clear the link cache
+                        if (respJson.has(Defines.Jsonkey.RandomizedBundleToken.getKey())) {
+                            String new_Randomized_Bundle_Token = respJson.getString(Defines.Jsonkey.RandomizedBundleToken.getKey());
+                            if (!prefHelper_.getRandomizedBundleToken().equals(new_Randomized_Bundle_Token)) {
+                                //On setting a new Randomized Bundle Token clear the link cache
                                 linkCache_.clear();
-                                prefHelper_.setIdentityID(new_Identity_Id);
+                                prefHelper_.setRandomizedBundleToken(new_Randomized_Bundle_Token);
                                 updateRequestsInQueue = true;
                             }
                         }
-                        if (respJson.has(Defines.Jsonkey.DeviceFingerprintID.getKey())) {
-                            prefHelper_.setDeviceFingerPrintID(respJson.getString(Defines.Jsonkey.DeviceFingerprintID.getKey()));
+                        if (respJson.has(Defines.Jsonkey.RandomizedDeviceToken.getKey())) {
+                            prefHelper_.setRandomizedDeviceToken(respJson.getString(Defines.Jsonkey.RandomizedDeviceToken.getKey()));
                             updateRequestsInQueue = true;
                         }
                         if (updateRequestsInQueue) {

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchStrongMatchHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchStrongMatchHelper.java
@@ -167,9 +167,9 @@ class BranchStrongMatchHelper {
             if (gaid != null && !BranchUtil.checkTestMode(context)) {
                 uriString += "&" + Defines.Jsonkey.GoogleAdvertisingID.getKey() + "=" + gaid;
             }
-            // Add device finger print if available
-            if (!prefHelper.getDeviceFingerPrintID().equals(PrefHelper.NO_STRING_VALUE)) {
-                uriString += "&" + Defines.Jsonkey.DeviceFingerprintID.getKey() + "=" + prefHelper.getDeviceFingerPrintID();
+            // Add randomized device token if available
+            if (!prefHelper.getRandomizedDeviceToken().equals(PrefHelper.NO_STRING_VALUE)) {
+                uriString += "&" + Defines.Jsonkey.RandomizedDeviceToken.getKey() + "=" + prefHelper.getRandomizedDeviceToken();
             }
             //Add App version
             if (!deviceInfo.getAppVersion().equals(SystemObserver.BLANK)) {

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -8,10 +8,9 @@ package io.branch.referral;
 public class Defines {
     
     public enum Jsonkey {
-        
-        IdentityID("identity_id"),
+        RandomizedBundleToken("randomized_bundle_token"),
         Identity("identity"),
-        DeviceFingerprintID("device_fingerprint_id"),
+        RandomizedDeviceToken("randomized_device_token"),
         SessionID("session_id"),
         LinkClickID("link_click_id"),
         GoogleSearchInstallReferrer("google_search_install_referrer"),

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -182,8 +182,8 @@ class DeviceInfo {
             }
 
             if (prefHelper != null) {
-                if (!isNullOrEmptyOrBlank(prefHelper.getDeviceFingerPrintID())) {
-                    userDataObj.put(Defines.Jsonkey.DeviceFingerprintID.getKey(), prefHelper.getDeviceFingerPrintID());
+                if (!isNullOrEmptyOrBlank(prefHelper.getRandomizedDeviceToken())) {
+                    userDataObj.put(Defines.Jsonkey.RandomizedDeviceToken.getKey(), prefHelper.getRandomizedDeviceToken());
                 }
                 String devId = prefHelper.getIdentity();
                 if (!isNullOrEmptyOrBlank(devId)) {

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -66,9 +66,9 @@ public class PrefHelper {
     
     private static final String KEY_BRANCH_KEY = "bnc_branch_key";
     private static final String KEY_APP_VERSION = "bnc_app_version";
-    private static final String KEY_DEVICE_FINGERPRINT_ID = "bnc_device_fingerprint_id";
+    private static final String KEY_RANDOMIZED_DEVICE_TOKEN = "bnc_randomized_device_token";
     private static final String KEY_SESSION_ID = "bnc_session_id";
-    private static final String KEY_IDENTITY_ID = "bnc_identity_id";
+    private static final String KEY_RANDOMIZED_BUNDLE_TOKEN = "bnc_randomized_bundle_token";
     private static final String KEY_IDENTITY = "bnc_identity";
     private static final String KEY_LINK_CLICK_ID = "bnc_link_click_id";
     private static final String KEY_LINK_CLICK_IDENTIFIER = "bnc_link_click_identifier";
@@ -403,23 +403,23 @@ public class PrefHelper {
     }
     
     /**
-     * <p>Sets the {@link android.os.Build#FINGERPRINT} value of the current OS build, on the current device,
+     * <p>Sets the {@link android.os.Build#RANDOMIZEDDEVICETOKEN} value of the current OS build, on the current device,
      * as a {@link String} in preferences.</p>
      *
-     * @param device_fingerprint_id A {@link String} that uniquely identifies this build.
+     * @param randomized_device_token A {@link String} that uniquely identifies this build.
      */
-    public void setDeviceFingerPrintID(String device_fingerprint_id) {
-        setString(KEY_DEVICE_FINGERPRINT_ID, device_fingerprint_id);
+    public void setRandomizedDeviceToken(String randomized_device_token) {
+        setString(KEY_RANDOMIZED_DEVICE_TOKEN, randomized_device_token);
     }
     
     /**
-     * <p>Gets the {@link android.os.Build#FINGERPRINT} value of the current OS build, on the current device,
+     * <p>Gets the {@link android.os.Build#RANDOMIZEDDEVICETOKEN} value of the current OS build, on the current device,
      * as a {@link String} from preferences.</p>
      *
      * @return A {@link String} that uniquely identifies this build.
      */
-    public String getDeviceFingerPrintID() {
-        return getString(KEY_DEVICE_FINGERPRINT_ID);
+    public String getRandomizedDeviceToken() {
+        return getString(KEY_RANDOMIZED_DEVICE_TOKEN);
     }
     
     /**
@@ -443,28 +443,28 @@ public class PrefHelper {
     }
     
     /**
-     * <p>Sets the {@link #KEY_IDENTITY_ID} {@link String} value that has been set via the Branch API.</p>
+     * <p>Sets the {@link #KEY_RANDOMIZED_BUNDLE_TOKEN} {@link String} value that has been set via the Branch API.</p>
      * <p>
      * <p>This is used to identify a specific <b>user ID</b> and link that to a current session. Useful both
      * for analytics and debugging purposes.</p>
      * <p>
      * <p><b>Note: </b> Not to be confused with {@link #setIdentity(String)} - the name of the user</p>
      *
-     * @param identity_id A {@link String} value containing the currently configured identity
+     * @param randomized_bundle_token A {@link String} value containing the currently configured identity
      *                    within preferences.
      */
-    public void setIdentityID(String identity_id) {
-        setString(KEY_IDENTITY_ID, identity_id);
+    public void setRandomizedBundleToken(String randomized_bundle_token) {
+        setString(KEY_RANDOMIZED_BUNDLE_TOKEN, randomized_bundle_token);
     }
     
     /**
-     * <p>Gets the {@link #KEY_IDENTITY_ID} {@link String} value that has been set via the Branch API.</p>
+     * <p>Gets the {@link #KEY_RANDOMIZED_BUNDLE_TOKEN} {@link String} value that has been set via the Branch API.</p>
      *
      * @return A {@link String} value containing the currently configured user id within
      * preferences.
      */
-    public String getIdentityID() {
-        return getString(KEY_IDENTITY_ID);
+    public String getRandomizedBundleToken() {
+        return getString(KEY_RANDOMIZED_BUNDLE_TOKEN);
     }
     
     /**
@@ -473,7 +473,7 @@ public class PrefHelper {
      * <p>This is used to identify a specific <b>user identity</b> and link that to a current session. Useful both
      * for analytics and debugging purposes.</p>
      * <p>
-     * <p><b>Note: </b> Not to be confused with {@link #setIdentityID(String)} - the UID reference of the user</p>
+     * <p><b>Note: </b> Not to be confused with {@link #setRandomizedBundleToken(String)} - the UID reference of the user</p>
      *
      * @param identity A {@link String} value containing the currently configured identity
      *                 within preferences.

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -403,7 +403,7 @@ public class PrefHelper {
     }
     
     /**
-     * <p>Sets the {@link android.os.Build#RANDOMIZEDDEVICETOKEN} value of the current OS build, on the current device,
+     * <p>Sets the randomized device token value of the current OS build, on the current device,
      * as a {@link String} in preferences.</p>
      *
      * @param randomized_device_token A {@link String} that uniquely identifies this build.
@@ -413,7 +413,7 @@ public class PrefHelper {
     }
     
     /**
-     * <p>Gets the {@link android.os.Build#RANDOMIZEDDEVICETOKEN} value of the current OS build, on the current device,
+     * <p>Gets the randomized device token value of the current OS build, on the current device,
      * as a {@link String} from preferences.</p>
      *
      * @return A {@link String} that uniquely identifies this build.

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -470,7 +470,7 @@ public abstract class ServerRequest {
     
     private boolean payloadContainsDeviceIdentifiers(JSONObject payload) {
         return payload.has(Defines.Jsonkey.AndroidID.getKey()) ||
-                payload.has(Defines.Jsonkey.DeviceFingerprintID.getKey()) ||
+                payload.has(Defines.Jsonkey.RandomizedDeviceToken.getKey()) ||
                 payload.has(Defines.ModuleNameKeys.imei.getKey());
     }
     
@@ -481,7 +481,7 @@ public abstract class ServerRequest {
             if (userDataObj != null) {
                 try {
                     userDataObj.put(Defines.Jsonkey.DeveloperIdentity.getKey(), prefHelper_.getIdentity());
-                    userDataObj.put(Defines.Jsonkey.DeviceFingerprintID.getKey(), prefHelper_.getDeviceFingerPrintID());
+                    userDataObj.put(Defines.Jsonkey.RandomizedDeviceToken.getKey(), prefHelper_.getRandomizedDeviceToken());
                 } catch (JSONException ignore) {
                 }
             }

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestActionCompleted.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestActionCompleted.java
@@ -38,8 +38,8 @@ class ServerRequestActionCompleted extends ServerRequest {
         JSONObject post = new JSONObject();
 
         try {
-            post.put(Defines.Jsonkey.IdentityID.getKey(), prefHelper_.getIdentityID());
-            post.put(Defines.Jsonkey.DeviceFingerprintID.getKey(), prefHelper_.getDeviceFingerPrintID());
+            post.put(Defines.Jsonkey.RandomizedBundleToken.getKey(), prefHelper_.getRandomizedBundleToken());
+            post.put(Defines.Jsonkey.RandomizedDeviceToken.getKey(), prefHelper_.getRandomizedDeviceToken());
             post.put(Defines.Jsonkey.SessionID.getKey(), prefHelper_.getSessionID());
             if (!prefHelper_.getLinkClickID().equals(PrefHelper.NO_STRING_VALUE)) {
                 post.put(Defines.Jsonkey.LinkClickID.getKey(), prefHelper_.getLinkClickID());

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestCreateUrl.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestCreateUrl.java
@@ -67,8 +67,8 @@ class ServerRequestCreateUrl extends ServerRequest {
 
         linkPost_ = new BranchLinkData();
         try {
-            linkPost_.put(Defines.Jsonkey.IdentityID.getKey(), prefHelper_.getIdentityID());
-            linkPost_.put(Defines.Jsonkey.DeviceFingerprintID.getKey(), prefHelper_.getDeviceFingerPrintID());
+            linkPost_.put(Defines.Jsonkey.RandomizedBundleToken.getKey(), prefHelper_.getRandomizedBundleToken());
+            linkPost_.put(Defines.Jsonkey.RandomizedDeviceToken.getKey(), prefHelper_.getRandomizedDeviceToken());
             linkPost_.put(Defines.Jsonkey.SessionID.getKey(), prefHelper_.getSessionID());
             if (!prefHelper_.getLinkClickID().equals(PrefHelper.NO_STRING_VALUE)) {
                 linkPost_.put(Defines.Jsonkey.LinkClickID.getKey(), prefHelper_.getLinkClickID());
@@ -191,7 +191,7 @@ class ServerRequestCreateUrl extends ServerRequest {
         String longUrl = baseUrl;
         try {
             if (Branch.getInstance().isTrackingDisabled() && !longUrl.contains(DEF_BASE_URL)) {
-                // By def the base url contains identity id as query param. This should be removed when tracking is disabled.
+                // By def the base url contains randomized bundle token as query param. This should be removed when tracking is disabled.
                 longUrl = longUrl.replace(new URL(longUrl).getQuery(), "");
             }
             longUrl += longUrl.contains("?") ? "" : "?";

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestIdentifyUserRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestIdentifyUserRequest.java
@@ -33,8 +33,8 @@ class ServerRequestIdentifyUserRequest extends ServerRequest {
 
         JSONObject post = new JSONObject();
         try {
-            post.put(Defines.Jsonkey.IdentityID.getKey(), prefHelper_.getIdentityID());
-            post.put(Defines.Jsonkey.DeviceFingerprintID.getKey(), prefHelper_.getDeviceFingerPrintID());
+            post.put(Defines.Jsonkey.RandomizedBundleToken.getKey(), prefHelper_.getRandomizedBundleToken());
+            post.put(Defines.Jsonkey.RandomizedDeviceToken.getKey(), prefHelper_.getRandomizedDeviceToken());
             post.put(Defines.Jsonkey.SessionID.getKey(), prefHelper_.getSessionID());
             if (!prefHelper_.getLinkClickID().equals(PrefHelper.NO_STRING_VALUE)) {
                 post.put(Defines.Jsonkey.LinkClickID.getKey(), prefHelper_.getLinkClickID());
@@ -57,7 +57,7 @@ class ServerRequestIdentifyUserRequest extends ServerRequest {
                 prefHelper_.setIdentity(getPost().getString(Defines.Jsonkey.Identity.getKey()));
             }
 
-            prefHelper_.setIdentityID(resp.getObject().getString(Defines.Jsonkey.IdentityID.getKey()));
+            prefHelper_.setRandomizedBundleToken(resp.getObject().getString(Defines.Jsonkey.RandomizedBundleToken.getKey()));
             prefHelper_.setUserURL(resp.getObject().getString(Defines.Jsonkey.Link.getKey()));
 
             if (resp.getObject().has(Defines.Jsonkey.ReferringData.getKey())) {

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -274,8 +274,8 @@ abstract class ServerRequestInitSession extends ServerRequest {
                 || post.has(Defines.Jsonkey.AndroidPushIdentifier.getKey())
                 || post.has(Defines.Jsonkey.LinkIdentifier.getKey()))) {
 
-            post.remove(Defines.Jsonkey.DeviceFingerprintID.getKey());
-            post.remove(Defines.Jsonkey.IdentityID.getKey());
+            post.remove(Defines.Jsonkey.RandomizedDeviceToken.getKey());
+            post.remove(Defines.Jsonkey.RandomizedBundleToken.getKey());
             post.remove(Defines.Jsonkey.FaceBookAppLinkChecked.getKey());
             post.remove(Defines.Jsonkey.External_Intent_Extra.getKey());
             post.remove(Defines.Jsonkey.External_Intent_URI.getKey());

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestLogout.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestLogout.java
@@ -28,8 +28,8 @@ class ServerRequestLogout extends ServerRequest {
         callback_ = callback;
         JSONObject post = new JSONObject();
         try {
-            post.put(Defines.Jsonkey.IdentityID.getKey(), prefHelper_.getIdentityID());
-            post.put(Defines.Jsonkey.DeviceFingerprintID.getKey(), prefHelper_.getDeviceFingerPrintID());
+            post.put(Defines.Jsonkey.RandomizedBundleToken.getKey(), prefHelper_.getRandomizedBundleToken());
+            post.put(Defines.Jsonkey.RandomizedDeviceToken.getKey(), prefHelper_.getRandomizedDeviceToken());
             post.put(Defines.Jsonkey.SessionID.getKey(), prefHelper_.getSessionID());
             if (!prefHelper_.getLinkClickID().equals(PrefHelper.NO_STRING_VALUE)) {
                 post.put(Defines.Jsonkey.LinkClickID.getKey(), prefHelper_.getLinkClickID());
@@ -49,7 +49,7 @@ class ServerRequestLogout extends ServerRequest {
     public void onRequestSucceeded(ServerResponse resp, Branch branch) {
         try {
             prefHelper_.setSessionID(resp.getObject().getString(Defines.Jsonkey.SessionID.getKey()));
-            prefHelper_.setIdentityID(resp.getObject().getString(Defines.Jsonkey.IdentityID.getKey()));
+            prefHelper_.setRandomizedBundleToken(resp.getObject().getString(Defines.Jsonkey.RandomizedBundleToken.getKey()));
             prefHelper_.setUserURL(resp.getObject().getString(Defines.Jsonkey.Link.getKey()));
 
             prefHelper_.setInstallParams(PrefHelper.NO_STRING_VALUE);

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterClose.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterClose.java
@@ -23,8 +23,8 @@ class ServerRequestRegisterClose extends ServerRequest {
         super(context, Defines.RequestPath.RegisterClose);
         JSONObject closePost = new JSONObject();
         try {
-            closePost.put(Defines.Jsonkey.DeviceFingerprintID.getKey(), prefHelper_.getDeviceFingerPrintID());
-            closePost.put(Defines.Jsonkey.IdentityID.getKey(), prefHelper_.getIdentityID());
+            closePost.put(Defines.Jsonkey.RandomizedDeviceToken.getKey(), prefHelper_.getRandomizedDeviceToken());
+            closePost.put(Defines.Jsonkey.RandomizedBundleToken.getKey(), prefHelper_.getRandomizedBundleToken());
             closePost.put(Defines.Jsonkey.SessionID.getKey(), prefHelper_.getSessionID());
             if (!prefHelper_.getLinkClickID().equals(PrefHelper.NO_STRING_VALUE)) {
                 closePost.put(Defines.Jsonkey.LinkClickID.getKey(), prefHelper_.getLinkClickID());

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterOpen.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterOpen.java
@@ -25,8 +25,8 @@ class ServerRequestRegisterOpen extends ServerRequestInitSession {
         callback_ = callback;
         JSONObject openPost = new JSONObject();
         try {
-            openPost.put(Defines.Jsonkey.DeviceFingerprintID.getKey(), prefHelper_.getDeviceFingerPrintID());
-            openPost.put(Defines.Jsonkey.IdentityID.getKey(), prefHelper_.getIdentityID());
+            openPost.put(Defines.Jsonkey.RandomizedDeviceToken.getKey(), prefHelper_.getRandomizedDeviceToken());
+            openPost.put(Defines.Jsonkey.RandomizedBundleToken.getKey(), prefHelper_.getRandomizedBundleToken());
             setPost(openPost);
         } catch (JSONException ex) {
             ex.printStackTrace();


### PR DESCRIPTION
Changed deprecated variables to randomizedDeviceToken and randomizedBundleToken

## Reference
SDK-1202 -- replace "identity_id" with "randomized_bundle_token" on Android
SDK-1206 -- replace "device_fingerprint_id" with "randomized_device_token" on Android

## Description
Updated old variable names to newer, more relevant names. 

## Testing Instructions
<!-- TESTING INSTRUCTIONS -->

## Risk Assessment [`MEDIUM`]
There were a lot of occurrences of these two variables, which leads to higher risk.

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
