### PR TITLE
[INTENG-16632][patch] Fix for dropped developer_identity's

### DIFF
--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
@@ -470,7 +470,7 @@ public class MainActivity extends Activity {
     @Override
     protected void onStart() {
         super.onStart();
-        Branch.getInstance().setIdentity("testDevID3");
+        Branch.getInstance().setIdentity("testDevID");
 
         Branch.getInstance().addFacebookPartnerParameterWithName("em", getHashedValue("sdkadmin@branch.io"));
         Branch.getInstance().addFacebookPartnerParameterWithName("ph", getHashedValue("6516006060"));

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroiddemo/MainActivity.java
@@ -108,8 +108,6 @@ public class MainActivity extends Activity {
                         Log.e("BranchSDK_Tester", "install params = " + referringParams.toString());
                         if (error != null) {
                             Log.e("BranchSDK_Tester", "branch set Identity failed. Caused by -" + error.getMessage());
-                        } else {
-                            Log.e("BranchSDK_Tester", "install params = " + referringParams.toString());
                         }
                     }
                 });
@@ -472,6 +470,8 @@ public class MainActivity extends Activity {
     @Override
     protected void onStart() {
         super.onStart();
+        Branch.getInstance().setIdentity("testDevID3");
+
         Branch.getInstance().addFacebookPartnerParameterWithName("em", getHashedValue("sdkadmin@branch.io"));
         Branch.getInstance().addFacebookPartnerParameterWithName("ph", getHashedValue("6516006060"));
         Log.e("BranchSDK_Tester", "initSession");

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -382,7 +382,10 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             "extra_launch_uri",   // Key for embedded uri in FB ads triggered intents
             "branch_intent"       // A boolean that specifies if this intent is originated by Branch
     };
-    
+
+    public static String installDeveloperId = null;
+    public static Boolean hasSleptTest = false;
+
     CountDownLatch getFirstReferringParamsLatch = null;
     CountDownLatch getLatestReferringParamsLatch = null;
 
@@ -1140,7 +1143,8 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      */
     public void setIdentity(@NonNull String userId, @Nullable BranchReferralInitListener
             callback) {
-        prefHelper_.setIdentity(userId);
+
+        installDeveloperId = userId;
 
         ServerRequestIdentifyUserRequest req = new ServerRequestIdentifyUserRequest(context_, callback, userId);
         if (!req.constructError_ && !req.handleErrors(context_)) {

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -384,7 +384,6 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     };
 
     public static String installDeveloperId = null;
-    public static Boolean hasSleptTest = false;
 
     CountDownLatch getFirstReferringParamsLatch = null;
     CountDownLatch getLatestReferringParamsLatch = null;

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestIdentifyUserRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestIdentifyUserRequest.java
@@ -53,6 +53,10 @@ class ServerRequestIdentifyUserRequest extends ServerRequest {
 
     public void onRequestSucceeded(ServerResponse resp, Branch branch) {
         try {
+            if (getPost() != null && getPost().has(Defines.Jsonkey.Identity.getKey())) {
+                prefHelper_.setIdentity(Branch.installDeveloperId);
+            }
+
             prefHelper_.setRandomizedBundleToken(resp.getObject().getString(Defines.Jsonkey.RandomizedBundleToken.getKey()));
             prefHelper_.setUserURL(resp.getObject().getString(Defines.Jsonkey.Link.getKey()));
 

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -60,7 +60,7 @@ abstract class ServerRequestInitSession extends ServerRequest {
         updateInstallStateAndTimestamps(post);
         updateEnvironment(context_, post);
 
-        String identity = prefHelper_.getIdentity();
+        String identity = Branch.installDeveloperId;
 
         if(!TextUtils.isEmpty(identity) && !identity.equals(PrefHelper.NO_STRING_VALUE)){
             post.put(Defines.Jsonkey.Identity.getKey(), identity);


### PR DESCRIPTION
## Reference
INTENG-16632 -- Drop in user_data_developer_identity after installing Android SDK version 5.2.1

## Description
`setIdentity()` was not properly calling `v1/profile` because of the order PrefHelper was saving the `developer_identity`. Since dev_id already existed, the SDK would not call v1/profile. This change creates a new variable which temporarily exists just for sending the dev_id in `v1/installs`, but still allows `v1/profile` to be successfully called and the PrefHelper save `developer_identity` after the request. 

## Testing Instructions
Call `setIdentity()` and when you freshly install your app, you should see both a `v1/install` with the identity field and a `v1/profile` call. 

## Risk Assessment [`MEDIUM`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->
Changes to network request behavior.

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
