### PR TITLE
[SDK-2161] Update release announcement to new sdk-releases channel

### DIFF
--- a/.github/workflows/sync-readme-changelog.yml
+++ b/.github/workflows/sync-readme-changelog.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Announce New Release in Slack
       uses: slackapi/slack-github-action@v1.24.0
       with:
-        channel-id: "CDFGXRM9S"
+        channel-id: "C063MQJMKJN" #sdk-releases
         payload: |
             {
                 "text": "New Release: Branch Android SDK v${{ github.event.release.tag_name }}",


### PR DESCRIPTION
## Reference
SDK-2162 -- Create #sdk-releases channel in Slack

## Description
Updated the sync-readme-changelog GHA to send the release announcement slack message in the new #sdk-releases channel instead of #sdk.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
