### PR TITLE
Fix improper unit test reference and manifest

### DIFF
--- a/Branch-SDK-TestBed/build.gradle.kts
+++ b/Branch-SDK-TestBed/build.gradle.kts
@@ -14,10 +14,10 @@ dependencies {
         exclude(module = "support-v4")
     }
 
-    androidTestImplementation("androidx.test.ext:junit:1.1.1")
-    androidTestImplementation("androidx.test:runner:1.2.0")
-    androidTestImplementation("androidx.test:rules:1.2.0")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.2.0")
+    androidTestImplementation("androidx.test.ext:junit:1.1.3")
+    androidTestImplementation("androidx.test:runner:1.4.0")
+    androidTestImplementation("androidx.test:rules:1.4.0")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
 }
 
 android {

--- a/Branch-SDK/build.gradle.kts
+++ b/Branch-SDK/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to "*.jar")))
     implementation(kotlin("stdlib"))
     implementation(kotlin("stdlib-jdk8"))
-    implementation("androidx.annotation:annotation:1.3.0")
+    implementation("androidx.annotation:annotation:1.4.0")
     implementation("com.android.installreferrer:installreferrer:2.2")
 
     // --- optional dependencies -----
@@ -22,10 +22,10 @@ dependencies {
 
     compileOnly("com.huawei.hms:ads-installreferrer:3.4.39.302")
 
-    androidTestImplementation("androidx.test.ext:junit:1.1.2")
-    androidTestImplementation("androidx.test:runner:1.3.0")
-    androidTestImplementation("androidx.test:rules:1.3.0")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.3.0")
+    androidTestImplementation("androidx.test.ext:junit:1.1.3")
+    androidTestImplementation("androidx.test:runner:1.4.0")
+    androidTestImplementation("androidx.test:rules:1.4.0")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
     // assume partner has it
     androidTestImplementation("com.google.android.gms:play-services-ads-identifier:17.0.0")
 

--- a/Branch-SDK/src/androidTest/AndroidManifest.xml
+++ b/Branch-SDK/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.branch.referral">
+    package="io.branch.referral.test">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchTest.java
@@ -2,26 +2,24 @@ package io.branch.referral;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.os.Handler;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
-import androidx.lifecycle.Lifecycle;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.json.JSONObject;
-import org.junit.Assert;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import io.branch.referral.mock.MockActivity;
-import io.branch.referral.mock.MockRemoteInterface;
+import io.branch.referral.test.mock.MockActivity;
+import io.branch.referral.test.mock.MockRemoteInterface;
 
 /**
  * Base Instrumented test, which will execute on an Android device.

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/test/mock/MockActivity.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/test/mock/MockActivity.java
@@ -1,4 +1,4 @@
-package io.branch.referral.mock;
+package io.branch.referral.test.mock;
 
 import android.app.Activity;
 import android.os.Bundle;

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/test/mock/MockRemoteInterface.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/test/mock/MockRemoteInterface.java
@@ -1,4 +1,4 @@
-package io.branch.referral.mock;
+package io.branch.referral.test.mock;
 
 import org.json.JSONObject;
 


### PR DESCRIPTION
## Reference
SDK-1522 -- Fix improper unit test reference and manifest

## Description
After the migration to Kotlin DSL from Groovy for our Gradle build definitions, some unit tests were impacted by a namespace change, specifically those requiring `MockActivity`.

The solution is to fix the instrumented apk's manifest to properly reference the class's package name and move the class file under `\test\`.

Additionally I updated the test 

## Testing Instructions
Before checking this out, verify that a subset of unit tests fail, then check out this changeset and verify all tests pass.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [✅ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
