### PR TITLE
[SDK-1981] Add new method for logEvent with a callback

### DIFF
--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
@@ -512,8 +512,19 @@ public class MainActivity extends Activity {
                         .addCustomDataProperty("Custom_Event_Property_Key1", "Custom_Event_Property_val1")
                         .addCustomDataProperty("Custom_Event_Property_Key2", "Custom_Event_Property_val2")
                         .addContentItems(branchUniversalObject)
-                        .logEvent(MainActivity.this);
-                Toast.makeText(getApplicationContext(), "Sent Branch Commerce Event", Toast.LENGTH_SHORT).show();
+                        .logEvent(MainActivity.this, new BranchEvent.BranchLogEventCallback() {
+                            @Override
+                            public void onEventLogged(boolean success) {
+                                Toast.makeText(getApplicationContext(), "Sent Branch Commerce Event", Toast.LENGTH_SHORT).show();
+                            }
+
+                            @Override
+                            public void onFailure(int errorCode, String errorMessage) {
+                                Toast.makeText(getApplicationContext(), "Error sending Branch Commerce Event: " + errorMessage, Toast.LENGTH_SHORT).show();
+                            }
+                        });
+
+
             }
         });
 

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
@@ -48,6 +48,7 @@ import io.branch.referral.BranchError;
 import io.branch.referral.PrefHelper;
 import io.branch.referral.QRCode.BranchQRCode;
 import io.branch.referral.Defines;
+import io.branch.referral.ServerResponse;
 import io.branch.referral.SharingHelper;
 import io.branch.referral.util.BRANCH_STANDARD_EVENT;
 import io.branch.referral.util.BranchContentSchema;
@@ -514,7 +515,7 @@ public class MainActivity extends Activity {
                         .addContentItems(branchUniversalObject)
                         .logEvent(MainActivity.this, new BranchEvent.BranchLogEventCallback() {
                             @Override
-                            public void onEventLogged(boolean success) {
+                            public void onSuccess(ServerResponse response, Branch branch) {
                                 Toast.makeText(getApplicationContext(), "Sent Branch Commerce Event", Toast.LENGTH_SHORT).show();
                             }
 

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
@@ -515,13 +515,13 @@ public class MainActivity extends Activity {
                         .addContentItems(branchUniversalObject)
                         .logEvent(MainActivity.this, new BranchEvent.BranchLogEventCallback() {
                             @Override
-                            public void onSuccess(ServerResponse response, Branch branch) {
-                                Toast.makeText(getApplicationContext(), "Sent Branch Commerce Event", Toast.LENGTH_SHORT).show();
+                            public void onSuccess(int responseCode) {
+                                Toast.makeText(getApplicationContext(), "Sent Branch Commerce Event: " + responseCode, Toast.LENGTH_SHORT).show();
                             }
 
                             @Override
-                            public void onFailure(int errorCode, String errorMessage) {
-                                Toast.makeText(getApplicationContext(), "Error sending Branch Commerce Event: " + errorMessage, Toast.LENGTH_SHORT).show();
+                            public void onFailure(Exception e) {
+                                Toast.makeText(getApplicationContext(), "Error sending Branch Commerce Event: " + e.toString(), Toast.LENGTH_SHORT).show();
                             }
                         });
 

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -745,8 +745,7 @@ public class PrefHelper {
             params = new JSONObject(string);
         }
         catch (JSONException e) {
-            e.printStackTrace();
-            //TODO: Log e with Prefhelper.Error
+            PrefHelper.LogException("Unable to get URL query parameters as string: ", e);
         }
 
         return params;

--- a/Branch-SDK/src/main/java/io/branch/referral/ReferringUrlUtility.kt
+++ b/Branch-SDK/src/main/java/io/branch/referral/ReferringUrlUtility.kt
@@ -120,7 +120,6 @@ class ReferringUrlUtility (prefHelper: PrefHelper) {
 
     private fun deserializeFromJson(json: JSONObject): MutableMap<String, BranchUrlQueryParameter> {
         val result = mutableMapOf<String, BranchUrlQueryParameter>()
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault())
 
         val keys = json.keys()
         while (keys.hasNext()) {

--- a/Branch-SDK/src/main/java/io/branch/referral/util/BranchEvent.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/util/BranchEvent.java
@@ -288,7 +288,7 @@ public class BranchEvent {
                     }
             );
         } else if (callback != null) {
-            callback.onEventLogged(false);
+            callback.onFailure(0, "Error logging event because the Branch instance was not available");
         }
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/util/BranchEvent.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/util/BranchEvent.java
@@ -244,16 +244,11 @@ public class BranchEvent {
      * Logs this BranchEvent to Branch for tracking and analytics
      *
      * @param context Current context
-     * @return {@code true} if the event is logged to Branch
+     * @return {@code true}
      */
     public boolean logEvent(Context context) {
-        boolean isReqQueued = false;
-        Defines.RequestPath reqPath = isStandardEvent ? Defines.RequestPath.TrackStandardEvent : Defines.RequestPath.TrackCustomEvent;
-        if (Branch.getInstance() != null) {
-            Branch.getInstance().handleNewRequest(new ServerRequestLogEvent(context, reqPath, eventName, topLevelProperties, standardProperties, customProperties, buoList));
-            isReqQueued = true;
-        }
-        return isReqQueued;
+        logEvent(context, null);
+        return true;
     }
 
     public interface BranchLogEventCallback {

--- a/Branch-SDK/src/main/java/io/branch/referral/util/BranchEvent.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/util/BranchEvent.java
@@ -248,8 +248,8 @@ public class BranchEvent {
     }
 
     public interface BranchLogEventCallback {
-        void onSuccess(ServerResponse response, Branch branch);
-        void onFailure(int errorCode, String errorMessage);
+        void onSuccess(int responseCode);
+        void onFailure(Exception e);
     }
 
     /**
@@ -268,21 +268,23 @@ public class BranchEvent {
                         @Override
                         public void onRequestSucceeded(ServerResponse response, Branch branch) {
                             if (callback != null) {
-                                callback.onSuccess(response, branch);
+                                callback.onSuccess(response.getStatusCode());
                             }
                         }
 
                         @Override
                         public void handleFailure(int statusCode, String causeMsg) {
                             if (callback != null) {
-                                callback.onFailure(statusCode, causeMsg);
+                                Exception e = new Exception("Failed logEvent server request: " + statusCode + causeMsg);
+                                callback.onFailure(e);
                             }
                         }
                     }
             );
             isReqQueued = true;
         } else if (callback != null) {
-            callback.onFailure(0, "Error logging event because the Branch instance was not available");
+            Exception e = new Exception("Failed logEvent server request: The Branch instance was not available");
+            callback.onFailure(e);
         }
         return isReqQueued;
     }


### PR DESCRIPTION
## Reference
SDK-1981 -- Add new method for logEvent with a callback

## Description
This PR adds a new method, `logEvent(Context context, final BranchLogEventCallback callback)`, which logs Branch events and provides a callback on success or failure. The callback interface, `BranchLogEventCallback`, is triggered based on the result of the log event server request.

The existing `logEvent` method has been updated to call the new logEvent with a null callback to reduce code duplication while maintaining it's original behavior.

This update brings more parity between the Android and iOS SDK, which already has a `logEvent` method with a callback.

There are also a couple of very small unrelated fixes in other files which i though may as well be included here.

## Testing Instructions
Try the new and existing `logEvent` methods and see if the success and failure callback's are being properly triggered.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
