### PR TITLE
Fix UnsupportedOperationException in parseReferringURL for non-hierarchical URIs

### DIFF
--- a/Branch-SDK/src/androidTest/java/io/branch/referral/ReferringUrlUtilityTests.kt
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/ReferringUrlUtilityTests.kt
@@ -73,6 +73,16 @@ class ReferringUrlUtilityTests : BranchTest() {
     }
 
     @Test
+    fun testReferringURLWithEmptyURIScheme() {
+        val url = "branchtest://home"
+        val expected = JSONObject()
+
+        referringUrlUtility.parseReferringURL(url)
+        val params = referringUrlUtility.getURLQueryParamsForRequest(openServerRequest())
+
+        assertTrue(areJSONObjectsEqual(expected, params))
+    }
+    @Test
     fun testReferringURLWithURISchemeSanityCheck() {
         val url = "branchtest://?gclid=12345"
         val expected = JSONObject("""{"gclid": "12345", "is_deeplink_gclid": true}""")

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/ReferringUrlUtilityTests.kt
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/ReferringUrlUtilityTests.kt
@@ -1,6 +1,5 @@
 package io.branch.referral
 
-import android.util.Log
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.json.JSONException
 
@@ -46,6 +45,17 @@ class ReferringUrlUtilityTests : BranchTest() {
         val expected = JSONObject()
 
         referringUrlUtility.parseReferringURL(url)
+        val params = referringUrlUtility.getURLQueryParamsForRequest(openServerRequest())
+
+        assertTrue(areJSONObjectsEqual(expected, params))
+    }
+
+    @Test
+    fun testReferringURINonHierarchical() {
+        val uri = "branchtest:non-hierarchical"
+        val expected = JSONObject()
+
+        referringUrlUtility.parseReferringURL(uri)
         val params = referringUrlUtility.getURLQueryParamsForRequest(openServerRequest())
 
         assertTrue(areJSONObjectsEqual(expected, params))

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2296,7 +2296,7 @@ public class Branch {
             }
 
             ServerRequestInitSession initRequest = branch.getInstallOrOpenRequest(callback, isAutoInitialization);
-            BranchLogger.d("Creating " + initRequest + " from init on thread " + Thread.currentThread());
+            BranchLogger.d("Creating " + initRequest + " from init on thread " + Thread.currentThread().getName());
             branch.initializeSession(initRequest, delay);
         }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2296,7 +2296,7 @@ public class Branch {
             }
 
             ServerRequestInitSession initRequest = branch.getInstallOrOpenRequest(callback, isAutoInitialization);
-            BranchLogger.d("Creating " + initRequest + " from init");
+            BranchLogger.d("Creating " + initRequest + " from init on thread " + Thread.currentThread());
             branch.initializeSession(initRequest, delay);
         }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestQueue.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestQueue.java
@@ -325,7 +325,7 @@ public class ServerRequestQueue {
 
                 serverSema_.release();
                 if (req != null) {
-                    BranchLogger.d("processNextQueueItem, req " + req.getClass().getSimpleName());
+                    BranchLogger.d("processNextQueueItem, req " + req);
                     if (!req.isWaitingOnProcessToFinish()) {
                         // All request except Install request need a valid RandomizedBundleToken
                         if (!(req instanceof ServerRequestRegisterInstall) && !hasUser()) {


### PR DESCRIPTION
## Description
**Issue**: The `parseReferringURL` function in the ReferringUrlUtility class throws an UnsupportedOperationException with the message "This isn't a hierarchical URI". This error occurs when attempting to access `uri.queryParameterNames` for a non-hierarchical URI (e.g., app:home), which lacks the structured path and query parameters of a hierarchical URI (e.g., app://home).

**Solution**: The fix involves adding a check to determine if the URI is hierarchical using `uri.isHierarchical()` before iterating over `uri.queryParameterNames` in the for loop. If the URI is found to be non-hierarchical, the function now logs a debug message and bypasses the query parameter parsing logic, preventing the UnsupportedOperationException. There is also a new unit test to properly test this case.

## Testing Instructions
Open a test app with a hierarchical and non-hierarchical URI to see the proper behavior and logging.

## Risk Assessment [`LOW`]

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
