### PR TITLE
[SDK-2072] Create GHA to sync release notes with ReadMe Version History

### DIFF
--- a/.github/workflows/sync-readme-changelog
+++ b/.github/workflows/sync-readme-changelog
@@ -1,0 +1,89 @@
+name: Update Changelog on Readme.com
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Format and publish release notes to version history doc
+      id: update
+      run: |
+        # Get release name, body, and date from the release event
+        release_name="${{ github.event.release.tag_name }}"
+        release_body="${{ github.event.release.body }}"
+        release_date=$(date -d "${{ github.event.release.published_at }}" +"%Y-%B-%d")
+        # Format release notes
+        formatted_notes="## v$release_name\n\n**($release_date)**\n\n$release_body"
+        
+        # Get existing version history page
+        existing_content=$(curl --request GET \
+            --url https://dash.readme.com/api/v1/docs/android-version-history \
+            --header 'accept: application/json' \
+            --header "authorization: Basic ${{ secrets.readme_api_key_base64 }}" \
+            | jq -r '.body')
+    
+        # Prepend new release notes to existing content
+        new_content=$(echo -e "$formatted_notes\n\n$existing_content")
+        payload=$(jq -n --arg nc "$new_content" '{"body": $nc}')
+
+        # Update version history page with new release notes
+        curl --request PUT \
+            --url https://dash.readme.com/api/v1/docs/android-version-history \
+            --header 'accept: application/json' \
+            --header "authorization: Basic ${{ secrets.readme_api_key_base64 }}" \
+            --header 'content-type: application/json' \
+            --data "$payload"
+
+    - name: Announce New Release in Slack
+      uses: slackapi/slack-github-action@v1.24.0
+      with:
+        channel-id: "CDFGXRM9S"
+        payload: |
+            {
+                "text": "New Release: Branch Android SDK v${{ github.event.release.tag_name }}",
+                "blocks": [
+                    {
+                        "type": "header",
+                        "text": {
+                            "type": "plain_text",
+                            "text": ":rocket: New Release: Branch Android SDK v${{ github.event.release.tag_name }}",                            
+                            "emoji": true
+                        }
+                    },
+                    {
+                        "type": "divider"
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": ":star: *What's New*:\n\n${{ github.event.release.body }}"
+                        }
+                    },
+                    {
+                        "type": "divider"
+                    },
+                    {
+                        "type": "actions",
+                        "elements": [
+                            {
+                                "type": "button",
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": ":git: GitHub Release",
+                                    "emoji": true
+                                },
+                                "value": "github",
+                                "action_id": "github",
+                                "url": "${{ github.event.release.html_url }}"
+                            }
+                        ]
+                    }
+                ]
+            }
+    env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_SDK_BOT_TOKEN }}

--- a/.github/workflows/sync-readme-changelog.yml
+++ b/.github/workflows/sync-readme-changelog.yml
@@ -1,4 +1,4 @@
-name: Update Changelog on Readme.com
+name: Update Version History on Readme
 
 on:
   release:
@@ -61,9 +61,16 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": ":star: *What's New*:\n\n${{ github.event.release.body }}"
+                            "text": ":star: *What's New*"
                         }
                     },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": ${{ toJSON(github.event.release.body) }}
+                        }
+                	},
                     {
                         "type": "divider"
                     },


### PR DESCRIPTION
## Reference
SDK-2072 -- Help Docs automate Readme changelogs

## Description
Created a new Github Action that runs whenever a new Github Release is made. It uses the release tag and description to create a new section in the [public readme doc's version history page](https://help.branch.io/developers-hub/docs/android-version-history). It also uses this data to send a Slack message in the SDK channel announcing the new release. 

## Testing Instructions
The action can be run locally using Act or a test release can be made to ensure everything works properly.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
