### PR TITLE
[SDK-2171] - [Android] Improve client-side network error logging

### DIFF
--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
@@ -519,6 +519,7 @@ public class MainActivity extends Activity {
 
                             @Override
                             public void onFailure(Exception e) {
+                                Log.d("BranchSDK_Tester", e.toString());
                                 Toast.makeText(getApplicationContext(), "Error sending Branch Commerce Event: " + e.toString(), Toast.LENGTH_SHORT).show();
                             }
                         });

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchError.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchError.java
@@ -6,7 +6,7 @@ package io.branch.referral;
 public class BranchError {
     
     String errorMessage_ = "";
-    int errorCode_ = ERR_BRANCH_NO_CONNECTIVITY;
+    int errorCode_ = ERR_OTHER;
     
     /* Error processing request since session not initialised yet. */
     public static final int ERR_NO_SESSION = -101;
@@ -42,6 +42,10 @@ public class BranchError {
     public static final int ERR_IMPROPER_REINITIALIZATION = -119;
     /* Request task timed out before completing*/
     public static final int ERR_BRANCH_TASK_TIMEOUT = -120;
+    /* Error when network request is made on main thread */
+    public static final int ERR_NETWORK_ON_MAIN = -121;
+    /* General error reporting */
+    public static final int ERR_OTHER = -122;
 
     /**
      * <p>Returns the message explaining the error.</p>
@@ -88,7 +92,7 @@ public class BranchError {
         String errMsg;
         if (statusCode == ERR_BRANCH_NO_CONNECTIVITY) {
             errorCode_ = ERR_BRANCH_NO_CONNECTIVITY;
-            errMsg = " Branch API Error: poor network connectivity. Please try again later.";
+            errMsg = " Check network connectivity or DNS settings.";
         } else if (statusCode == ERR_BRANCH_KEY_INVALID) {
             errorCode_ = ERR_BRANCH_KEY_INVALID;
             errMsg = " Branch API Error: Please enter your branch_key in your project's manifest file first.";
@@ -142,8 +146,8 @@ public class BranchError {
             errorCode_ = ERR_BRANCH_TASK_TIMEOUT;
             errMsg = " Task exceeded timeout.";
         } else {
-            errorCode_ = ERR_BRANCH_NO_CONNECTIVITY;
-            errMsg = " Check network connectivity and that you properly initialized.";
+            errorCode_ = ERR_OTHER;
+            errMsg = " See exception message or logs for more details. ";
         }
         return errMsg;
     }

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerResponse.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerResponse.java
@@ -41,6 +41,8 @@ public class ServerResponse {
      */
     private String requestId_;
 
+    private String message_;
+
     /**
      * <p>Main constructor method for the {@link ServerResponse} class that allows for the instantiation
      * of a server response object as a direct result of a server call.</p>
@@ -48,10 +50,11 @@ public class ServerResponse {
      * @param tag        A {@link String} value of the <i>Tag</i> attribute of the current link.
      * @param statusCode {@link Integer} value of the HTTP status code.
      */
-    public ServerResponse(String tag, int statusCode, String requestId) {
+    public ServerResponse(String tag, int statusCode, String requestId, String message) {
         tag_ = tag;
         statusCode_ = statusCode;
         requestId_ = requestId;
+        message_ = message;
     }
 
     /**
@@ -136,4 +139,7 @@ public class ServerResponse {
         return causeMsg;
     }
 
+    public String getMessage() {
+        return message_;
+    }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
@@ -5,6 +5,7 @@ import android.graphics.BitmapFactory;
 import android.net.TrafficStats;
 import android.os.NetworkOnMainThreadException;
 import android.util.Base64;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -101,7 +102,7 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
             }
         } catch (SocketException ex) {
             BranchLogger.v("Http connect exception: " + ex.getMessage());
-            throw new BranchRemoteException(BranchError.ERR_BRANCH_NO_CONNECTIVITY);
+            throw new BranchRemoteException(BranchError.ERR_BRANCH_NO_CONNECTIVITY, ex.getMessage());
 
         } catch (SocketTimeoutException ex) {
             // On socket  time out retry the request for retryNumber of times
@@ -114,7 +115,7 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
                 retryNumber++;
                 return doRestfulGet(url, retryNumber);
             } else {
-                throw new BranchRemoteException(BranchError.ERR_BRANCH_REQ_TIMED_OUT);
+                throw new BranchRemoteException(BranchError.ERR_BRANCH_REQ_TIMED_OUT, ex.getMessage());
             }
         } catch(InterruptedIOException ex){
             // When the thread times out before or while sending the request
@@ -127,11 +128,11 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
                 retryNumber++;
                 return doRestfulGet(url, retryNumber);
             } else {
-                throw new BranchRemoteException(BranchError.ERR_BRANCH_TASK_TIMEOUT);
+                throw new BranchRemoteException(BranchError.ERR_BRANCH_TASK_TIMEOUT, ex.getMessage());
             }
         } catch (IOException ex) {
             BranchLogger.v("Branch connect exception: " + ex.getMessage());
-            throw new BranchRemoteException(BranchError.ERR_BRANCH_NO_CONNECTIVITY);
+            throw new BranchRemoteException(BranchError.ERR_BRANCH_NO_CONNECTIVITY, ex.getMessage());
         } finally {
             if (connection != null) {
                 connection.disconnect();
@@ -223,6 +224,7 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
 
 
         } catch (SocketTimeoutException ex) {
+            BranchLogger.v("Encountered exception while attempting network request: " + Log.getStackTraceString(ex));
             // On socket  time out retry the request for retryNumber of times
             if (retryNumber < prefHelper.getRetryCount()) {
                 try {
@@ -233,9 +235,10 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
                 retryNumber++;
                 return doRestfulPost(url, payload, retryNumber);
             } else {
-                throw new BranchRemoteException(BranchError.ERR_BRANCH_REQ_TIMED_OUT);
+                throw new BranchRemoteException(BranchError.ERR_BRANCH_REQ_TIMED_OUT, Log.getStackTraceString(ex));
             }
         } catch(InterruptedIOException ex){
+            BranchLogger.v("Encountered exception while attempting network request: " + ex);
             // When the thread times out before or while sending the request
             if (retryNumber < prefHelper.getRetryCount()) {
                 try {
@@ -246,11 +249,12 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
                 retryNumber++;
                 return doRestfulPost(url, payload, retryNumber);
             } else {
-                throw new BranchRemoteException(BranchError.ERR_BRANCH_TASK_TIMEOUT);
+                throw new BranchRemoteException(BranchError.ERR_BRANCH_TASK_TIMEOUT, ex.getMessage());
             }
         }
         // Unable to resolve host/Unknown host exception
         catch (IOException ex) {
+            BranchLogger.v("Encountered exception while attempting network request: " + Log.getStackTraceString(ex));
             if (retryNumber < prefHelper.getRetryCount()) {
                 try {
                     Thread.sleep(prefHelper.getRetryInterval());
@@ -262,15 +266,15 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
                 return doRestfulPost(url, payload, retryNumber);
             }
             else {
-                throw new BranchRemoteException(BranchError.ERR_BRANCH_NO_CONNECTIVITY);
+                throw new BranchRemoteException(BranchError.ERR_BRANCH_NO_CONNECTIVITY, ex.getMessage());
             }
         } catch (Exception ex) {
-            BranchLogger.v("Exception: " + ex.getMessage());
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB) {
-                if (ex instanceof NetworkOnMainThreadException)
-                    BranchLogger.v("Branch Error: Don't call our synchronous methods on the main thread!!!");
+            BranchLogger.v("Encountered exception while attempting network request: " + Log.getStackTraceString(ex));
+            if (ex instanceof NetworkOnMainThreadException) {
+                BranchLogger.v("Branch Error: Cannot make network request on main thread: " + Log.getStackTraceString(ex));
+                throw new BranchRemoteException((BranchError.ERR_NETWORK_ON_MAIN), ex.getMessage());
             }
-            return new BranchResponse(null, 500);
+            throw new BranchRemoteException(BranchError.ERR_OTHER, ex.getMessage());
         } finally {
             if (connection != null) {
                 connection.disconnect();


### PR DESCRIPTION
## Reference
[SDK-2171] - [Android] Improve client-side network error logging

## Description
Regarding "poor network connectivity" errors, in the 5.X.X family of the Android SDK, it is possible that client side exceptions will return the message Check network connectivity and that you properly initialized.` which is inaccurate.

This PR updates some of the language in our messaging:
`Branch API Error: poor network connectivity. Please try again later.`
now reads
`Check network connectivity or DNS settings.`

The underlying exception is passed through to the callback and will read as for example:
`Failed to connect to api2.branch.io/0.0.0.0:443 Check network connectivity or DNS settings.`

A field is added to `BranchRemoteException` to add the exception message, which gets passed to into `ServerResponse`, which in failure then is finally passed back as a `BranchError` object. Refactoring this indirection is not scope.

## Testing Instructions
Tested with an adblocker that modifies DNS, turned off network. See that logs are appropriate.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [✅] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.


[SDK-2171]: https://branch.atlassian.net/browse/SDK-2171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ