### PR TITLE
Fix POM Name

### DIFF
--- a/Branch-SDK/build.gradle.kts
+++ b/Branch-SDK/build.gradle.kts
@@ -120,6 +120,7 @@ publishing {
     val GROUP: String by project
     val VERSION_NAME: String by project
     val POM_ARTIFACT_ID: String by project
+    val POM_NAME: String by project
     val POM_DESCRIPTION: String by project
     val POM_URL: String by project
     val POM_SCM_URL: String by project
@@ -137,6 +138,7 @@ publishing {
             artifactId = POM_ARTIFACT_ID
             version = VERSION_NAME
             pom {
+                name.set(POM_NAME)
                 url.set(POM_URL)
                 description.set(POM_DESCRIPTION)
                 developers {


### PR DESCRIPTION
POM generated did not have POM_NAME referenced after the migration, adding it back.

## Reference
SDK-1573 -- Android - Fix POM name

## Description

This is one of the requirements for uploading to Maven Central. Without it, we cannot upload to Maven Central.

## Testing Instructions
I verified by running the publish command and seeing it in the resulting artifact in Staging. I then discarded it before publishing to production.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [✅ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
