### PR TITLE
chore(dep):Revert annotations version and update instrumented tests gh runner api level to 34

### DIFF
--- a/.github/workflows/unit-and-instrumented-tests-action.yml
+++ b/.github/workflows/unit-and-instrumented-tests-action.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Launch Emulator
         run: |
           echo "Starting emulator and waiting for boot to complete."
-          nohup $ANDROID_HOME/tools/emulator -avd test -no-audio -no-boot-anim -camera-back none -camera-front none -qemu -m 2048 2>&1 &
+          nohup $ANDROID_HOME/tools/emulator -avd test -no-audio -no-boot-anim -camera-back none -camera-front none -qemu -memory 8192 -cache-size 1000 -partition-size 8192 2>&1 &
           $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do echo "waiting..."; sleep 1; done; input keyevent 82'
           echo "Emulator has finished booting"
       # repo's gradle is configured to run on java 17

--- a/.github/workflows/unit-and-instrumented-tests-action.yml
+++ b/.github/workflows/unit-and-instrumented-tests-action.yml
@@ -2,7 +2,7 @@ name: unit-and-instrumented-tests
 on: [push]
 env:
   API_MIN: 21
-  API_CURRENT: 33
+  API_CURRENT: 34
   JAVA_DISTRIBUTION: 'corretto'
   JAVA_VERSION: '17'
 jobs:
@@ -96,8 +96,9 @@ jobs:
       - name: Create Android emulator
         run: |
           echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --licenses
-          echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install "system-images;android-"$API_CURRENT";google_apis;x86_64"
-          echo "no" | $ANDROID_HOME/tools/bin/avdmanager --verbose create avd --force --name test --package "system-images;android-"$API_CURRENT";google_apis;x86_64"
+          echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install "system-images;android-"$API_CURRENT";google_apis_playstore;x86_64"
+          echo "no" | $ANDROID_HOME/tools/bin/avdmanager list device
+          echo "no" | $ANDROID_HOME/tools/bin/avdmanager --verbose create avd --force --name test --package "system-images;android-"$API_CURRENT";google_apis_playstore;x86_64"
       # boots and waits for the emulator to be ready
       - name: Launch Emulator
         run: |

--- a/.github/workflows/unit-and-instrumented-tests-action.yml
+++ b/.github/workflows/unit-and-instrumented-tests-action.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Launch Emulator
         run: |
           echo "Starting emulator and waiting for boot to complete."
-          nohup $ANDROID_HOME/tools/emulator -avd test -no-audio -no-boot-anim -camera-back none -camera-front none -qemu -m 8192 -cache-size 1000 -partition-size 8192 2>&1 &
+          nohup $ANDROID_HOME/tools/emulator -avd test -no-audio -no-boot-anim -camera-back none -camera-front none -qemu -m 2048 2>&1 &
           $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do echo "waiting..."; sleep 1; done; input keyevent 82'
           echo "Emulator has finished booting"
       # repo's gradle is configured to run on java 17

--- a/.github/workflows/unit-and-instrumented-tests-action.yml
+++ b/.github/workflows/unit-and-instrumented-tests-action.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Launch Emulator
         run: |
           echo "Starting emulator and waiting for boot to complete."
-          nohup $ANDROID_HOME/tools/emulator -avd test -no-audio -no-boot-anim -camera-back none -camera-front none -qemu -memory 8192 -cache-size 1000 -partition-size 8192 2>&1 &
+          nohup $ANDROID_HOME/tools/emulator -avd test -no-audio -no-boot-anim -camera-back none -camera-front none -qemu -m 8192 -cache-size 1000 -partition-size 8192 2>&1 &
           $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do echo "waiting..."; sleep 1; done; input keyevent 82'
           echo "Emulator has finished booting"
       # repo's gradle is configured to run on java 17

--- a/Branch-SDK/build.gradle.kts
+++ b/Branch-SDK/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to "*.jar")))
     implementation(kotlin("stdlib"))
     implementation(kotlin("stdlib-jdk8"))
-    implementation("androidx.annotation:annotation:1.6.0")
+    implementation("androidx.annotation:annotation:1.4.0")
     implementation("com.android.installreferrer:installreferrer:2.2")
 
     // --- optional dependencies -----


### PR DESCRIPTION
## Reference
SDK-XXX -- <TITLE>.

## Description
`implementation("androidx.annotation:annotation:1.6.0")` is built with an incompatible kotlin library
Reverting to original `implementation("androidx.annotation:annotation:1.4.0")`


## Testing Instructions
<!-- TESTING INSTRUCTIONS -->

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
