### PR TITLE
Remove setContentExpiration in TestBed app

### DIFF
--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
@@ -78,7 +78,6 @@ public class MainActivity extends Activity {
                 .setTitle("My Content Title")
                 .setContentDescription("my_product_description1")
                 .setContentImageUrl("https://example.com/mycontent-12345.png")
-                .setContentExpiration(new Date(1573415635000L))
                 .setContentImageUrl("https://test_img_url")
                 .addKeyWord("My_Keyword1")
                 .addKeyWord("My_Keyword2")


### PR DESCRIPTION
This line has caused some confusion as the link generated is set to expire before it is even generated `1573415635000` -> Sunday, November 10, 2019 11:53:55 AM [GMT-08:00](https://www.epochconverter.com/timezones?q=1573415635000)

For now, removing it.

## Reference
[SDK-XXX -- <TITLE>.](https://github.com/BranchMetrics/android-branch-deep-linking-attribution/issues/996)

## Description
<!-- SUFFICIENT DESCRIPTION TO EXPLAIN THE PROBLEM THAT IS BEING SOLVED -->

## Testing Instructions
<!-- TESTING INSTRUCTIONS -->

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
