### PR TITLE
 Fix minification warning for install referrers

### DIFF
--- a/Branch-SDK/proguard-consumer.txt
+++ b/Branch-SDK/proguard-consumer.txt
@@ -1,2 +1,6 @@
 # Remove references to Huawei's OAID (Google's advertising id equivalent) if the dependency is not available in your project.
 -dontwarn com.huawei.hms.ads.**
+
+-dontwarn com.miui.referrer.**
+-dontwarn com.samsung.android.sdk.sinstallreferrer.**
+

--- a/Branch-SDK/proguard-consumer.txt
+++ b/Branch-SDK/proguard-consumer.txt
@@ -3,4 +3,3 @@
 
 -dontwarn com.miui.referrer.**
 -dontwarn com.samsung.android.sdk.sinstallreferrer.**
-


### PR DESCRIPTION
## Reference
SDK-2062 -- Fix minification warning for install referrers

## Description
[<!-- SUFFICIENT DESCRIPTION TO EXPLAIN THE PROBLEM THAT IS BEING SOLVED -->
](https://github.com/BranchMetrics/android-branch-deep-linking-attribution/issues/1105)

As of gradle 8, R8 the minification tool fails the build when not importing all declared classes. Adding proguard policies to suppress these and not break builds. This was done for Huawei prior https://github.com/BranchMetrics/android-branch-deep-linking-attribution/pull/1063/files

Only Samsung and Xiaomi classes were newly added.

## Testing Instructions
Import 5.6.3 into a project and see that it fails with minification. Test with this branch and build should succeed.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [✅] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
