### PR TITLE
chore(deps): SDK-1989 - [Android] Update Android Gradle Plugin to 8

### DIFF
--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -7,6 +7,8 @@ env:
   SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
   BROWSERSTACK_USER: ${{ secrets.BROWSER_STACK_USER }}
   BROWSERSTACK_KEY: ${{ secrets.BROWSER_STACK_KEY }}
+  JAVA_DISTRIBUTION: 'corretto'
+  JAVA_VERSION: '17'
 jobs:  
   appium-automation-tests:
     name: appium-automation-tests
@@ -27,8 +29,8 @@ jobs:
       - name: Setup java 11 for gradle
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: $JAVA_DISTRIBUTION
+          java-version: $JAVA_VERSION
       # to reduce complexity, testbed app uses sdk as a project reference
       - name: Build testbed app
         run: |

--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -44,7 +44,7 @@ jobs:
           echo "::add-mask::$parsed"
           echo "APP_URL=$parsed" >> "$GITHUB_ENV"
       # automation is compatible with java 11
-      - name: Setup java for gradle
+      - name: Setup java for automation
         uses: actions/setup-java@v3
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}

--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -7,7 +7,7 @@ env:
   SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
   BROWSERSTACK_USER: ${{ secrets.BROWSER_STACK_USER }}
   BROWSERSTACK_KEY: ${{ secrets.BROWSER_STACK_KEY }}
-  JAVA_DISTRIBUTION: 'oracle'
+  JAVA_DISTRIBUTION: 'corretto'
   JAVA_VERSION: '17'
 jobs:  
   appium-automation-tests:
@@ -29,8 +29,8 @@ jobs:
       - name: Setup java 11 for gradle
         uses: actions/setup-java@v3
         with:
-          distribution: $JAVA_DISTRIBUTION
-          java-version: $JAVA_VERSION
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
       # to reduce complexity, testbed app uses sdk as a project reference
       - name: Build testbed app
         run: |

--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -7,7 +7,7 @@ env:
   SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
   BROWSERSTACK_USER: ${{ secrets.BROWSER_STACK_USER }}
   BROWSERSTACK_KEY: ${{ secrets.BROWSER_STACK_KEY }}
-  JAVA_DISTRIBUTION: 'corretto'
+  JAVA_DISTRIBUTION: 'oracle'
   JAVA_VERSION: '17'
 jobs:  
   appium-automation-tests:

--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -9,6 +9,7 @@ env:
   BROWSERSTACK_KEY: ${{ secrets.BROWSER_STACK_KEY }}
   JAVA_DISTRIBUTION: 'corretto'
   JAVA_VERSION: '17'
+  JAVA_VERSION_AUTOMATION: '11'
 jobs:  
   appium-automation-tests:
     name: appium-automation-tests
@@ -25,8 +26,8 @@ jobs:
           path: qa
           repository: BranchMetrics/qentelli-saas-sdk-testing-automation
           token: ${{ secrets.BRANCHLET_ACCESS_TOKEN_PUBLIC }}
-        # repo's gradle is configured to run on java 11
-      - name: Setup java 11 for gradle
+      # repo's gradle is configured to run on java 17
+      - name: Setup java for gradle
         uses: actions/setup-java@v3
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
@@ -42,6 +43,12 @@ jobs:
           parsed=$(echo $response | jq ".app_url")
           echo "::add-mask::$parsed"
           echo "APP_URL=$parsed" >> "$GITHUB_ENV"
+      # automation is compatible with java 11
+      - name: Setup java for gradle
+        uses: actions/setup-java@v3
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION_AUTOMATION }}
       - name: Execute automation
         run: |
           cd qa

--- a/.github/workflows/unit-and-instrumented-tests-action.yml
+++ b/.github/workflows/unit-and-instrumented-tests-action.yml
@@ -3,6 +3,8 @@ on: [push]
 env:
   API_MIN: 21
   API_CURRENT: 33
+  JAVA_DISTRIBUTION: 'corretto'
+  JAVA_VERSION: '17'
 jobs:
   unit-test-api-level-min:
     name: unit-test-api-level-$API_MIN
@@ -14,8 +16,8 @@ jobs:
       - name: Setup java 17 for gradle
         uses: actions/setup-java@v3
         with:
-          distribution: 'corretto'
-          java-version: '17'
+          distribution: $JAVA_DISTRIBUTION
+          java-version: $JAVA_VERSION
       - name: Run unit tests
         run: |
           ./gradlew :Branch-SDK:testDebugUnitTest 
@@ -49,8 +51,8 @@ jobs:
       - name: Setup java 17 for gradle
         uses: actions/setup-java@v3
         with:
-          distribution: 'corretto'
-          java-version: '17'
+          distribution: $JAVA_DISTRIBUTION
+          java-version: $JAVA_VERSION
       # gradlew will automatically connect to booted emulator
       - name: Run instrumented tests
         run: |
@@ -72,8 +74,8 @@ jobs:
       - name: Setup java 17 for gradle
         uses: actions/setup-java@v3
         with:
-          distribution: 'corretto'
-          java-version: '17'
+          distribution: $JAVA_DISTRIBUTION
+          java-version: $JAVA_VERSION
       - name: Run unit tests
         run: |
           ./gradlew :Branch-SDK:testDebugUnitTest 
@@ -107,8 +109,8 @@ jobs:
       - name: Setup java 17 for gradle
         uses: actions/setup-java@v3
         with:
-          distribution: 'corretto'
-          java-version: '17'
+          distribution: $JAVA_DISTRIBUTION
+          java-version: $JAVA_VERSION
       # gradlew will automatically connect to booted emulator
       - name: Run instrumented tests
         run: |

--- a/.github/workflows/unit-and-instrumented-tests-action.yml
+++ b/.github/workflows/unit-and-instrumented-tests-action.yml
@@ -3,7 +3,7 @@ on: [push]
 env:
   API_MIN: 21
   API_CURRENT: 33
-  JAVA_DISTRIBUTION: 'corretto'
+  JAVA_DISTRIBUTION: 'oracle'
   JAVA_VERSION: '17'
 jobs:
   unit-test-api-level-min:

--- a/.github/workflows/unit-and-instrumented-tests-action.yml
+++ b/.github/workflows/unit-and-instrumented-tests-action.yml
@@ -10,12 +10,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      # repo's gradle is configured to run on java 11
-      - name: Setup java 11 for gradle
+      # repo's gradle is configured to run on java 17
+      - name: Setup java 17 for gradle
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: 'corretto'
+          java-version: '17'
       - name: Run unit tests
         run: |
           ./gradlew :Branch-SDK:testDebugUnitTest 
@@ -45,12 +45,12 @@ jobs:
           nohup $ANDROID_HOME/tools/emulator -avd test -no-audio -no-boot-anim -camera-back none -camera-front none -qemu -m 2048 2>&1 &
           $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do echo "waiting..."; sleep 1; done; input keyevent 82'
           echo "Emulator has finished booting"
-      # repo's gradle is configured to run on java 11
-      - name: Setup java 11 for gradle
+      # repo's gradle is configured to run on java 17
+      - name: Setup java 17 for gradle
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: 'corretto'
+          java-version: '17'
       # gradlew will automatically connect to booted emulator
       - name: Run instrumented tests
         run: |
@@ -68,12 +68,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      # repo's gradle is configured to run on java 11
-      - name: Setup java 11 for gradle
+      # repo's gradle is configured to run on java 17
+      - name: Setup java 17 for gradle
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: 'corretto'
+          java-version: '17'
       - name: Run unit tests
         run: |
           ./gradlew :Branch-SDK:testDebugUnitTest 
@@ -103,12 +103,12 @@ jobs:
           nohup $ANDROID_HOME/tools/emulator -avd test -no-audio -no-boot-anim -camera-back none -camera-front none -qemu -m 2048 2>&1 &
           $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do echo "waiting..."; sleep 1; done; input keyevent 82'
           echo "Emulator has finished booting"
-      # repo's gradle is configured to run on java 11
-      - name: Setup java 11 for gradle
+      # repo's gradle is configured to run on java 17
+      - name: Setup java 17 for gradle
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: 'corretto'
+          java-version: '17'
       # gradlew will automatically connect to booted emulator
       - name: Run instrumented tests
         run: |

--- a/.github/workflows/unit-and-instrumented-tests-action.yml
+++ b/.github/workflows/unit-and-instrumented-tests-action.yml
@@ -3,7 +3,7 @@ on: [push]
 env:
   API_MIN: 21
   API_CURRENT: 33
-  JAVA_DISTRIBUTION: 'oracle'
+  JAVA_DISTRIBUTION: 'corretto'
   JAVA_VERSION: '17'
 jobs:
   unit-test-api-level-min:
@@ -16,8 +16,8 @@ jobs:
       - name: Setup java 17 for gradle
         uses: actions/setup-java@v3
         with:
-          distribution: 'corretto'
-          java-version: $JAVA_VERSION
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
       - name: Run unit tests
         run: |
           ./gradlew :Branch-SDK:testDebugUnitTest 
@@ -51,8 +51,8 @@ jobs:
       - name: Setup java 17 for gradle
         uses: actions/setup-java@v3
         with:
-          distribution: $JAVA_DISTRIBUTION
-          java-version: $JAVA_VERSION
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
       # gradlew will automatically connect to booted emulator
       - name: Run instrumented tests
         run: |
@@ -74,8 +74,8 @@ jobs:
       - name: Setup java 17 for gradle
         uses: actions/setup-java@v3
         with:
-          distribution: $JAVA_DISTRIBUTION
-          java-version: $JAVA_VERSION
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
       - name: Run unit tests
         run: |
           ./gradlew :Branch-SDK:testDebugUnitTest 
@@ -109,8 +109,8 @@ jobs:
       - name: Setup java 17 for gradle
         uses: actions/setup-java@v3
         with:
-          distribution: $JAVA_DISTRIBUTION
-          java-version: $JAVA_VERSION
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
       # gradlew will automatically connect to booted emulator
       - name: Run instrumented tests
         run: |

--- a/.github/workflows/unit-and-instrumented-tests-action.yml
+++ b/.github/workflows/unit-and-instrumented-tests-action.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup java 17 for gradle
         uses: actions/setup-java@v3
         with:
-          distribution: $JAVA_DISTRIBUTION
+          distribution: 'corretto'
           java-version: $JAVA_VERSION
       - name: Run unit tests
         run: |

--- a/Branch-SDK-Automation-TestBed/build.gradle
+++ b/Branch-SDK-Automation-TestBed/build.gradle
@@ -25,6 +25,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    namespace 'io.branch.saas.sdk.testbed'
 }
 
 dependencies {

--- a/Branch-SDK-Automation-TestBed/src/main/AndroidManifest.xml
+++ b/Branch-SDK-Automation-TestBed/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.branch.saas.sdk.testbed">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>

--- a/Branch-SDK-TestBed/build.gradle.kts
+++ b/Branch-SDK-TestBed/build.gradle.kts
@@ -15,10 +15,10 @@ dependencies {
     }
     implementation("com.android.billingclient:billing:5.1.0")
 
-    androidTestImplementation("androidx.test.ext:junit:1.1.3")
-    androidTestImplementation("androidx.test:runner:1.4.0")
-    androidTestImplementation("androidx.test:rules:1.4.0")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test:runner:1.5.2")
+    androidTestImplementation("androidx.test:rules:1.5.0")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 }
 
 android {

--- a/Branch-SDK-TestBed/build.gradle.kts
+++ b/Branch-SDK-TestBed/build.gradle.kts
@@ -74,4 +74,5 @@ android {
             signingConfig = signingConfigs.findByName("release")
         }
     }
+    namespace = "io.branch.branchandroidtestbed"
 }

--- a/Branch-SDK-TestBed/src/main/AndroidManifest.xml
+++ b/Branch-SDK-TestBed/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.branch.branchandroidtestbed"
     android:versionCode="1"
     android:versionName="1.0" >
 

--- a/Branch-SDK/build.gradle.kts
+++ b/Branch-SDK/build.gradle.kts
@@ -79,6 +79,7 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+    namespace = "io.branch.referral"
 
     publishing {
         singleVariant("release") {

--- a/Branch-SDK/build.gradle.kts
+++ b/Branch-SDK/build.gradle.kts
@@ -60,6 +60,10 @@ android {
         abortOnError = false
     }
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     buildTypes {
         fun String.wrapInQuotes(): String {
             return "\"$this\""

--- a/Branch-SDK/build.gradle.kts
+++ b/Branch-SDK/build.gradle.kts
@@ -70,7 +70,7 @@ android {
         }
 
         debug {
-            isTestCoverageEnabled = true
+            enableUnitTestCoverage = true
             buildConfigField("long", "VERSION_CODE", VERSION_CODE)
             buildConfigField("String", "VERSION_NAME", VERSION_NAME.wrapInQuotes())
         }

--- a/Branch-SDK/src/androidTest/AndroidManifest.xml
+++ b/Branch-SDK/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.branch.referral.test">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/Branch-SDK/src/main/AndroidManifest.xml
+++ b/Branch-SDK/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.branch.referral"
     android:versionCode="1"
     android:versionName="1.0" >
 </manifest>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 import  org.gradle.api.tasks.testing.logging.*
 
 plugins {
-    id("com.android.library") version "7.3.1" apply false
-    id("com.android.application") version "7.3.1" apply false
-    kotlin("android") version "1.6.20" apply false
+    id("com.android.library") version "8.0.0" apply false
+    id("com.android.application") version "8.0.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
 }
 
 val VERSION_NAME: String by project

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 import  org.gradle.api.tasks.testing.logging.*
 
 plugins {
-    id("com.android.library") version "8.0.0" apply false
-    id("com.android.application") version "8.0.0" apply false
+    id("com.android.library") version "8.0.2" apply false
+    id("com.android.application") version "8.0.2" apply false
     id("org.jetbrains.kotlin.android") version "1.8.22" apply false
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 import  org.gradle.api.tasks.testing.logging.*
 
 plugins {
-    id("com.android.library") version "7.2.2" apply false
-    id("com.android.application") version "7.2.2" apply false
+    id("com.android.library") version "7.3.1" apply false
+    id("com.android.application") version "7.3.1" apply false
     kotlin("android") version "1.6.20" apply false
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jun 12 15:42:40 PDT 2019
+#Tue Jun 20 16:10:36 PDT 2023
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Reference
SDK-1989 - [Android] Update Android Gradle Plugin to 8

## Description
Android Gradle Plugin **8.0** was released earlier this year and adoption is increasing. An incompatibility with our library was raised regarding the `R8` tool (shrinking/minifying) where classes not in the path, even when declared as `compileOnly`, will throw an error. A PR for which will be merged into this PR https://github.com/BranchMetrics/android-branch-deep-linking-attribution/pull/1063

Updating the tooling to be consistent and catch errors proactively.  

## Testing Instructions
Check out the branch and ensure that the library and test apps build. You may need to clear the IDE cache.
AGP 8 requires Java 17 to run.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [✅ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
