### PR TITLE
Change POM scope for firebase-appindexing

### DIFF
--- a/Branch-SDK/build.gradle.kts
+++ b/Branch-SDK/build.gradle.kts
@@ -176,11 +176,21 @@ publishing {
                         .forEach { dependency ->
                             val artifactId = dependency.getChild("artifactId")
                             if (artifactId.text() == "okhttp" || artifactId.text() == "firebase-appindexing") {
+                                // Ensure optional flag is set
                                 val optional = dependency.getChildOrNull("optional")
                                 if (optional != null) {
                                     optional.setValue("true")
                                 } else {
                                     dependency.appendNode("optional", "true")
+                                }
+
+                                // Ensure scope is set to 'compile'
+                                val scope = dependency.getChildOrNull("scope")
+                                if (scope != null) {
+                                    scope.setValue("compile")
+                                }
+                                else {
+                                    dependency.appendNode("scope", "compile")
                                 }
                             }
                         }


### PR DESCRIPTION
Change POM scope for firebase-appindexing from "runtime" to "compile"

## Reference
SDK-1606 -- [Android] Change scope of firebase-appindexing to 'compile']

## Description
POM scope for firebase-appindexing (optional dependency) was being set to "runtime".
This change outputs the scope as "compile" in the POM file.

## Testing Instructions
1. Publish (locally) as is `./gradlew publishToMavenLocal`
2. Verify POM value of `runtime`
3. Publish (locally) with change `./gradlew publishToMavenLocal`
4. Verify POM value of `compile`

## Risk Assessment [`LOW`]

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
