### PR TITLE
Remove remaining Tune references

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -304,8 +304,7 @@ public class Branch {
     private static boolean enableInstantDeepLinking = false;
     private final TrackingController trackingController;
 
-    /** Variables for reporting plugin type and version (some TUNE customers do that), plus helps
-     * us make data driven decisions. */
+    // Variables for reporting plugin type and version, plus helps us make data driven decisions.
     private static String pluginVersion = null;
     private static String pluginName = null;
 

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -159,6 +159,12 @@ public class Defines {
         Description("description"),
         SearchQuery("search_query"),
         AdType("ad_type"),
+        
+        CPUType("cpu_type"),
+        DeviceBuildId("build"),
+        Locale("locale"),
+        ConnectionType("connection_type"),
+        DeviceCarrier("device_carrier"),
 
         PluginName("plugin_name"),
         PluginVersion("plugin_version"),

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -165,7 +165,6 @@ public class Defines {
         Locale("locale"),
         ConnectionType("connection_type"),
         DeviceCarrier("device_carrier"),
-
         PluginName("plugin_name"),
         PluginVersion("plugin_version"),
         OSVersionAndroid("os_version_android"),

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -160,12 +160,6 @@ public class Defines {
         SearchQuery("search_query"),
         AdType("ad_type"),
 
-        // to accommodate Tune -> Branch migration
-        CPUType("cpu_type"),
-        DeviceBuildId("build"),
-        Locale("locale"),
-        ConnectionType("connection_type"),
-        DeviceCarrier("device_carrier"),
         PluginName("plugin_name"),
         PluginVersion("plugin_version"),
         OSVersionAndroid("os_version_android"),

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -159,7 +159,7 @@ public class Defines {
         Description("description"),
         SearchQuery("search_query"),
         AdType("ad_type"),
-        
+
         CPUType("cpu_type"),
         DeviceBuildId("build"),
         Locale("locale"),

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -90,8 +90,6 @@ class DeviceInfo {
 
             requestObj.put(Defines.Jsonkey.APILevel.getKey(), SystemObserver.getAPILevel());
 
-            maybeAddTuneFields(serverRequest, requestObj);
-
             if (Branch.getPluginName() != null) {
                 requestObj.put(Defines.Jsonkey.PluginName.getKey(), Branch.getPluginName());
                 requestObj.put(Defines.Jsonkey.PluginVersion.getKey(), Branch.getPluginVersion());
@@ -170,8 +168,6 @@ class DeviceInfo {
 
             userDataObj.put(Defines.Jsonkey.APILevel.getKey(), SystemObserver.getAPILevel());
 
-            maybeAddTuneFields(serverRequest, userDataObj);
-
             if (Branch.getPluginName() != null) {
                 userDataObj.put(Defines.Jsonkey.PluginName.getKey(), Branch.getPluginName());
                 userDataObj.put(Defines.Jsonkey.PluginVersion.getKey(), Branch.getPluginVersion());
@@ -219,18 +215,6 @@ class DeviceInfo {
 
         } catch (JSONException e) {
             BranchLogger.d(e.getMessage());
-        }
-    }
-
-    private void maybeAddTuneFields(ServerRequest serverRequest, JSONObject requestObj) throws JSONException {
-        if (serverRequest.isInitializationOrEventRequest()) {
-            // fields for parity with Tune traffic
-            requestObj.put(Defines.Jsonkey.CPUType.getKey(), SystemObserver.getCPUType());
-            requestObj.put(Defines.Jsonkey.DeviceBuildId.getKey(), SystemObserver.getDeviceBuildId());
-            requestObj.put(Defines.Jsonkey.Locale.getKey(), SystemObserver.getLocale());
-            requestObj.put(Defines.Jsonkey.ConnectionType.getKey(), SystemObserver.getConnectionType(context_));
-            requestObj.put(Defines.Jsonkey.DeviceCarrier.getKey(), SystemObserver.getCarrier(context_));
-            requestObj.put(Defines.Jsonkey.OSVersionAndroid.getKey(), SystemObserver.getOSVersion());
         }
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -734,12 +734,4 @@ public abstract class ServerRequest {
         // Default return false. Return true for request need to be executed when tracking is disabled
         return false;
     }
-
-    // needed for TUNE/Branch field parity for certain request (i.e. initialization and events)
-    boolean isInitializationOrEventRequest() {
-        for (Defines.RequestPath item : initializationAndEventRoutes) {
-            if (item.equals(requestPath_)) return true;
-        }
-        return false;
-    }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -26,7 +26,6 @@ abstract class ServerRequestInitSession extends ServerRequest {
     private static final int STATE_FRESH_INSTALL = 0;
     private static final int STATE_NO_CHANGE = 1;
     private static final int STATE_UPDATE = 2;
-    private static final int STATE_TUNE_MIGRATION = 5;
 
     static final String INITIATED_BY_CLIENT = "INITIATED_BY_CLIENT";
 
@@ -221,13 +220,6 @@ abstract class ServerRequestInitSession extends ServerRequest {
             if ((lastUpdateTime - firstInstallTime) >= updateBufferTime) {
                 installOrUpdateState = STATE_UPDATE;
             }
-
-            // Finally, we check if this is the first session after a TUNE-> Branch migration, in which
-            // case server expects a special value.
-            if (isTuneMigration()) {
-                installOrUpdateState = STATE_TUNE_MIGRATION;
-            }
-
         } else if (!prefHelper_.getAppVersion().equals(currAppVersion)) {
             // if the current app version doesn't match the stored version, then it's an update
             installOrUpdateState = STATE_UPDATE;
@@ -251,14 +243,6 @@ abstract class ServerRequestInitSession extends ServerRequest {
             prefHelper_.setLong(PrefHelper.KEY_LAST_KNOWN_UPDATE_TIME, lastUpdateTime);
         }
         post.put(Defines.Jsonkey.PreviousUpdateTime.getKey(), prefHelper_.getLong(PrefHelper.KEY_PREVIOUS_UPDATE_TIME));
-    }
-
-    private boolean isTuneMigration() {
-        // getApplicationContext() matters here
-        SharedPreferences tunePrefs = context_.getApplicationContext().getSharedPreferences(
-                "com.mobileapptracking", Context.MODE_PRIVATE);
-        final String tuneID = tunePrefs.getString("mat_id", null);
-        return !TextUtils.isEmpty(tuneID);
     }
 
     @Override


### PR DESCRIPTION
## Reference
SDK-2102 -- Remove remaining Tune references

## Description
Apps migrating from Tune to Branch SDK would set a flag informing us this fact. 
With the scheduled removal of Tune support, removing all references to Tune.

## Testing Instructions
Review the code, ensure no field that is actually still being used on server side is impacted.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [✅] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
