### PR TITLE
Fix retry logic when no internet connectivity

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
@@ -222,9 +222,22 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
             } else {
                 throw new BranchRemoteException(BranchError.ERR_BRANCH_TASK_TIMEOUT);
             }
-        } catch (IOException ex) {
-            PrefHelper.Debug("Http connect exception: " + ex.getMessage());
-            throw new BranchRemoteException(BranchError.ERR_BRANCH_NO_CONNECTIVITY);
+        }
+        // Unable to resolve host/Unknown host exception
+        catch (IOException ex) {
+            if (retryNumber < prefHelper.getRetryCount()) {
+                try {
+                    Thread.sleep(prefHelper.getRetryInterval());
+                }
+                catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                retryNumber++;
+                return doRestfulPost(url, payload, retryNumber);
+            }
+            else {
+                throw new BranchRemoteException(BranchError.ERR_BRANCH_NO_CONNECTIVITY);
+            }
         } catch (Exception ex) {
             PrefHelper.Debug("Exception: " + ex.getMessage());
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB) {


### PR DESCRIPTION
Add retries to the generic catch for connection exceptions.

## Reference
INTENG-15152 - [Bug] Android SDK pings api continuously when there is no connection.

## Description

Normally connection exceptions are retried with the default number of retries and each spaced between with a default interval. It was noted that the init retries were flooding the log when the sdk attempted to initialize when the device had no internet connectivity.

This was partially a result of adding init (install/open) calls to be retried (placed back on the queue).  Before, this would silently fail and the SDK would not be able to recover. There is no built recovery mechanism when connection is reestablished, currently.

The root cause is the exception handling when no internet. The exception that is thrown is https://docs.oracle.com/javase/8/docs/api/java/rmi/UnknownHostException.html which is caught as an IOException. There is no retry logic in this catch. 

1. The init request fails (immediately)
2. A custom Branch error is returned
3. The init request is flagged for retry
4. The init request fails (immediately)

Solution is to add retries for this block so that the retry interval is invoked. By design, there is no maximum for retries for the Branch Request.

The retry interval can be set by Branch.getInstance().setRetryInterval(`interval`)
Where `interval` is an integer in milliseconds.

## Testing Instructions

Manual verification. Unit tests all successful.

## Risk Assessment [`LOW`]

- [✅] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
