### PR TITLE
[SDK-2150] Add back fields related to TUNE

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -90,8 +90,6 @@ class DeviceInfo {
 
             requestObj.put(Defines.Jsonkey.APILevel.getKey(), SystemObserver.getAPILevel());
 
-            maybeAddSDFields(serverRequest, requestObj);
-
             if (Branch.getPluginName() != null) {
                 requestObj.put(Defines.Jsonkey.PluginName.getKey(), Branch.getPluginName());
                 requestObj.put(Defines.Jsonkey.PluginVersion.getKey(), Branch.getPluginVersion());
@@ -110,6 +108,15 @@ class DeviceInfo {
             String localIpAddr = SystemObserver.getLocalIPAddress();
             if ((!TextUtils.isEmpty(localIpAddr))) {
                 requestObj.put(Defines.Jsonkey.LocalIP.getKey(), localIpAddr);
+            }
+
+            if (serverRequest.isInitializationOrEventRequest()) {
+                requestObj.put(Defines.Jsonkey.CPUType.getKey(), SystemObserver.getCPUType());
+                requestObj.put(Defines.Jsonkey.DeviceBuildId.getKey(), SystemObserver.getDeviceBuildId());
+                requestObj.put(Defines.Jsonkey.Locale.getKey(), SystemObserver.getLocale());
+                requestObj.put(Defines.Jsonkey.ConnectionType.getKey(), SystemObserver.getConnectionType(context_));
+                requestObj.put(Defines.Jsonkey.DeviceCarrier.getKey(), SystemObserver.getCarrier(context_));
+                requestObj.put(Defines.Jsonkey.OSVersionAndroid.getKey(), SystemObserver.getOSVersion());
             }
         } catch (JSONException e) {
             BranchLogger.d(e.getMessage());
@@ -170,8 +177,6 @@ class DeviceInfo {
 
             userDataObj.put(Defines.Jsonkey.APILevel.getKey(), SystemObserver.getAPILevel());
 
-            maybeAddSDFields(serverRequest, userDataObj);
-
             if (Branch.getPluginName() != null) {
                 userDataObj.put(Defines.Jsonkey.PluginName.getKey(), Branch.getPluginName());
                 userDataObj.put(Defines.Jsonkey.PluginVersion.getKey(), Branch.getPluginVersion());
@@ -217,19 +222,17 @@ class DeviceInfo {
                         ((ServerRequestGetLATD) serverRequest).getAttributionWindow());
             }
 
+            if (serverRequest.isInitializationOrEventRequest()) {
+                userDataObj.put(Defines.Jsonkey.CPUType.getKey(), SystemObserver.getCPUType());
+                userDataObj.put(Defines.Jsonkey.DeviceBuildId.getKey(), SystemObserver.getDeviceBuildId());
+                userDataObj.put(Defines.Jsonkey.Locale.getKey(), SystemObserver.getLocale());
+                userDataObj.put(Defines.Jsonkey.ConnectionType.getKey(), SystemObserver.getConnectionType(context_));
+                userDataObj.put(Defines.Jsonkey.DeviceCarrier.getKey(), SystemObserver.getCarrier(context_));
+                userDataObj.put(Defines.Jsonkey.OSVersionAndroid.getKey(), SystemObserver.getOSVersion());
+            }
+
         } catch (JSONException e) {
             BranchLogger.d(e.getMessage());
-        }
-    }
-
-    private void maybeAddSDFields(ServerRequest serverRequest, JSONObject requestObj) throws JSONException {
-        if (serverRequest.isInitializationOrEventRequest()) {
-            requestObj.put(Defines.Jsonkey.CPUType.getKey(), SystemObserver.getCPUType());
-            requestObj.put(Defines.Jsonkey.DeviceBuildId.getKey(), SystemObserver.getDeviceBuildId());
-            requestObj.put(Defines.Jsonkey.Locale.getKey(), SystemObserver.getLocale());
-            requestObj.put(Defines.Jsonkey.ConnectionType.getKey(), SystemObserver.getConnectionType(context_));
-            requestObj.put(Defines.Jsonkey.DeviceCarrier.getKey(), SystemObserver.getCarrier(context_));
-            requestObj.put(Defines.Jsonkey.OSVersionAndroid.getKey(), SystemObserver.getOSVersion());
         }
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -90,6 +90,8 @@ class DeviceInfo {
 
             requestObj.put(Defines.Jsonkey.APILevel.getKey(), SystemObserver.getAPILevel());
 
+            maybeAddSDFields(serverRequest, requestObj);
+
             if (Branch.getPluginName() != null) {
                 requestObj.put(Defines.Jsonkey.PluginName.getKey(), Branch.getPluginName());
                 requestObj.put(Defines.Jsonkey.PluginVersion.getKey(), Branch.getPluginVersion());
@@ -168,6 +170,8 @@ class DeviceInfo {
 
             userDataObj.put(Defines.Jsonkey.APILevel.getKey(), SystemObserver.getAPILevel());
 
+            maybeAddSDFields(serverRequest, userDataObj);
+
             if (Branch.getPluginName() != null) {
                 userDataObj.put(Defines.Jsonkey.PluginName.getKey(), Branch.getPluginName());
                 userDataObj.put(Defines.Jsonkey.PluginVersion.getKey(), Branch.getPluginVersion());
@@ -215,6 +219,17 @@ class DeviceInfo {
 
         } catch (JSONException e) {
             BranchLogger.d(e.getMessage());
+        }
+    }
+
+    private void maybeAddSDFields(ServerRequest serverRequest, JSONObject requestObj) throws JSONException {
+        if (serverRequest.isInitializationOrEventRequest()) {
+            requestObj.put(Defines.Jsonkey.CPUType.getKey(), SystemObserver.getCPUType());
+            requestObj.put(Defines.Jsonkey.DeviceBuildId.getKey(), SystemObserver.getDeviceBuildId());
+            requestObj.put(Defines.Jsonkey.Locale.getKey(), SystemObserver.getLocale());
+            requestObj.put(Defines.Jsonkey.ConnectionType.getKey(), SystemObserver.getConnectionType(context_));
+            requestObj.put(Defines.Jsonkey.DeviceCarrier.getKey(), SystemObserver.getCarrier(context_));
+            requestObj.put(Defines.Jsonkey.OSVersionAndroid.getKey(), SystemObserver.getOSVersion());
         }
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -737,4 +737,12 @@ public abstract class ServerRequest {
         // Default return false. Return true for request need to be executed when tracking is disabled
         return false;
     }
+
+    // needed for adding SD fields for certain request (i.e. initialization and events)
+    boolean isInitializationOrEventRequest() {
+        for (Defines.RequestPath item : initializationAndEventRoutes) {
+            if (item.equals(requestPath_)) return true;
+        }
+        return false;
+    }
 }

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,9 @@
 # Branch Android SDK change log
+- v5.8.0
+  * _*Master Release*_ - Oct 3, 2023
+    - Fixed bug that prevented session from initializing after opening a link with gclid
+    - Removed remaining TUNE references
+    - Factored out queueing code from the Branch object
 - v5.7.0
   * _*Master Release*_ - Sep 1, 2023
     - SDK internal logging behavior has changed. Messages will now be sent through standard channels (`ERROR`, `WARN`, `INFO`, `DEBUG`, `VERBOSE`). Before, nearly all logs were sent to `INFO`.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,5 @@
 # Branch Android SDK change log
-- v5.8.0
+- v5.7.1
   * _*Master Release*_ - Oct 3, 2023
     - Fixed bug that prevented session from initializing after opening a link with gclid
     - Removed remaining TUNE references

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.7.0
-VERSION_CODE=050700
+VERSION_NAME=5.8.0
+VERSION_CODE=050800
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.8.0
-VERSION_CODE=050800
+VERSION_NAME=5.7.1
+VERSION_CODE=050701
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.


### PR DESCRIPTION
## Reference
SDK-2150: Rollback removal of field collections from 5.7.1 that were apart of the TUNE removal. 

## Description
These fields were orignally used for TUNE and were removed once TUNE was deprecated. However, they are also used for suspicious device detection for some customers and therefore still need to be included, just under a new method name. 

Original Removal Commit: https://github.com/BranchMetrics/android-branch-deep-linking-attribution/commit/79267fd8dc63233bbd00dde3be450e3a8a06df51

## Testing Instructions
<!-- TESTING INSTRUCTIONS -->
Ensure the fields show up in the right fields and test still pass.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
