### PR TITLE
Release 5.2.7

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,10 @@
 # Branch Android SDK change log
+- v5.2.7
+  * _*Master Release*_ - Dec 7, 2022
+  * Fixes a bug with setIdentity not consistently calling v1/profile
+  * Adds switch to prioritize referrer links for attribution over preinstall metadata
+    - To enable, call `setReferringLinkAttributionForPreinstalledAppsEnabled` before `Branch.getAutoInstance(this)`
+
 - v5.2.6
   * _*Master Release*_ - Oct 25, 2022
   * `debug` field is now included in all events, previously only on init requests

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.2.6
-VERSION_CODE=050206
+VERSION_NAME=5.2.7
+VERSION_CODE=050207
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.


### PR DESCRIPTION
- v5.2.7
  * _*Master Release*_ - Dec 7, 2022
  * Fixes a bug with setIdentity not consistently calling v1/profile
  * Adds switch to prioritize referrer links for attribution over preinstall metadata
    - To enable, call `setReferringLinkAttributionForPreinstalledAppsEnabled` before `Branch.getAutoInstance(this)`

## Reference
SDK-1735 -- [Android] Release 5.2.7

## Description
<!-- SUFFICIENT DESCRIPTION TO EXPLAIN THE PROBLEM THAT IS BEING SOLVED -->

## Testing Instructions
<!-- TESTING INSTRUCTIONS -->

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
