### PR TITLE
SDK-1683 Out-opt method for default preinstall handling from Install Referrer

### DIFF
--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
@@ -474,8 +474,6 @@ public class MainActivity extends Activity {
         super.onStart();
         Branch.getInstance().addFacebookPartnerParameterWithName("em", getHashedValue("sdkadmin@branch.io"));
         Branch.getInstance().addFacebookPartnerParameterWithName("ph", getHashedValue("6516006060"));
-        Branch.getInstance().setPreinstallCampaign("TestCampaign");
-        Branch.getInstance().setPreinstallPartner("TestPartner");
         Log.e("BranchSDK_Tester", "initSession");
         Branch.sessionBuilder(this).withCallback(new Branch.BranchUniversalReferralInitListener() {
             @Override

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
@@ -474,6 +474,8 @@ public class MainActivity extends Activity {
         super.onStart();
         Branch.getInstance().addFacebookPartnerParameterWithName("em", getHashedValue("sdkadmin@branch.io"));
         Branch.getInstance().addFacebookPartnerParameterWithName("ph", getHashedValue("6516006060"));
+        Branch.getInstance().setPreinstallCampaign("TestCampaign");
+        Branch.getInstance().setPreinstallPartner("TestPartner");
         Log.e("BranchSDK_Tester", "initSession");
         Branch.sessionBuilder(this).withCallback(new Branch.BranchUniversalReferralInitListener() {
             @Override

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -300,6 +300,8 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     static boolean checkInstallReferrer_ = true;
     private static long playStoreReferrerWaitTime = 1500;
     public static final long NO_PLAY_STORE_REFERRER_WAIT = 0;
+
+    static boolean referringLinkAttributionForPreinstalledAppsEnabled = false;
     
     /**
      * <p>A {@link Branch} object that is instantiated on init and holds the singleton instance of
@@ -403,7 +405,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      * us make data driven decisions. */
     private static String pluginVersion = null;
     private static String pluginName = null;
-    
+
     /**
      * <p>The main constructor of the Branch class is private because the class uses the Singleton
      * pattern.</p>
@@ -871,6 +873,20 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     public Branch setPreinstallPartner(@NonNull String preInstallPartner) {
         addInstallMetadata(PreinstallKey.partner.getKey(), preInstallPartner);
         return this;
+    }
+
+    /**
+     * Enables referring url attribution for preinstalled apps.
+     *
+     * By default, Branch prioritizes preinstall attribution on preinstalled apps.
+     * Some clients prefer the referring link, when present, to be prioritized over preinstall attribution.
+     */
+    public static void setReferringLinkAttributionForPreinstalledAppsEnabled() {
+        referringLinkAttributionForPreinstalledAppsEnabled = true;
+    }
+
+    public static boolean isReferringLinkAttributionForPreinstalledAppsEnabled() {
+        return referringLinkAttributionForPreinstalledAppsEnabled;
     }
 
     public static void setIsUserAgentSync(boolean sync){

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -560,7 +560,7 @@ public abstract class ServerRequest {
         }
     }
 
-    private boolean shouldOmitPreinstallData(JSONObject params) {
+    private boolean prioritizeLinkAttribution(JSONObject params) {
         if (Branch.isReferringLinkAttributionForPreinstalledAppsEnabled()
                 && params.has(Defines.Jsonkey.LinkIdentifier.getKey())) {
             return true;
@@ -584,7 +584,7 @@ public abstract class ServerRequest {
     void doFinalUpdateOnBackgroundThread() {
         if (this instanceof ServerRequestInitSession) {
             ((ServerRequestInitSession) this).updateLinkReferrerParams();
-            if (shouldOmitPreinstallData(this.params_)) {
+            if (prioritizeLinkAttribution(this.params_)) {
                 removePreinstallData(this.params_);
             }
         }


### PR DESCRIPTION
## Reference
SDK-1683 

## Description
By default, Branch prioritizes preinstall attribution on preinstalled apps. Some clients prefer the referring link, when present, to be prioritized over preinstall attribution.

## Testing Instructions
Set preinstall data. I used `setPreinstallCampaign` and `setPreinstallPartner`.
Set the run configuration to pass a referring link.
Run the app and the Install payload should contain the preinstall data and the referring link data.
Uninstall app.

Now use `setReferringLinkAttributionForPreinstalledAppsEnabled` to enable referring links to override preinstall data.
Rerun the test and the preinstall data should be omitted while the referring link data is still present.

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW, this is an optional feature that is off by default.

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [x] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
