### PR TITLE
Release 5.2.2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,9 @@
 # Branch Android SDK change log
+- v5.2.2
+  * _*Master Release*_ - Aug 15, 2022
+  * Sending app_store install source on requests
+  * Added default retry cap for no-internet request queues 
+  
 - v5.2.1
   * _*Master Release*_ - Aug 8, 2022
   * Removed unused IMEI strings and references in the Java

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.2.1
-VERSION_CODE=050201
+VERSION_NAME=5.2.2
+VERSION_CODE=050202
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.


### PR DESCRIPTION
- v5.2.2
  * _*Master Release*_ - Aug 15, 2022
  * Sending app_store install source on requests
  * Added default retry cap for no-internet request queues 