### PR TITLE
Fix quick consecutive init race condition

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -602,6 +602,7 @@ public class PrefHelper {
      * @param uri A {@link String} value containing intent URI to set
      */
     public void setExternalIntentUri(String uri) {
+        BranchLogger.v("setExternalIntentUri " + uri);
         setString(KEY_EXTERNAL_INTENT_URI, uri);
     }
     
@@ -611,7 +612,9 @@ public class PrefHelper {
      * @return A {@link String} value containing external URI set.
      */
     public String getExternalIntentUri() {
-        return getString(KEY_EXTERNAL_INTENT_URI);
+        String result = getString(KEY_EXTERNAL_INTENT_URI);
+        BranchLogger.v("getExternalIntentUri " + result);
+        return result;
     }
     
     

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -602,7 +602,6 @@ public class PrefHelper {
      * @param uri A {@link String} value containing intent URI to set
      */
     public void setExternalIntentUri(String uri) {
-        BranchLogger.v("setExternalIntentUri " + uri);
         setString(KEY_EXTERNAL_INTENT_URI, uri);
     }
     

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -612,7 +612,6 @@ public class PrefHelper {
      */
     public String getExternalIntentUri() {
         String result = getString(KEY_EXTERNAL_INTENT_URI);
-        BranchLogger.v("getExternalIntentUri " + result);
         return result;
     }
     

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -12,6 +12,7 @@ import androidx.annotation.NonNull;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.Arrays;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -666,6 +667,10 @@ public abstract class ServerRequest {
      */
     public void removeProcessWaitLock(PROCESS_WAIT_LOCK lock) {
         locks_.remove(lock);
+    }
+
+    public String printWaitLocks(){
+        return Arrays.toString(locks_.toArray());
     }
     
     

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -683,6 +683,7 @@ public abstract class ServerRequest {
      * Also attaches any required URL query parameters based on the request type.
      */
     public void onPreExecute() {
+        BranchLogger.v("onPreExecute " + this);
         if (this instanceof ServerRequestRegisterOpen || this instanceof ServerRequestLogEvent) {
             try {
                 ReferringUrlUtility utility = new ReferringUrlUtility(prefHelper_);

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -84,21 +84,6 @@ abstract class ServerRequestInitSession extends ServerRequest {
     @Override
     public void onRequestSucceeded(ServerResponse response, Branch branch) {
         Branch.getInstance().unlockSDKInitWaitLock();
-        // Check for any Third party SDK for data handling
-        prefHelper_.setLinkClickIdentifier(PrefHelper.NO_STRING_VALUE);
-        prefHelper_.setGoogleSearchInstallIdentifier(PrefHelper.NO_STRING_VALUE);
-        prefHelper_.setAppStoreReferrer(PrefHelper.NO_STRING_VALUE);
-        prefHelper_.setExternalIntentUri(PrefHelper.NO_STRING_VALUE);
-        prefHelper_.setExternalIntentExtra(PrefHelper.NO_STRING_VALUE);
-        prefHelper_.setAppLink(PrefHelper.NO_STRING_VALUE);
-        prefHelper_.setPushIdentifier(PrefHelper.NO_STRING_VALUE);
-        prefHelper_.setInstallReferrerParams(PrefHelper.NO_STRING_VALUE);
-        prefHelper_.setIsFullAppConversion(false);
-        prefHelper_.setInitialReferrer(PrefHelper.NO_STRING_VALUE);
-
-        if (prefHelper_.getLong(PrefHelper.KEY_PREVIOUS_UPDATE_TIME) == 0) {
-            prefHelper_.setLong(PrefHelper.KEY_PREVIOUS_UPDATE_TIME, prefHelper_.getLong(PrefHelper.KEY_LAST_KNOWN_UPDATE_TIME));
-        }
     }
 
     void onInitSessionCompleted(ServerResponse response, Branch branch) {

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterInstall.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterInstall.java
@@ -133,6 +133,7 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
     
     @Override
     public void clearCallbacks() {
+        BranchLogger.v(this + " clearCallbacks");
         callback_ = null;
     }
     

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterOpen.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterOpen.java
@@ -57,6 +57,7 @@ class ServerRequestRegisterOpen extends ServerRequestInitSession {
     @Override
     public void onRequestSucceeded(ServerResponse resp, Branch branch) {
         super.onRequestSucceeded(resp, branch);
+        BranchLogger.v("onRequestSucceeded " + this + " " + resp + " on callback " + callback_);
         try {
             if (resp.getObject().has(Defines.Jsonkey.LinkClickID.getKey())) {
                 prefHelper_.setLinkClickID(resp.getObject().getString(Defines.Jsonkey.LinkClickID.getKey()));
@@ -114,6 +115,7 @@ class ServerRequestRegisterOpen extends ServerRequestInitSession {
     
     @Override
     public void clearCallbacks() {
+        BranchLogger.v(this + " clearCallbacks " + callback_);
         callback_ = null;
     }
     

--- a/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
@@ -73,7 +73,7 @@ public class TrackingController {
     private void onTrackingEnabled() {
         Branch branch = Branch.getInstance();
         if (branch != null) {
-            branch.registerAppInit(branch.getInstallOrOpenRequest(null, true), true);
+            branch.registerAppInit(branch.getInstallOrOpenRequest(null, true), true, false);
         }
     }
 }

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,8 @@
 # Branch Android SDK change log
+- v5.7.5
+  * _*Master Release*_ - Nov 27, 2023
+    - Fix a race condition where two quickly queued consecutive init/reInit requests would overwrite uri arguments and return no params.
+    - Added more verbose trace logging
 - v5.7.4
   * _*Master Release*_ - Nov 21, 2023
     - Added check for non-hierarchical URIs when parsing query parameters.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.7.4
-VERSION_CODE=050704
+VERSION_NAME=5.7.5
+VERSION_CODE=050705
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.


### PR DESCRIPTION
## Reference
SDK-XXX -- <TITLE>.

## Description
This PR aims to solve 2 problems.

1. Originally the SDK would retrieve any persisted open request, or request enqueued, and upon finding one, will take the current request object's callback and assign it to the older one. This would create some de-coherence when expecting callbacks to be executed in order, or possibly having a callback dropped all together

2. A race condition was found where, in certain integrations, if an init call were made, and a second were made shortly after, it is possible to encounter a read/write bug.

Normal order of events:
  init()A is created
  init()A processes the uri
  init()A saves the uri to disk
  init()A post request is made, reading uri parameter from disk
  init()A callback returns result, clears uri from disk

With more than 1 init happening immediately:
  init()A is created
  init()A processes the uri
  init()A saves the uri to disk
  init()A post request is made, reading uri parameter from disk
  **init()B is created**
  **init()B processes the uri**
  **init()B saves the uri to disk** 
  init()A callback returns result, **clears uri from disk**
  **init()B post request is made, reading uri parameter from disk**
  init()B callback returns result, clears uri from disk
  
The symptom would be the latest init call would return no params.

The solution to 1 is to add in a condition for `reInit` or force new session to explicitly allow a secondary callback to execute. Otherwise, latest params will be lost.

Solution for 2 is to only clear the persisted data after all init requests have cleared from the queue. It is possible that the uri is written to disk several times before it is cleared.

A more long term solution would be to have init requests follow the same enqueueing path as the rest of the events and to have the POST params in memory per request object. 

## Testing Instructions
<!-- TESTING INSTRUCTIONS -->

## Risk Assessment [`MEDIUM`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [✅] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
