### PR TITLE
[SDK-1534] Move "source" to top level for v1/url requests

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/BranchLinkData.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchLinkData.java
@@ -318,6 +318,21 @@ class BranchLinkData extends JSONObject {
     }
 
     /**
+     * <p>Adds Android as the source.</p>
+     *
+     * @throws JSONException The parameter value must be in valid JSON format, or a
+     *                       {@link JSONException} will be thrown.
+     */
+    public void putSource() throws JSONException {
+        this.put("source", Defines.Jsonkey.URLSource.getKey());
+    }
+
+    public String getSource() {
+        return Defines.Jsonkey.URLSource.getKey();
+    }
+
+
+    /**
      * <p>Compares a BranchLinkData object by instance
      * ("is the object the exact same one in memory") and by associated
      * attributes ("is this object identically configured?")</p>

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchUrlBuilder.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchUrlBuilder.java
@@ -118,7 +118,7 @@ abstract class BranchUrlBuilder<T extends BranchUrlBuilder> {
         if (branchReferral_ != null) {
             ServerRequestCreateUrl req = new ServerRequestCreateUrl(context_, alias_, type_, duration_, tags_,
                     channel_, feature_, stage_, campaign_,
-                    BranchUtil.formatLinkParam(params_), null, false, defaultToLongUrl_);
+                    params_, null, false, defaultToLongUrl_);
             shortUrl = branchReferral_.generateShortLinkInternal(req);
         }
         return shortUrl;
@@ -128,7 +128,7 @@ abstract class BranchUrlBuilder<T extends BranchUrlBuilder> {
         if (branchReferral_ != null) {
             ServerRequestCreateUrl req = new ServerRequestCreateUrl(context_, alias_, type_, duration_, tags_,
                     channel_, feature_, stage_, campaign_,
-                    BranchUtil.formatLinkParam(params_), callback, true, defaultToLongUrl_);
+                    params_, callback, true, defaultToLongUrl_);
             branchReferral_.generateShortLinkInternal(req);
         } else {
             if (callback != null) {

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
@@ -129,35 +129,6 @@ public class BranchUtil {
     /** @deprecated (see enableDebugMode for more information) */
     public static boolean isDebugEnabled() { return false; }
 
-    /**
-     * Converts a given link param as {@link JSONObject} to string after adding the source param and removes replaces any illegal characters.
-     *
-     * @param params Link param JSONObject.
-     * @return A {@link String} representation of link params.
-     */
-    static JSONObject formatLinkParam(JSONObject params) {
-        return addSource(params);
-    }
-
-    /**
-     * Convert the given JSONObject to string and adds source value as
-     *
-     * @param params JSONObject to convert to string
-     * @return A {@link String} value representing the JSONObject
-     */
-
-    static JSONObject addSource(JSONObject params) {
-        if (params == null) {
-            params = new JSONObject();
-        }
-        try {
-            params.put("source", "android");
-        } catch (JSONException e) {
-            e.printStackTrace();
-        }
-        return params;
-    }
-
     public static String decodeResourceId(Context context, int resourceId) {
         try {
             if (resourceId != -1) {

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -122,7 +122,7 @@ public class Defines {
         Params("params"),
         SharedLink("$shared_link"),
         ShareError("$share_error"),
-        
+        URLSource("android"),
         
         External_Intent_URI("external_intent_uri"),
         External_Intent_Extra("external_intent_extra"),

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestCreateUrl.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestCreateUrl.java
@@ -83,6 +83,7 @@ class ServerRequestCreateUrl extends ServerRequest {
             linkPost_.putStage(stage);
             linkPost_.putCampaign(campaign);
             linkPost_.putParams(params);
+            linkPost_.putSource();
 
             setPost(linkPost_);
 

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestCreateUrl.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestCreateUrl.java
@@ -2,6 +2,7 @@ package io.branch.referral;
 
 import android.app.Application;
 import android.content.Context;
+import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -236,12 +237,16 @@ class ServerRequestCreateUrl extends ServerRequest {
             long duration = linkPost_.getDuration();
             longUrl = longUrl + Defines.LinkParam.Duration + "=" + duration;
 
-            String params = linkPost_.getParams().toString();
+            String source = Defines.Jsonkey.URLSource.getKey();
+            longUrl = longUrl + "&source=" + source;
+
+            JSONObject params = linkPost_.getParams();
             if (params != null && params.length() > 0) {
-                byte[] data = params.getBytes();
+                String paramsString = params.toString();
+                byte[] data = paramsString.getBytes();
                 String base64Data = Base64.encodeToString(data, android.util.Base64.NO_WRAP);
                 String urlEncodedBase64Data = URLEncoder.encode(base64Data, "UTF8");
-                longUrl = longUrl + "&source=android&data=" + urlEncodedBase64Data;
+                longUrl = longUrl + "&data=" + urlEncodedBase64Data;
             }
         } catch (Exception ignore) {
             callback_.onLinkCreate(null, new BranchError("Trouble creating a URL.", BranchError.ERR_BRANCH_INVALID_REQUEST));


### PR DESCRIPTION
## Reference
SDK-1534 -- Move 'source' to top level for v1/url

## Description
Originally, v1/url requests had `source: android` nested inside the `data` object. However, iOS has always sent `source` at the top level. This change updates the Android SDK's behavior to be like the iOS SDK's by moving `source` to the top level of v1/url requests.

The old methods that added source were also removed in this change. `generateLongUrlWithParams()` was also updated slightly to fix tests and to be more like `getShortUrl()`. 

## Testing Instructions
Create a short URL to send a v1/url request and note that source has moved from being within data to at the top level.

**Previous Request**
```
{
  "tags": [],
  "alias": "",
   ...
  "data": {
    "custom": "data",
    "source": "android",  //Inside data{}
  },
}
```

**New Request**
```
{
  "tags": [],
  "alias": "",
  "source": "android",  //Moved to outside data{}
   ...
  "data": {
    "custom": "data",
  },
}
```

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
