### PR TITLE
Add app store source in request

### DIFF
--- a/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
@@ -196,4 +196,12 @@ public class PrefHelperTest extends BranchTest {
 
         Assert.assertEquals(max, prefHelper.getNoConnectionRetryMax());
     }
+
+    @Test
+    public void testAppStoreSource(){
+        prefHelper.setAppStoreSource(Defines.Jsonkey.Google_Play_Store.getKey());
+
+        String result = prefHelper.getAppStoreSource();
+        Assert.assertEquals(Defines.Jsonkey.Google_Play_Store.getKey(), result);
+    }
 }

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/StoreReferrerTests.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/StoreReferrerTests.java
@@ -42,9 +42,12 @@ public class StoreReferrerTests extends BranchTest {
         StoreReferrerXiaomiGetApps.clickTimestamp = Long.MAX_VALUE-3;
         StoreReferrerXiaomiGetApps.rawReferrer = "xiaomi";
 
-        String result = StoreReferrerUtils.getLatestValidReferrerStore();
+        String result = StoreReferrerUtils.getLatestValidReferrerStore(context);
 
-        Assert.assertEquals(Defines.Jsonkey.HUAWEI_APP_GALLERY.getKey(), result);
+        Assert.assertEquals(Defines.Jsonkey.Huawei_App_Gallery.getKey(), result);
+
+        StoreReferrerUtils.writeLatestInstallReferrer(context, result);
+        Assert.assertEquals(Defines.Jsonkey.Huawei_App_Gallery.getKey(), prefHelper.getAppStoreSource());
     }
 
     @Test
@@ -65,9 +68,12 @@ public class StoreReferrerTests extends BranchTest {
         StoreReferrerXiaomiGetApps.clickTimestamp = Long.MIN_VALUE;
         StoreReferrerXiaomiGetApps.rawReferrer = null;
 
-        String result = StoreReferrerUtils.getLatestValidReferrerStore();
+        String result = StoreReferrerUtils.getLatestValidReferrerStore(context);
 
         Assert.assertEquals("", result);
+
+        StoreReferrerUtils.writeLatestInstallReferrer(context, result);
+        Assert.assertEquals(PrefHelper.NO_STRING_VALUE, prefHelper.getAppStoreSource());
     }
 
     @Test
@@ -88,9 +94,12 @@ public class StoreReferrerTests extends BranchTest {
         StoreReferrerXiaomiGetApps.clickTimestamp = 0L;
         StoreReferrerXiaomiGetApps.rawReferrer = null;
 
-        String result = StoreReferrerUtils.getLatestValidReferrerStore();
+        String result = StoreReferrerUtils.getLatestValidReferrerStore(context);
 
-        Assert.assertEquals(Defines.Jsonkey.GOOGLE_PLAY_STORE.getKey(), result);
+        Assert.assertEquals(Defines.Jsonkey.Google_Play_Store.getKey(), result);
+
+        StoreReferrerUtils.writeLatestInstallReferrer(context, result);
+        Assert.assertEquals(Defines.Jsonkey.Google_Play_Store.getKey(), prefHelper.getAppStoreSource());
     }
 
     @Test
@@ -111,9 +120,10 @@ public class StoreReferrerTests extends BranchTest {
         StoreReferrerXiaomiGetApps.clickTimestamp = 0L;
         StoreReferrerXiaomiGetApps.rawReferrer = null;
 
-        String result = StoreReferrerUtils.getLatestValidReferrerStore();
+        String result = StoreReferrerUtils.getLatestValidReferrerStore(context);
 
         StoreReferrerUtils.writeLatestInstallReferrer(context, result);
         Assert.assertEquals(StoreReferrerGooglePlayStore.rawReferrer, PrefHelper.getInstance(context).getAppStoreReferrer());
+        Assert.assertEquals(Defines.Jsonkey.Google_Play_Store.getKey(), prefHelper.getAppStoreSource());
     }
 }

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/StoreReferrerTests.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/StoreReferrerTests.java
@@ -42,7 +42,7 @@ public class StoreReferrerTests extends BranchTest {
         StoreReferrerXiaomiGetApps.clickTimestamp = Long.MAX_VALUE-3;
         StoreReferrerXiaomiGetApps.rawReferrer = "xiaomi";
 
-        String result = StoreReferrerUtils.getLatestValidReferrerStore(context);
+        String result = StoreReferrerUtils.getLatestValidReferrerStore();
 
         Assert.assertEquals(Defines.Jsonkey.Huawei_App_Gallery.getKey(), result);
 
@@ -68,7 +68,7 @@ public class StoreReferrerTests extends BranchTest {
         StoreReferrerXiaomiGetApps.clickTimestamp = Long.MIN_VALUE;
         StoreReferrerXiaomiGetApps.rawReferrer = null;
 
-        String result = StoreReferrerUtils.getLatestValidReferrerStore(context);
+        String result = StoreReferrerUtils.getLatestValidReferrerStore();
 
         Assert.assertEquals("", result);
 
@@ -94,7 +94,7 @@ public class StoreReferrerTests extends BranchTest {
         StoreReferrerXiaomiGetApps.clickTimestamp = 0L;
         StoreReferrerXiaomiGetApps.rawReferrer = null;
 
-        String result = StoreReferrerUtils.getLatestValidReferrerStore(context);
+        String result = StoreReferrerUtils.getLatestValidReferrerStore();
 
         Assert.assertEquals(Defines.Jsonkey.Google_Play_Store.getKey(), result);
 
@@ -120,7 +120,7 @@ public class StoreReferrerTests extends BranchTest {
         StoreReferrerXiaomiGetApps.clickTimestamp = 0L;
         StoreReferrerXiaomiGetApps.rawReferrer = null;
 
-        String result = StoreReferrerUtils.getLatestValidReferrerStore(context);
+        String result = StoreReferrerUtils.getLatestValidReferrerStore();
 
         StoreReferrerUtils.writeLatestInstallReferrer(context, result);
         Assert.assertEquals(StoreReferrerGooglePlayStore.rawReferrer, PrefHelper.getInstance(context).getAppStoreReferrer());

--- a/Branch-SDK/src/main/java/io/branch/referral/AppStoreReferrer.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/AppStoreReferrer.java
@@ -15,8 +15,11 @@ public abstract class AppStoreReferrer {
     /* Link identifier on installing app from play store. */
     private static String installID_ = PrefHelper.NO_STRING_VALUE;
 
-    protected static void processReferrerInfo(Context context, String rawReferrerString, long referrerClickTS, long installClickTS) {
+    protected static void processReferrerInfo(Context context, String rawReferrerString, long referrerClickTS, long installClickTS, String store) {
         PrefHelper prefHelper = PrefHelper.getInstance(context);
+        if(!TextUtils.isEmpty(store)){
+            prefHelper.setAppStoreSource(store);
+        }
         if (referrerClickTS > 0) {
             prefHelper.setLong(PrefHelper.KEY_REFERRER_CLICK_TS, referrerClickTS);
         }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1038,7 +1038,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
 
     private void tryProcessNextQueueItemAfterInstallReferrer() {
         if(!(waitingForGoogleInstallReferrer || waitingForHuaweiInstallReferrer || waitingForSamsungInstallReferrer || waitingForXiaomiInstallReferrer)){
-            String store = StoreReferrerUtils.getLatestValidReferrerStore(context_);
+            String store = StoreReferrerUtils.getLatestValidReferrerStore();
             StoreReferrerUtils.writeLatestInstallReferrer(context_, store);
             processNextQueueItem();
         }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1038,7 +1038,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
 
     private void tryProcessNextQueueItemAfterInstallReferrer() {
         if(!(waitingForGoogleInstallReferrer || waitingForHuaweiInstallReferrer || waitingForSamsungInstallReferrer || waitingForXiaomiInstallReferrer)){
-            String store = StoreReferrerUtils.getLatestValidReferrerStore();
+            String store = StoreReferrerUtils.getLatestValidReferrerStore(context_);
             StoreReferrerUtils.writeLatestInstallReferrer(context_, store);
             processNextQueueItem();
         }

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -218,10 +218,11 @@ public class Defines {
         QRCodeBranchKey("branch_key"),
         QRCodeResponseString("QRCodeString"),
 
-        GOOGLE_PLAY_STORE("google_play_store"),
-        HUAWEI_APP_GALLERY("huawei_app_gallery"),
-        SAMSUNG_GALAXY_STORE("samsung_galaxy_store"),
-        XIAOMI_GET_APPS("xiaomi_get_apps");
+        App_Store("app_store"),
+        Google_Play_Store("PlayStore"),
+        Huawei_App_Gallery("AppGallery"),
+        Samsung_Galaxy_Store("GalaxyStore"),
+        Xiaomi_Get_Apps("GetApps");
 
         private final String key;
         

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -183,9 +183,7 @@ class DeviceInfo {
                 }
 
                 String appStore = prefHelper.getAppStoreSource();
-                if(!isNullOrEmptyOrBlank(appStore)){
-                    userDataObj.put(Defines.Jsonkey.App_Store.getKey(), appStore);
-                }
+                userDataObj.put(Defines.Jsonkey.App_Store.getKey(), appStore);
             }
 
             userDataObj.put(Defines.Jsonkey.AppVersion.getKey(), getAppVersion());

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -181,6 +181,11 @@ class DeviceInfo {
                 if (!isNullOrEmptyOrBlank(devId)) {
                     userDataObj.put(Defines.Jsonkey.DeveloperIdentity.getKey(), devId);
                 }
+
+                String appStore = prefHelper.getAppStoreSource();
+                if(!isNullOrEmptyOrBlank(appStore)){
+                    userDataObj.put(Defines.Jsonkey.App_Store.getKey(), appStore);
+                }
             }
 
             userDataObj.put(Defines.Jsonkey.AppVersion.getKey(), getAppVersion());

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -183,7 +183,9 @@ class DeviceInfo {
                 }
 
                 String appStore = prefHelper.getAppStoreSource();
-                userDataObj.put(Defines.Jsonkey.App_Store.getKey(), appStore);
+                if(!NO_STRING_VALUE.equals(appStore)) {
+                    userDataObj.put(Defines.Jsonkey.App_Store.getKey(), appStore);
+                }
             }
 
             userDataObj.put(Defines.Jsonkey.AppVersion.getKey(), getAppVersion());

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -76,6 +76,7 @@ public class PrefHelper {
     private static final String KEY_LINK_CLICK_IDENTIFIER = "bnc_link_click_identifier";
     private static final String KEY_GOOGLE_SEARCH_INSTALL_IDENTIFIER = "bnc_google_search_install_identifier";
     private static final String KEY_GOOGLE_PLAY_INSTALL_REFERRER_EXTRA = "bnc_google_play_install_referrer_extras";
+    private static final String KEY_APP_STORE_SOURCE = "bnc_app_store_source";
     private static final String KEY_GCLID_JSON_OBJECT = "bnc_gclid_json_object";
     private static final String KEY_GCLID_VALUE = "bnc_gclid_value";
     private static final String KEY_GCLID_EXPIRATION_DATE = "bnc_gclid_expiration_date";
@@ -693,6 +694,14 @@ public class PrefHelper {
      */
     public String getAppStoreReferrer() {
         return getString(KEY_GOOGLE_PLAY_INSTALL_REFERRER_EXTRA);
+    }
+
+    public void setAppStoreSource(String store){
+        setString(KEY_APP_STORE_SOURCE, store);
+    }
+
+    public String getAppStoreSource(){
+        return getString(KEY_APP_STORE_SOURCE);
     }
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -697,7 +697,7 @@ public class PrefHelper {
     }
 
     public void setAppStoreSource(String store){
-        if(!DeviceInfo.isNullOrEmptyOrBlank(store)) {
+        if(!TextUtils.isEmpty(store)) {
             setString(KEY_APP_STORE_SOURCE, store);
         }
     }

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -697,7 +697,9 @@ public class PrefHelper {
     }
 
     public void setAppStoreSource(String store){
-        setString(KEY_APP_STORE_SOURCE, store);
+        if(!DeviceInfo.isNullOrEmptyOrBlank(store)) {
+            setString(KEY_APP_STORE_SOURCE, store);
+        }
     }
 
     public String getAppStoreSource(){

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -168,6 +168,17 @@ abstract class ServerRequestInitSession extends ServerRequest {
             } catch (JSONException ignore) {
             }
         }
+
+        String appStore = prefHelper_.getAppStoreSource();
+        if(!TextUtils.isEmpty(appStore) && !PrefHelper.NO_STRING_VALUE.equals(appStore)){
+            try{
+                getPost().put(Defines.Jsonkey.App_Store.getKey(), appStore);
+            }
+            catch (JSONException ignore){
+
+            }
+        }
+
         // Check for Conversion from instant app to full app
         if (prefHelper_.isFullAppConversion()) {
             try {

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -170,13 +170,10 @@ abstract class ServerRequestInitSession extends ServerRequest {
         }
 
         String appStore = prefHelper_.getAppStoreSource();
-        if(!TextUtils.isEmpty(appStore) && !PrefHelper.NO_STRING_VALUE.equals(appStore)){
-            try{
-                getPost().put(Defines.Jsonkey.App_Store.getKey(), appStore);
-            }
-            catch (JSONException ignore){
-
-            }
+        try{
+            getPost().put(Defines.Jsonkey.App_Store.getKey(), appStore);
+        }
+        catch (JSONException ignore){
         }
 
         // Check for Conversion from instant app to full app

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -170,10 +170,11 @@ abstract class ServerRequestInitSession extends ServerRequest {
         }
 
         String appStore = prefHelper_.getAppStoreSource();
-        try{
-            getPost().put(Defines.Jsonkey.App_Store.getKey(), appStore);
-        }
-        catch (JSONException ignore){
+        if(!PrefHelper.NO_STRING_VALUE.equals(appStore)) {
+            try {
+                getPost().put(Defines.Jsonkey.App_Store.getKey(), appStore);
+            } catch (JSONException ignore) {
+            }
         }
 
         // Check for Conversion from instant app to full app

--- a/Branch-SDK/src/main/java/io/branch/referral/StoreReferrerUtils.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/StoreReferrerUtils.java
@@ -1,9 +1,9 @@
 package io.branch.referral;
 
-import static io.branch.referral.Defines.Jsonkey.GOOGLE_PLAY_STORE;
-import static io.branch.referral.Defines.Jsonkey.HUAWEI_APP_GALLERY;
-import static io.branch.referral.Defines.Jsonkey.SAMSUNG_GALAXY_STORE;
-import static io.branch.referral.Defines.Jsonkey.XIAOMI_GET_APPS;
+import static io.branch.referral.Defines.Jsonkey.Google_Play_Store;
+import static io.branch.referral.Defines.Jsonkey.Huawei_App_Gallery;
+import static io.branch.referral.Defines.Jsonkey.Samsung_Galaxy_Store;
+import static io.branch.referral.Defines.Jsonkey.Xiaomi_Get_Apps;
 
 import android.content.Context;
 import android.text.TextUtils;
@@ -17,46 +17,46 @@ public class StoreReferrerUtils {
      * Then iterate for first non-null string.
      * @return Name of the store
      */
-    public static String getLatestValidReferrerStore(){
+    public static String getLatestValidReferrerStore(Context context){
         String result = "";
-        Long latestTimeStamp = Long.MIN_VALUE;
+        Long latestTimeStamp = 0L;
 
         if(StoreReferrerGooglePlayStore.installBeginTimestamp > latestTimeStamp){
             latestTimeStamp = StoreReferrerGooglePlayStore.installBeginTimestamp;
-            result = GOOGLE_PLAY_STORE.getKey();
+            result = Google_Play_Store.getKey();
         }
 
         if(StoreReferrerHuaweiAppGallery.installBeginTimestamp > latestTimeStamp){
             latestTimeStamp = StoreReferrerHuaweiAppGallery.installBeginTimestamp;
-            result = HUAWEI_APP_GALLERY.getKey();
+            result = Huawei_App_Gallery.getKey();
         }
 
         if(StoreReferrerSamsungGalaxyStore.installBeginTimestamp > latestTimeStamp){
             latestTimeStamp = StoreReferrerSamsungGalaxyStore.installBeginTimestamp;
-            result = SAMSUNG_GALAXY_STORE.getKey();
+            result = Samsung_Galaxy_Store.getKey();
         }
 
         if(StoreReferrerXiaomiGetApps.installBeginTimestamp > latestTimeStamp){
-            result = XIAOMI_GET_APPS.getKey();
+            result = Xiaomi_Get_Apps.getKey();
         }
 
         // iterate through non-null strings for cases like Google Play returning
         // "utm_source=google-play&utm_medium=organic" for organic installs
         if(result.isEmpty()){
             if(!TextUtils.isEmpty(StoreReferrerGooglePlayStore.rawReferrer)){
-                result = GOOGLE_PLAY_STORE.getKey();
+                result = Google_Play_Store.getKey();
             }
 
             if(!TextUtils.isEmpty(StoreReferrerHuaweiAppGallery.rawReferrer)){
-                result = HUAWEI_APP_GALLERY.getKey();
+                result = Huawei_App_Gallery.getKey();
             }
 
             if(!TextUtils.isEmpty(StoreReferrerSamsungGalaxyStore.rawReferrer)){
-                result = SAMSUNG_GALAXY_STORE.getKey();
+                result = Samsung_Galaxy_Store.getKey();
             }
 
             if(!TextUtils.isEmpty(StoreReferrerXiaomiGetApps.rawReferrer)){
-                result = XIAOMI_GET_APPS.getKey();
+                result = Xiaomi_Get_Apps.getKey();
             }
         }
 
@@ -64,17 +64,17 @@ public class StoreReferrerUtils {
     }
 
     public static void writeLatestInstallReferrer(Context context_, String store) {
-        if(store.equals(Defines.Jsonkey.GOOGLE_PLAY_STORE.getKey())){
-            AppStoreReferrer.processReferrerInfo(context_, StoreReferrerGooglePlayStore.rawReferrer, StoreReferrerGooglePlayStore.clickTimestamp, StoreReferrerGooglePlayStore.installBeginTimestamp);
+        if(store.equals(Defines.Jsonkey.Google_Play_Store.getKey())){
+            AppStoreReferrer.processReferrerInfo(context_, StoreReferrerGooglePlayStore.rawReferrer, StoreReferrerGooglePlayStore.clickTimestamp, StoreReferrerGooglePlayStore.installBeginTimestamp, store);
         }
-        if(store.equals(Defines.Jsonkey.HUAWEI_APP_GALLERY.getKey())){
-            AppStoreReferrer.processReferrerInfo(context_, StoreReferrerHuaweiAppGallery.rawReferrer, StoreReferrerHuaweiAppGallery.clickTimestamp, StoreReferrerHuaweiAppGallery.installBeginTimestamp);
+        if(store.equals(Defines.Jsonkey.Huawei_App_Gallery.getKey())){
+            AppStoreReferrer.processReferrerInfo(context_, StoreReferrerHuaweiAppGallery.rawReferrer, StoreReferrerHuaweiAppGallery.clickTimestamp, StoreReferrerHuaweiAppGallery.installBeginTimestamp, store);
         }
-        if(store.equals(Defines.Jsonkey.SAMSUNG_GALAXY_STORE.getKey())){
-            AppStoreReferrer.processReferrerInfo(context_, StoreReferrerSamsungGalaxyStore.rawReferrer, StoreReferrerSamsungGalaxyStore.clickTimestamp, StoreReferrerSamsungGalaxyStore.installBeginTimestamp);
+        if(store.equals(Defines.Jsonkey.Samsung_Galaxy_Store.getKey())){
+            AppStoreReferrer.processReferrerInfo(context_, StoreReferrerSamsungGalaxyStore.rawReferrer, StoreReferrerSamsungGalaxyStore.clickTimestamp, StoreReferrerSamsungGalaxyStore.installBeginTimestamp, store);
         }
-        if(store.equals(Defines.Jsonkey.XIAOMI_GET_APPS.getKey())){
-            AppStoreReferrer.processReferrerInfo(context_, StoreReferrerXiaomiGetApps.rawReferrer, StoreReferrerXiaomiGetApps.clickTimestamp, StoreReferrerXiaomiGetApps.installBeginTimestamp);
+        if(store.equals(Defines.Jsonkey.Xiaomi_Get_Apps.getKey())){
+            AppStoreReferrer.processReferrerInfo(context_, StoreReferrerXiaomiGetApps.rawReferrer, StoreReferrerXiaomiGetApps.clickTimestamp, StoreReferrerXiaomiGetApps.installBeginTimestamp, store);
         }
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/StoreReferrerUtils.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/StoreReferrerUtils.java
@@ -17,7 +17,7 @@ public class StoreReferrerUtils {
      * Then iterate for first non-null string.
      * @return Name of the store
      */
-    public static String getLatestValidReferrerStore(Context context){
+    public static String getLatestValidReferrerStore(){
         String result = "";
         Long latestTimeStamp = 0L;
 

--- a/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
@@ -57,6 +57,7 @@ public class TrackingController {
         prefHelper.setAppLink(PrefHelper.NO_STRING_VALUE);
         prefHelper.setInstallReferrerParams(PrefHelper.NO_STRING_VALUE);
         prefHelper.setAppStoreReferrer(PrefHelper.NO_STRING_VALUE);
+        prefHelper.setAppStoreSource(PrefHelper.NO_STRING_VALUE);
         prefHelper.setGoogleSearchInstallIdentifier(PrefHelper.NO_STRING_VALUE);
         prefHelper.setInitialReferrer(PrefHelper.NO_STRING_VALUE);
         prefHelper.setExternalIntentUri(PrefHelper.NO_STRING_VALUE);


### PR DESCRIPTION
## Reference
SDK-1496 -- [Android] Persist and send app_store on requests

## Description
Recently a feature was added to support install referrer support across multiple OEMS. To add onto this, we're adding a field to v1 install/open and v2 events to explicitly denote the source that drove the installation of the app.

For v1 it is sent at top level
```
{
    "app_store": "PlayStore",
}

```
For v2
```
{
    "user_data":
    {
         "app_store": "PlayStore",
    }
}
```

Logs shared internally.

To conform with privacy practices - the field is removed when `disableTracking` is true.

## Testing Instructions
Same testing requirements as the original feature- must be tested in environments that support the OEMs' app stores. If not feasible, at least verifying no regressions with the Google Play Store installreferrer. Testing guide shared internally.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [✅ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
