### PR TITLE
SDK-1876 add anon_id to requests for some SAN APIs

### DIFF
--- a/Branch-SDK/src/androidTest/java/io/branch/referral/SystemObserverTests.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/SystemObserverTests.java
@@ -1,0 +1,29 @@
+package io.branch.referral;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.UUID;
+
+@RunWith(AndroidJUnit4.class)
+public class SystemObserverTests extends BranchTest {
+
+    @Test
+    public void testAnonID() {
+        initBranchInstance();
+        String anonID = SystemObserver.getAnonID(getTestContext());
+        try {
+            UUID.fromString(anonID);
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testAnonIDChangesWithDisableTracking() {
+        // TODO: figure out how to handle disable tracking, seems the tracking controller is not very testable
+    }
+}

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -61,6 +61,7 @@ public class Defines {
         HardwareIDTypeVendor("vendor_id"),
         HardwareIDTypeRandom("random"),
         IsHardwareIDReal("is_hardware_id_real"),
+        AnonID("anon_id"),
         AppVersion("app_version"),
         APILevel("os_version"),
         Country("country"),

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -56,6 +56,11 @@ class DeviceInfo {
                 requestObj.put(Defines.Jsonkey.IsHardwareIDReal.getKey(), hardwareID.isReal());
             }
 
+            String anonID = SystemObserver.getAnonID(context_);
+            if (!isNullOrEmptyOrBlank(anonID)) {
+                requestObj.put(Defines.Jsonkey.AnonID.getKey(), anonID);
+            }
+
             String brandName = SystemObserver.getPhoneBrand();
             if (!isNullOrEmptyOrBlank(brandName)) {
                 requestObj.put(Defines.Jsonkey.Brand.getKey(), brandName);
@@ -129,6 +134,11 @@ class DeviceInfo {
             SystemObserver.UniqueId hardwareID = getHardwareID();
             if (!isNullOrEmptyOrBlank(hardwareID.getId())) {
                 userDataObj.put(Defines.Jsonkey.AndroidID.getKey(), hardwareID.getId());
+            }
+
+            String anonID = SystemObserver.getAnonID(context_);
+            if (!isNullOrEmptyOrBlank(anonID)) {
+                userDataObj.put(Defines.Jsonkey.AnonID.getKey(), anonID);
             }
 
             String brandName = SystemObserver.getPhoneBrand();

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -125,7 +125,8 @@ public class PrefHelper {
     static final String KEY_AD_NETWORK_CALLOUTS_DISABLED = "bnc_ad_network_callouts_disabled";
 
     static final String KEY_RANDOMLY_GENERATED_UUID = "bnc_randomly_generated_uuid";
-    
+    static final String KEY_ANON_ID = "bnc_anon_id";
+
     /**
      * Internal static variable of own type {@link PrefHelper}. This variable holds the single
      * instance used when the class is instantiated via the Singleton pattern.
@@ -556,6 +557,21 @@ public class PrefHelper {
      */
     public String getRandomlyGeneratedUuid() {
         return getString(KEY_RANDOMLY_GENERATED_UUID);
+    }
+
+    /**
+     * Sets a new randomly generated UUID for some SAN APIs.
+     * @param uuid
+     */
+    public void setAnonID(String uuid){
+        setString(KEY_ANON_ID, uuid);
+    }
+
+    /**
+     * Returns our own randomly generated UUID for some SAN APIs.
+     */
+    public String getAnonID() {
+        return getString(KEY_ANON_ID);
     }
     
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -304,6 +304,7 @@ abstract class ServerRequestInitSession extends ServerRequest {
             post.remove(Defines.Jsonkey.LocalIP.getKey());
             post.remove(Defines.Jsonkey.ReferrerGclid.getKey());
             post.remove(Defines.Jsonkey.Identity.getKey());
+            post.remove(Defines.Jsonkey.AnonID.getKey());
             try {
                 post.put(Defines.Jsonkey.TrackingDisabled.getKey(), true);
             } catch (JSONException ignore) {

--- a/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
@@ -71,6 +71,20 @@ abstract class SystemObserver {
     }
 
     /**
+     * Randomly generated value for some SAN APIs.
+     *
+     * @return anon A {@link String} value that is a randomly generated UUID
+     */
+    static String getAnonID(Context context) {
+        String anonID = PrefHelper.getInstance(context).getAnonID();
+        if (TextUtils.isEmpty(anonID) || anonID.equals(BLANK)) {
+            anonID = UUID.randomUUID().toString();
+            PrefHelper.getInstance(context).setAnonID(anonID);
+        }
+        return anonID;
+    }
+
+    /**
      * Get the package name for this application.
      * @param context Context.
      * @return {@link String} with value as package name. Empty String in case of error
@@ -575,7 +589,6 @@ abstract class SystemObserver {
                         PrefHelper.getInstance(context).setRandomlyGeneratedUuid(androidID);
                     }
                 }
-
                 isRealId = false;
             }
             uniqueId = androidID;

--- a/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
@@ -64,6 +64,7 @@ public class TrackingController {
         prefHelper.setExternalIntentExtra(PrefHelper.NO_STRING_VALUE);
         prefHelper.setSessionParams(PrefHelper.NO_STRING_VALUE);
         prefHelper.saveLastStrongMatchTime(0);
+        prefHelper.setAnonID(PrefHelper.NO_STRING_VALUE);
         Branch.getInstance().clearPartnerParameters();
     }
     


### PR DESCRIPTION
## Reference
SDK-1876 add anon_id to requests for some SAN APIs

## Description
Add random guid that generates on app install or when tracking is reset. This is for compatibility with some SAN apis

## Testing Instructions
Event payloads should now contain an anon_id guid
The value should clear when tracking is disabled
The value should change on reinstall

See ticket for sample payloads.

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW - this is a new field and should not impact any existing fields

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
