### PR TITLE
User Agent String - Support 3rd party threading libraries

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -273,7 +273,17 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      * once. After initial use, subsequent attempts will not validate.
      */
     public static final int LINK_TYPE_ONE_TIME_USE = 1;
-    
+
+    /**
+     * If true, instantiate a new webview instance ui thread to retrieve user agent string
+     */
+    static boolean userAgentSync;
+
+    /**
+     * Package private user agent string cached to save on repeated queries
+     */
+    static String _userAgentString = "";
+
     /* Json object containing key-value pairs for debugging deep linking */
     private JSONObject deeplinkDebugParams_;
     
@@ -446,6 +456,11 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         /* If {@link Application} is instantiated register for activity life cycle events. */
         if (context instanceof Application) {
             branchReferral_.setActivityLifeCycleObserver((Application) context);
+        }
+
+        // Cache the user agent from a webview instance if needed
+        if(userAgentSync && DeviceInfo.getInstance() != null){
+            DeviceInfo.getInstance().getUserAgentStringSync(context);
         }
 
         return branchReferral_;
@@ -856,6 +871,10 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     public Branch setPreinstallPartner(@NonNull String preInstallPartner) {
         addInstallMetadata(PreinstallKey.partner.getKey(), preInstallPartner);
         return this;
+    }
+
+    public static void setIsUserAgentSync(boolean sync){
+        userAgentSync = sync;
     }
     
     /*

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -4,6 +4,8 @@ import android.app.UiModeManager;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.webkit.WebSettings;
@@ -294,37 +296,54 @@ class DeviceInfo {
      * @param context
      * @return user agent string
      */
-    private String getDefaultBrowserAgent(Context context) {
-        String userAgent = "";
+    String getDefaultBrowserAgent(final Context context) {
+        if(!TextUtils.isEmpty(Branch._userAgentString)) {
+            return Branch._userAgentString;
+        }
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             try {
-                // Some devices appear to crash when accessing chromium through the Android framework statics
-                // Suggested alternative is to use a webview instance
-                // https://bugs.chromium.org/p/chromium/issues/detail?id=1279562
-                // https://bugs.chromium.org/p/chromium/issues/detail?id=1271617
-                WebView w = new WebView(context);
-                if(w != null) {
-                    userAgent = w.getSettings().getUserAgentString();
-                    w.destroy();
-                }
+                PrefHelper.Debug("Did not get user agent string from webview instance. Retrieving from static.");
+                Branch._userAgentString = WebSettings.getDefaultUserAgent(context);
             }
-            // If the above fails because of no handler available, catch and fallback to the original method for static
-            catch (Exception e) {
-                PrefHelper.Debug(e.getMessage());
-                if(userAgent.isEmpty()){
-                    try {
-                        PrefHelper.Debug("Could not get user agent string from webview instance. Trying static.");
-                        userAgent = WebSettings.getDefaultUserAgent(context);
-                    }
-                    catch (Exception exception) {
-                        PrefHelper.Debug(exception.getMessage());
-                        // A known Android issue. Webview packages are not accessible while any updates for chrome is in progress.
-                        // https://bugs.chromium.org/p/chromium/issues/detail?id=506369
-                    }
-                }
+            catch (Exception exception) {
+                PrefHelper.Debug(exception.getMessage());
+                // A known Android issue. Webview packages are not accessible while any updates for chrome is in progress.
+                // https://bugs.chromium.org/p/chromium/issues/detail?id=506369
             }
         }
-        return userAgent;
+        return Branch._userAgentString;
+    }
+
+    /**
+     * Must be called from the main thread
+     * Some devices appear to crash when accessing chromium through the Android framework statics
+     * Suggested alternative is to use a webview instance
+     * https://bugs.chromium.org/p/chromium/issues/detail?id=1279562
+     * https://bugs.chromium.org/p/chromium/issues/detail?id=1271617
+     **/
+    String getUserAgentStringSync(final Context context){
+        if(!TextUtils.isEmpty(Branch._userAgentString)) {
+            return Branch._userAgentString;
+        }
+
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    PrefHelper.Debug("Running WebView initialization on thread" + Thread.currentThread());
+                    WebView w = new WebView(context);
+                    Branch._userAgentString = w.getSettings().getUserAgentString();
+                    w.destroy();
+                }
+                catch (Exception e) {
+                    PrefHelper.Debug(e.getMessage());
+                }
+
+            }
+        });
+
+        return Branch._userAgentString;
     }
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -303,7 +303,7 @@ class DeviceInfo {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             try {
-                PrefHelper.Debug("Unable to retrieve user agent string from WebView instance. Retrieving from WebSettings");
+                PrefHelper.Debug("Retrieving user agent string from WebSettings");
                 Branch._userAgentString = WebSettings.getDefaultUserAgent(context);
             }
             catch (Exception exception) {

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -303,7 +303,7 @@ class DeviceInfo {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             try {
-                PrefHelper.Debug("Did not get user agent string from webview instance. Retrieving from static.");
+                PrefHelper.Debug("Unable to retrieve user agent string from WebView instance. Retrieving from WebSettings");
                 Branch._userAgentString = WebSettings.getDefaultUserAgent(context);
             }
             catch (Exception exception) {
@@ -331,7 +331,7 @@ class DeviceInfo {
             @Override
             public void run() {
                 try {
-                    PrefHelper.Debug("Running WebView initialization on thread" + Thread.currentThread());
+                    PrefHelper.Debug("Running WebView initialization for user agent on thread " + Thread.currentThread());
                     WebView w = new WebView(context);
                     Branch._userAgentString = w.getSettings().getUserAgentString();
                     w.destroy();


### PR DESCRIPTION
## Reference
INTENG-14175 -- Android SDK crash while getting default User Agent

## Description
It was reported that with the recent most update to use a webview instance, the SDK was throwing an exception upon initializing when using 3rd party threading libraries.

To amend this, the WebView initialization is moved to the synchronous portion of the Branch SDK initialization and keeping the async call in tact.

To prevent further unforeseen crashes due to the previous issue reported with certain Chromium versions throwing, the user agent is cached on the Branch object privately.

The default behavior is to use the original backgrounded method, and if needed to avoid the original Chromium crash, a new setting is available to use the alternative WebView instance method.

Add

`Branch.setIsUserAgentSync(true);`

before the Branch singleton initialization call.

## Testing Instructions
```
public class CustomApplication extends Application {
    @Override
    public void onCreate(){
        super.onCreate();
        Branch.enableLogging();
        Branch.setIsUserAgentSync(true);
        Branch.getAutoInstance(this);
    }
}
```
Test both `true` and `false` and observe no crashes and valid user agents in v2 events.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [✅ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
