### PR TITLE
[SDK-2044] Fix exception logged in getReferringURLQueryParameters()

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -740,7 +740,7 @@ public class PrefHelper {
             try {
                 params = new JSONObject(string);
             } catch (JSONException e) {
-                PrefHelper.LogException("Unable to get URL query parameters as string: ", e);
+                PrefHelper.Warning("Unable to get URL query parameters as string: " + e);
             }
         }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -736,12 +736,14 @@ public class PrefHelper {
         String string = getString(KEY_REFERRING_URL_QUERY_PARAMETERS);
         JSONObject params = new JSONObject();
 
-        if (string != NO_STRING_VALUE) {
+        if (!TextUtils.isEmpty(string) && !PrefHelper.NO_STRING_VALUE.equals(string)) {
             try {
                 params = new JSONObject(string);
             } catch (JSONException e) {
                 PrefHelper.Warning("Unable to get URL query parameters as string: " + e);
             }
+        } else {
+            PrefHelper.Debug("There are no saved referring URL query parameters.");
         }
 
         return params;

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -735,11 +735,13 @@ public class PrefHelper {
 
         String string = getString(KEY_REFERRING_URL_QUERY_PARAMETERS);
         JSONObject params = new JSONObject();
-        try {
-            params = new JSONObject(string);
-        }
-        catch (JSONException e) {
-            PrefHelper.LogException("Unable to get URL query parameters as string: ", e);
+
+        if (string != NO_STRING_VALUE) {
+            try {
+                params = new JSONObject(string);
+            } catch (JSONException e) {
+                PrefHelper.LogException("Unable to get URL query parameters as string: ", e);
+            }
         }
 
         return params;

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -743,7 +743,7 @@ public class PrefHelper {
                 PrefHelper.Warning("Unable to get URL query parameters as string: " + e);
             }
         } else {
-            PrefHelper.Debug("There are no saved referring URL query parameters.");
+            PrefHelper.Debug("No URL parameters found.");
         }
 
         return params;


### PR DESCRIPTION
## Reference
SDK-2044 -- Fix exception log "Value bnc_no_value of type java.lang.String cannot be converted to JSONObject"

## Description
When the user had no referring URL query params saved, the function would try to create a JSONObject out of "bnc_no_value", which failed. This would log a long exception as seen in this Github issue: https://github.com/BranchMetrics/android-branch-deep-linking-attribution/issues/1092

## Testing Instructions
In an app with no saved URL query parameters, open the app and you should no longer see the exception logged.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
