### PR TITLE
[SDK-1715][minor] Support for v2/qr-code parameters

### DIFF
--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
@@ -380,7 +380,12 @@ public class MainActivity extends Activity {
                         .setMargin(2)
                         .setWidth(512)
                         .setImageFormat(BranchQRCode.BranchImageFormat.PNG)
-                        .setCenterLogo("https://cdn.branch.io/branch-assets/1598575682753-og_image.png");
+                        .setPattern(BranchQRCode.BranchQRCodePattern.Circles)
+                        .setFinderPattern(BranchQRCode.BranchQRCodeFinderPattern.Circle)
+                        .setFinderPatternColor("#57dbe0")
+                        .setBackgroundImage("https://cdn.branch.io/branch-assets/1598575682753-og_image.png")
+                        .setBackgroundImageOpacity(20)
+                        .setFinderEyeColor("#2a2e2e");
 
                 BranchUniversalObject buo = new BranchUniversalObject()
                         .setCanonicalIdentifier("content/12345")

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchQRCodeTests.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchQRCodeTests.java
@@ -38,7 +38,14 @@ public class BranchQRCodeTests extends BranchTest {
                         .setMargin(1)
                         .setWidth(512)
                         .setImageFormat(BranchQRCode.BranchImageFormat.PNG)
-                        .setCenterLogo("https://cdn.branch.io/branch-assets/1598575682753-og_image.png");
+                        .setCenterLogo("https://cdn.branch.io/branch-assets/1598575682753-og_image.png")
+                        .setPattern(BranchQRCode.BranchQRCodePattern.Circles)
+                        .setFinderPattern(BranchQRCode.BranchQRCodeFinderPattern.RoundedRectangle)
+                        .setFinderPatternColor("#a4c639")
+                        .setBackgroundImage("https://cdn.branch.io/branch-assets/1598575682753-og_image.png")
+                        .setBackgroundImageOpacity(20)
+                        .setPatternImage("https://cdn.branch.io/branch-assets/1598575682753-og_image.png")
+                        .setFinderEyeColor("#a4c639");
 
                 BranchUniversalObject buo = new BranchUniversalObject()
                         .setCanonicalIdentifier("test/123")

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -213,10 +213,18 @@ public class Defines {
         Margin("margin"),
         ImageFormat("image_format"),
         CenterLogo("center_logo_url"),
+        CodePattern("code_pattern"),
+        FinderPattern("finder_pattern"),
+        FinderPatternColor("finder_pattern_color"),
+        BackgroundImage("background_image_url"),
+        BackgroundImageOpacity("background_image_opacity"),
+        PatternImage("code_pattern_url"),
+        FinderEyeColor("finder_eye_color"),
         QRCodeSettings("qr_code_settings"),
         QRCodeData("data"),
         QRCodeBranchKey("branch_key"),
         QRCodeResponseString("QRCodeString"),
+
 
         App_Store("app_store"),
         Google_Play_Store("PlayStore"),
@@ -262,7 +270,7 @@ public class Defines {
         TrackCustomEvent("v2/event/custom"),
         GetCPID("v1/cpid"),
         GetLATD("v1/cpid/latd"),
-        QRCode("v1/qr-code");
+        QRCode("v2/qr-code");
 
         private final String key;
         

--- a/Branch-SDK/src/main/java/io/branch/referral/QRCode/BranchQRCode.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/QRCode/BranchQRCode.java
@@ -37,10 +37,40 @@ public class BranchQRCode {
     private Integer margin_;
     /* Image Format of the returned QR code. Can be a JPEG or PNG. */
     private BranchImageFormat imageFormat_;
+    /* The style of code pattern used to generate the QR code. */
+    private BranchQRCodePattern pattern_;
+    /* The style of finder pattern used to generate the QR code. */
+    private BranchQRCodeFinderPattern finderPattern_;
+    /* Color of the QR code's finder pattern. */
+    private String finderPatternColor_;
+    /* A URL of an image that will be added to the background of the QR code. Must be a PNG or JPEG. */
+    private String backgroundImage_;
+    /* Adjusts the opacity of the background image from 1-99. */
+    private Integer backgroundImageOpacity_;
+    /* A URL of an image to be used as the code-pattern itself on the QR Code.. Must be a PNG or JPEG. */
+    private String patternImage_;
+    /* Color of the  interior part of a QR code’s finder pattern. */
+    private String finderEyeColor_;
 
     public enum BranchImageFormat {
         JPEG, /* QR code is returned as a JPEG */
         PNG /*QR code is returned as a PNG */
+    }
+
+    public enum BranchQRCodePattern {
+        Standard,
+        Squares,
+        Circles,
+        Triangles,
+        Diamonds,
+        Hexagons,
+        Octagons
+    }
+
+    public enum BranchQRCodeFinderPattern {
+        Square,
+        RoundedRectangle,
+        Circle
     }
 
     public BranchQRCode() {
@@ -50,6 +80,13 @@ public class BranchQRCode {
         width_ = null;
         margin_ = null;
         imageFormat_ = null;
+        pattern_ = null;
+        finderPattern_ = null;
+        finderPatternColor_ = null;
+        backgroundImage_ = null;
+        backgroundImageOpacity_ = null;
+        patternImage_ = null;
+        finderEyeColor_ = null;
     }
 
     /**
@@ -172,6 +209,133 @@ public class BranchQRCode {
         return this;
     }
 
+    /**
+     * <p>
+     * Set the pattern for this BranchQRCode.
+     * </p>
+     *
+     * @param pattern A {@link BranchQRCodePattern} with value for the pattern.
+     * @return This instance to allow for chaining of calls to set methods
+     */
+    public BranchQRCode setPattern(@NonNull BranchQRCodePattern pattern) {
+        this.pattern_ = pattern;
+        return this;
+    }
+
+    /**
+     * <p>
+     * Set the finder pattern for this BranchQRCode.
+     * </p>
+     *
+     * @param finderPattern A {@link BranchQRCodeFinderPattern} with value for the finder pattern.
+     * @return This instance to allow for chaining of calls to set methods
+     */
+    public BranchQRCode setFinderPattern(@NonNull BranchQRCodeFinderPattern finderPattern) {
+        this.finderPattern_ = finderPattern;
+        return this;
+    }
+
+    /**
+     * <p>
+     * Set the finder pattern color for this BranchQRCode.
+     * </p>
+     *
+     * @param finderPatternColor A {@link int} with value for the finder pattern color.
+     * @return This instance to allow for chaining of calls to set methods
+     */
+    public BranchQRCode setFinderPatternColor(@NonNull int finderPatternColor) {
+        String finderPatternColorString = String.format("#%06X", 0xFFFFFF & finderPatternColor);
+        return setFinderPatternColor(finderPatternColorString);
+    }
+
+    /**
+     * <p>
+     * Set the finder pattern color for this BranchQRCode.
+     * </p>
+     *
+     * @param hexFinderPatternColor A {@link String} with value for the finder pattern color.
+     * @return This instance to allow for chaining of calls to set methods
+     */
+    public BranchQRCode setFinderPatternColor(@NonNull String hexFinderPatternColor) {
+        this.finderPatternColor_ = hexFinderPatternColor;
+        return this;
+    }
+
+    /**
+     * <p>
+     * Set the background image for this BranchQRCode.
+     * </p>
+     *
+     * @param backgroundImage A {@link String} with value for the background image.
+     * @return This instance to allow for chaining of calls to set methods
+     */
+    public BranchQRCode setBackgroundImage(@NonNull String backgroundImage) {
+        this.backgroundImage_ = backgroundImage;
+        return this;
+    }
+
+    /**
+     * <p>
+     * Set the background image opacity for this BranchQRCode.
+     * </p>
+     *
+     * @param backgroundImageOpacity An {@link Integer} with value for the background image opacity from 1-99.
+     * @return This instance to allow for chaining of calls to set methods
+     */
+    public BranchQRCode setBackgroundImageOpacity(@NonNull Integer backgroundImageOpacity) {
+        if (backgroundImageOpacity > 99) {
+            PrefHelper.Debug("Background image opacity was reduced to the maximum of 99.");
+            this.backgroundImageOpacity_ = 99;
+        } else if (backgroundImageOpacity < 1) {
+            PrefHelper.Debug("Background image opacity was increased to the minimum of 1.");
+            this.backgroundImageOpacity_ = 1;
+        } else {
+            this.backgroundImageOpacity_ = backgroundImageOpacity;
+        }
+        return this;
+    }
+
+    /**
+     * <p>
+     * Set the pattern image for this BranchQRCode.
+     * </p>
+     *
+     * @param patternImage A {@link String} with value for the pattern image.
+     * @return This instance to allow for chaining of calls to set methods
+     */
+    public BranchQRCode setPatternImage(@NonNull String patternImage) {
+        this.patternImage_ = patternImage;
+        return this;
+    }
+
+    /**
+     * <p>
+     * Set the finder eye color for this BranchQRCode.
+     * </p>
+     *
+     * @param finderEyeColor A {@link int} with value for the finder eye color.
+     * @return This instance to allow for chaining of calls to set methods
+     */
+    public BranchQRCode setFinderEyeColor(@NonNull int finderEyeColor) {
+        String finderEyeColorString = String.format("#%06X", 0xFFFFFF & finderEyeColor);
+        return setFinderEyeColor(finderEyeColorString);
+    }
+
+    /**
+     * <p>
+     * Set the finder eye color for this BranchQRCode.
+     * </p>
+     *
+     * @param hexFinderEyeColor A {@link String} with value for the finder eye color.
+     * @return This instance to allow for chaining of calls to set methods
+     */
+    public BranchQRCode setFinderEyeColor(@NonNull String hexFinderEyeColor) {
+        this.finderEyeColor_ = hexFinderEyeColor;
+        return this;
+    }
+
+
+
     public interface BranchQRCodeDataHandler<T> {
         void onSuccess(byte[] qrCodeData);
 
@@ -211,6 +375,28 @@ public class BranchQRCode {
         }
         if (this.centerLogo_ != null) {
             settings.put(Defines.Jsonkey.CenterLogo.getKey(), centerLogo_);
+        }
+
+        if (this.pattern_ != null) {
+            settings.put(Defines.Jsonkey.CodePattern.getKey(), pattern_.ordinal() + 1);
+        }
+        if (this.finderPattern_ != null) {
+            settings.put(Defines.Jsonkey.FinderPattern.getKey(), finderPattern_.ordinal() + 1);
+        }
+        if (this.finderPatternColor_ != null) {
+            settings.put(Defines.Jsonkey.FinderPatternColor.getKey(), finderPatternColor_);
+        }
+        if (this.backgroundImage_ != null) {
+            settings.put(Defines.Jsonkey.BackgroundImage.getKey(), backgroundImage_);
+        }
+        if (this.backgroundImageOpacity_ != null) {
+            settings.put(Defines.Jsonkey.BackgroundImageOpacity.getKey(), backgroundImageOpacity_);
+        }
+        if (this.patternImage_ != null) {
+            settings.put(Defines.Jsonkey.PatternImage.getKey(), patternImage_);
+        }
+        if (this.finderEyeColor_ != null) {
+            settings.put(Defines.Jsonkey.FinderEyeColor.getKey(), finderEyeColor_);
         }
 
         final Map<String, Object> parameters = new HashMap<String, Object>();


### PR DESCRIPTION
## Reference
SDK-1715 -- [Android] Add support for v2/qr-code

## Summary
To support the new and improved `v2/qr-code` endpoint, a few parameters for QR code customization had to be added. This involved adding 2 new enums, 7 new properties, and updating `getQRCodeAsData()` in the `BranchQRCode.java` file. 

The following properties were added:
- `pattern` for `code_pattern`
- `finderPattern` for `finder_pattern`
- `finderPatternColor` for`finder_pattern_color`
- `backgroundImage` for `background_image_url`
- `backgroundImageOpacity` for `background_image_opacity`
- `patternImage` for `code_pattern_url`
- `finderEyeColor` for `finder_eye_color`

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The existing code was for `v1/qr-code` but `v2/qr-code` was recently released with some new features. For clients to utilize the new parameters, the SDK needed to be updated.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing Instructions
Create a QR code with the new parameters to ensure they're properly available. A good example/code snippet would be the `qrCode_btn` function in the TestBed.


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->
