### PR TITLE
Use webview instance for user agent string

### DIFF
--- a/Branch-SDK/src/androidTest/java/io/branch/referral/DeviceInfoTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/DeviceInfoTest.java
@@ -5,7 +5,10 @@ import android.hardware.display.DisplayManager;
 import android.util.DisplayMetrics;
 import android.view.Display;
 import android.view.WindowManager;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
 
+import androidx.test.annotation.UiThreadTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Assert;
@@ -93,5 +96,17 @@ public class DeviceInfoTest extends BranchTest {
         Assert.assertEquals(displayMetrics1.widthPixels, displayMetrics2.widthPixels);
         Assert.assertEquals(displayMetrics1.heightPixels, displayMetrics2.heightPixels);
         Assert.assertEquals(displayMetrics1.densityDpi, displayMetrics2.densityDpi);
+    }
+
+    @Test
+    @UiThreadTest //instantiating the webview requires a handler
+    public void userAgentStaticAndInstanceSameString(){
+
+        String getDefaultUserAgentString = WebSettings.getDefaultUserAgent(getTestContext());
+        WebView w = new WebView(getTestContext());
+        String getUserAgentString = w.getSettings().getUserAgentString();
+
+        // This is true assuming the webview package was not updated in between this test execution
+        Assert.assertEquals(getDefaultUserAgentString, getUserAgentString);
     }
 }


### PR DESCRIPTION
## Reference
INTENG-14175 -- Android SDK crash while getting default User Agent

## Description
It's been reported that the sdk has been crashing when trying to retrieve the browser user agent string.
Previously we'd been using the WebSetting's static function to retrieve this but due to open issues
- https://bugs.chromium.org/p/chromium/issues/detail?id=1271617
- https://bugs.chromium.org/p/chromium/issues/detail?id=1279562

We will instead use the alternative to instantiate a webview and get the latest user agent.

I was not able to repro the crashes that were reported but this may be due to some race condition present in certain Chromium versions distributed to mostly Samsung. There is no currently no known root cause.

The only behavior difference is if the webview package were to be updated in between app load and accessing the user agent string, the previous implementation would only return the originally loaded user agent. This implementation retrieves the latest user agent during runtime.

## Testing Instructions
Check out the current master branch and note the user agent string sent in v2 events.
Compare with this branch's change of the same event.

**Samsung S21 with Android 12**

| Before | After |
| ------------- | ------------- |
| Mozilla/5.0 (Linux; Android 12; SM-G991U1 Build/SP1A.210812.016; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/105.0.5195.136 Mobile Safari/537.36  | Mozilla/5.0 (Linux; Android 12; SM-G991U1 Build/SP1A.210812.016; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/105.0.5195.136 Mobile Safari/537.36  |


**Samsung 28 with Android 9**

| Before | After |
| ------------- | ------------- |
| Mozilla/5.0 (Linux; Android 9; SM-G950U Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/104.0.5112.97 Mobile Safari/537.36 | Mozilla/5.0 (Linux; Android 9; SM-G950U Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/104.0.5112.97 Mobile Safari/537.36  |



**Pixel 4A with Android 13**

| Before | After |
| ------------- | ------------- |
| Mozilla/5.0 (Linux; Android 13; Build/TRA3.220607.006; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/105.0.5195.136 Mobile Safari/537.36 | Mozilla/5.0 (Linux; Android 13; Build/TRA3.220607.006; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/105.0.5195.136 Mobile Safari/537.36 |


## Risk Assessment [`LOW`]

- [✅ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
