### PR TITLE
chore(dep):SDK-1999 -- [Android] Revert Kotlin Plugin Update

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import  org.gradle.api.tasks.testing.logging.*
 plugins {
     id("com.android.library") version "8.0.2" apply false
     id("com.android.application") version "8.0.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    id("org.jetbrains.kotlin.android") version "1.6.20" apply false
 }
 
 val VERSION_NAME: String by project


### PR DESCRIPTION
## Reference
SDK-1999 -- [Android] Revert Kotlin Plugin Update

## Description
In the migration to gradle 8, we had updated the kotlin plugin to 1.8.22 which ended up breaking downstream integrations. Reverting.

## Testing Instructions
Verify the problem by downloading `5.6.0` into your app that is building with `1.6.0` 
You should see something like
```
.../.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.8.22/1a8e3601703ae14bb58757ea6b2d8e8e5935a586/kotlin-stdlib-common-1.8.22.jar!/META-INF/kotlin-stdlib-common.kotlin_module: Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.8.0, expected version is 1.6.0.
```
Integrate this branch sdk by maven local into an app targeting `1.6.20`, the original kotlin version.
No errors.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [✅] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
