### PR TITLE
[SDK-1689] Updated generateShortLinkSync to create short link when tracking is disabled

### DIFF
--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchApiTests.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchApiTests.java
@@ -71,7 +71,7 @@ public class BranchApiTests extends BranchTest {
     }
 
     @Test
-    public void test00GetShortUrlSyncFailure() {
+    public void test00GetShortUrlSync() {
         String url = new BranchShortLinkBuilder(getTestContext()).getShortUrl();
         Assert.assertNotNull(url);
     }

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchApiTests.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchApiTests.java
@@ -73,7 +73,7 @@ public class BranchApiTests extends BranchTest {
     @Test
     public void test00GetShortUrlSyncFailure() {
         String url = new BranchShortLinkBuilder(getTestContext()).getShortUrl();
-        Assert.assertNull(url);
+        Assert.assertNotNull(url);
     }
 
     @Test


### PR DESCRIPTION
## Reference
SDK-1689 -- Generate short link with disable tracking does not appear to work

## Description
Trying to create short urls when tracking is disabled led to a long link being created instead. This only happened when using `getShortUrl` but now `showShareSheet`. This change brings parity by now having them both create short links whether tracking is disabled or enabled.

## Testing Instructions
Try to create short links when tracking is disabled. Try with both `getShortUrl` and `showShareSheet.`

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
