### PR TITLE
Include debug field in all events

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -220,6 +220,8 @@ class DeviceInfo {
                     requestObj.put(Defines.Jsonkey.ReferrerGclid.getKey(), gclid);
                 }
             }
+
+            requestObj.put(Defines.Jsonkey.Debug.getKey(), Branch.isDeviceIDFetchDisabled());
         }
         catch (JSONException ignore){
         }

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -56,7 +56,6 @@ abstract class ServerRequestInitSession extends ServerRequest {
             post.put(Defines.Jsonkey.InitialReferrer.getKey(), prefHelper_.getInitialReferrer());
         }
         post.put(Defines.Jsonkey.FaceBookAppLinkChecked.getKey(), prefHelper_.getIsAppLinkTriggeredInit());
-        post.put(Defines.Jsonkey.Debug.getKey(), Branch.isDeviceIDFetchDisabled());
 
         updateInstallStateAndTimestamps(post);
         updateEnvironment(context_, post);


### PR DESCRIPTION
## Reference
SDK-1672 -- [Android] Include 'debug' in v2/event payloads. 

## Description
Historically the SDK exposed a public API to randomize the device id upon every fetch. Recently, this caused some complication upstream and resulted in a workaround checking for the `"debug"` field value in v1 open events. To finalize the workaround, the `debug` field must be present in v2 events.

This change includes the addition of the `debug` field in the method that adds a field for all events at the top field.
I've also removed the put from the v1 event that is now made redundant.

It should be noted that previously the only v1 events that had the debug field were init requests, open/install.

## Testing Instructions
1. Check out the branch and examine the field presence with the switch
        `Branch.disableDeviceIDFetch(true);`

- I will provide payload samples and a test apk internally.

2. Attribution team to validate the results of the events 
- Meets the requirement of the original fix
- Do not cause side effects.


## Risk Assessment [`MEDIUM`]
Because this originally relates to an incident, this risk is assuming that there are no further side effects which could have a costly impact.

- [✅ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
