### PR TITLE
Update consumer Proguard configuration

### DIFF
--- a/Branch-SDK/build.gradle.kts
+++ b/Branch-SDK/build.gradle.kts
@@ -54,6 +54,7 @@ android {
         minSdk = ANDROID_BUILD_TARGET_SDK_MINIMUM.toInt()
         targetSdk = ANDROID_BUILD_TARGET_SDK_VERSION.toInt()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("proguard-consumer.txt")
     }
 
     lint {

--- a/Branch-SDK/proguard-consumer.txt
+++ b/Branch-SDK/proguard-consumer.txt
@@ -1,0 +1,2 @@
+# Remove references to Huawei's OAID (Google's advertising id equivalent) if the dependency is not available in your project.
+-dontwarn com.huawei.hms.ads.**


### PR DESCRIPTION
## Reference
SDK-XXX -- Remove Huawei references if not present in project.

## Description
There needs to be a proguard config for the consumer that reflects what projects importing this library will need. In this case, we need to tell these projects it is okay to strip references to Huawei if it cannot compute its usage due to it not being in the classpath.

The motivation behind this change is from recent changes found in Android Gradle Plugin 8. R8 has become more strict and requires projects add this `dontwarn` rule to ensure it is okay to strip out code that is referenced via the `compileOnly` directive but otherwise aren't part of the classpath.

## Testing Instructions
<!-- TESTING INSTRUCTIONS -->

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs
