### PR TITLE
Add max retry setting for no connection errors

### DIFF
--- a/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
@@ -174,6 +174,7 @@ public class PrefHelperTest extends BranchTest {
         prefHelper.setReferrerGclidValidForWindow(PrefHelper.DEFAULT_VALID_WINDOW_FOR_REFERRER_GCLID);
     }
 
+    @Test
     public void testSetRandomlyGeneratedUuid(){
         String uuid = UUID.randomUUID().toString();
 
@@ -181,5 +182,18 @@ public class PrefHelperTest extends BranchTest {
         String result = prefHelper.getRandomlyGeneratedUuid();
 
         Assert.assertEquals(uuid, result);
+    }
+
+    @Test
+    public void testSetNoConnectionRetryMaxReturnsDefault(){
+        Assert.assertEquals(prefHelper.getNoConnectionRetryMax(), PrefHelper.DEFAULT_NO_CONNECTION_RETRY_MAX);
+    }
+
+    @Test
+    public void testSetNoConnectionRetryMax(){
+        int max = 10;
+        prefHelper.setNoConnectionRetryMax(max);
+
+        Assert.assertEquals(max, prefHelper.getNoConnectionRetryMax());
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -740,7 +740,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      * set a maximum number of attempts for the Branch Request to be tried.
      *
      * Must be greater than 0
-     * Defaults to 2
+     * Defaults to 3
      * @param retryMax
      */
     public void setNoConnectionRetryMax(int retryMax){

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -736,6 +736,20 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     }
 
     /**
+     * In cases of persistent no internet connection or offline modes,
+     * set a maximum number of attempts for the Branch Request to be tried.
+     *
+     * Must be greater than 0
+     * Defaults to 2
+     * @param retryMax
+     */
+    public void setNoConnectionRetryMax(int retryMax){
+        if(prefHelper_ != null && retryMax > 0){
+            prefHelper_.setNoConnectionRetryMax(retryMax);
+        }
+    }
+
+    /**
      * Sets the window for the referrer GCLID field. The GCLID will be persisted locally from the
      * time it is set + window in milliseconds. Thereafter, it will be deleted.
      *
@@ -2426,13 +2440,17 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             }
 
             boolean unretryableErrorCode = (400 <= status && status <= 451) || status == BranchError.ERR_BRANCH_TRACKING_DISABLED;
-            if (unretryableErrorCode || !thisReq_.shouldRetryOnFail()) {
+            // If it has an un-retryable error code, or it should not retry on fail, or the current retry count exceeds the max
+            // remove it from the queue
+            if (unretryableErrorCode || !thisReq_.shouldRetryOnFail() || (thisReq_.currentRetryCount >= prefHelper_.getNoConnectionRetryMax())) {
                 requestQueue_.remove(thisReq_);
             } else {
                 // failure has already been handled
                 // todo does it make sense to retry the request without a callback? (e.g. CPID, LATD)
                 thisReq_.clearCallbacks();
             }
+
+            thisReq_.currentRetryCount++;
         }
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -60,7 +60,7 @@ public class PrefHelper {
     static final long DEFAULT_VALID_WINDOW_FOR_REFERRER_GCLID = 2592000000L; // Default expiration is 30 days, in milliseconds
     static final long MAX_VALID_WINDOW_FOR_REFERRER_GCLID = 100000000000L; // Arbitrary maximum window to prevent overflow, 3 years, in milliseconds
     static final long MIN_VALID_WINDOW_FOR_REFERRER_GCLID = 0L; // Don't allow time set in the past , in milliseconds
-
+    static final int DEFAULT_NO_CONNECTION_RETRY_MAX = 3;
 
     private static final String SHARED_PREF_FILE = "branch_referral_shared_pref";
     
@@ -101,6 +101,7 @@ public class PrefHelper {
     private static final String KEY_TIMEOUT = "bnc_timeout";
     private static final String KEY_TASK_TIMEOUT = "bnc_task_timeout";
     private static final String KEY_CONNECT_TIMEOUT = "bnc_connect_timeout";
+    private static final String KEY_NO_CONNECTION_RETRY_MAX = "bnc_no_connection_retry_max";
 
     private static final String KEY_LAST_READ_SYSTEM = "bnc_system_read_date";
     
@@ -357,6 +358,23 @@ public class PrefHelper {
      */
     public int getRetryInterval() {
         return getInteger(KEY_RETRY_INTERVAL, INTERVAL_RETRY);
+    }
+
+    /**
+     * In cases of persistent no internet connection or offline modes,
+     * set a maximum number of attempts for the Branch Request to be tried.
+     * @param retryInt
+     */
+    public void setNoConnectionRetryMax(int retryInt){
+        setInteger(KEY_NO_CONNECTION_RETRY_MAX, retryInt);
+    }
+
+    /**
+     * Returns the set retry count for Branch Requests
+     * @return
+     */
+    public int getNoConnectionRetryMax(){
+        return getInteger(KEY_NO_CONNECTION_RETRY_MAX, DEFAULT_NO_CONNECTION_RETRY_MAX);
     }
     
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -63,7 +63,9 @@ public abstract class ServerRequest {
         V1_LATD,
         V2
     }
-    
+
+    public int currentRetryCount = 0;
+
     /**
      * <p>Creates an instance of ServerRequest.</p>
      *


### PR DESCRIPTION
## Reference
SDK-1558 --  [Android] Create Default Retry Cap for No-Internet Request Queues

## Description
Previously we fixed an issue wherein requests were not being retried at all when no connection could be established to our services. We succeeded in having the network requests retry, however some internal logic was used to determine whether or not a Branch Request would be retried, and connection errors were not considered "unretryable" and we had no cap.

This PR introduces a default retry cap for requests put on the queue that can be overridden with a public api.
For example, before starting the init session call the following: 
`Branch.getInstance().setNoConnectionRetryMax(5);`

## Testing Instructions
Manually tested, added some minor unit tests.
Test that it works as expected with internet and returns 200 on the first try.
Test turning off network on the device- see that it calls to our service the amount of times specified.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [✅] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
