### PR TITLE
Add identity string to v1 open

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1107,6 +1107,8 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      */
     public void setIdentity(@NonNull String userId, @Nullable BranchReferralInitListener
             callback) {
+        prefHelper_.setIdentity(userId);
+
         ServerRequestIdentifyUserRequest req = new ServerRequestIdentifyUserRequest(context_, callback, userId);
         if (!req.constructError_ && !req.handleErrors(context_)) {
             handleNewRequest(req);

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestIdentifyUserRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestIdentifyUserRequest.java
@@ -53,10 +53,6 @@ class ServerRequestIdentifyUserRequest extends ServerRequest {
 
     public void onRequestSucceeded(ServerResponse resp, Branch branch) {
         try {
-            if (getPost() != null && getPost().has(Defines.Jsonkey.Identity.getKey())) {
-                prefHelper_.setIdentity(getPost().getString(Defines.Jsonkey.Identity.getKey()));
-            }
-
             prefHelper_.setRandomizedBundleToken(resp.getObject().getString(Defines.Jsonkey.RandomizedBundleToken.getKey()));
             prefHelper_.setUserURL(resp.getObject().getString(Defines.Jsonkey.Link.getKey()));
 
@@ -114,7 +110,7 @@ class ServerRequestIdentifyUserRequest extends ServerRequest {
     /**
      * Return true if the user id provided for user identification is the same as existing id
      *
-     * @return True if the user id refferes to the existing user
+     * @return True if the user id refers to the existing user
      */
     public boolean isExistingID() {
         try {

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -60,6 +60,12 @@ abstract class ServerRequestInitSession extends ServerRequest {
 
         updateInstallStateAndTimestamps(post);
         updateEnvironment(context_, post);
+
+        String identity = prefHelper_.getIdentity();
+
+        if(!TextUtils.isEmpty(identity) && !identity.equals(PrefHelper.NO_STRING_VALUE)){
+            post.put(Defines.Jsonkey.Identity.getKey(), identity);
+        }
     }
 
     @Override
@@ -289,6 +295,7 @@ abstract class ServerRequestInitSession extends ServerRequest {
             post.remove(Defines.Jsonkey.IsHardwareIDReal.getKey());
             post.remove(Defines.Jsonkey.LocalIP.getKey());
             post.remove(Defines.Jsonkey.ReferrerGclid.getKey());
+            post.remove(Defines.Jsonkey.Identity.getKey());
             try {
                 post.put(Defines.Jsonkey.TrackingDisabled.getKey(), true);
             } catch (JSONException ignore) {


### PR DESCRIPTION
## Reference
SDK-1527 -- developer id in v1/open, v1/install

## Description
Part 1 of many phases, this PR only adds identity as a top level field in v1 open and install request bodies.
A minor change in behavior is when the identity is saved locally. 

Before when setIdentity("id") is called, it awaited a successful response from v1/profile before committing that same in memory string to disk.
Now, it is saved immediately when the function is called so that if setIdentity is called before the session is initialized, it can be passed in installs.

## Testing Instructions
✅ **[Mobile & Desktop SDKs]When set, developer id is present on the install and open requests top level for the key identity**

- Set an identity then verify in the request `"identity": "value"` is sent on the next open. 

**[Web SDK] When set, developer id is present on the open and both pageview requests top level for the key identity**

- NA

✅ **[All SDKs] Calling setIdentity() before initializing should be accepted and not cause any errors.**

- Call setIdentity in the application before creating the session so that it can be picked on install. No errors found 
 
✅ **v2/event is not impacted by the change in developer id.**

- No changes made to v2, I want to remark that it already exists under `userData` as `developer_identity`

✅ **logout or equivalent method clears the developer id and it is not included in any network request.**

- `SeverRequestLogout.onRequestSucceeded` already clears identity with             `prefHelper_.setIdentity(PrefHelper.NO_STRING_VALUE);`


✅ **setTrackingDisabled clears the developer id and it is not included in any network request.**

- `setTrackingDisabled` now includes removing the newly added `identity` field from the request. 

## Risk Assessment [`LOW`]

- [✅ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
