### PR TITLE
[Android] External Logging interface

### DIFF
--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
@@ -1,14 +1,22 @@
 package io.branch.branchandroidtestbed;
 
 import android.app.Application;
+import android.util.Log;
 
+import io.branch.interfaces.IBranchLoggingCallbacks;
 import io.branch.referral.Branch;
 
 public final class CustomBranchApp extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        Branch.enableLogging();
+        IBranchLoggingCallbacks iBranchLoggingCallbacks = new IBranchLoggingCallbacks() {
+            @Override
+            public void onBranchLog(String logMessage, String severityConstantName) {
+                Log.v( "CustomTag", logMessage);
+            }
+        };
+        Branch.enableLogging(iBranchLoggingCallbacks);
         Branch.getAutoInstance(this);
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/interfaces/IBranchLoggingCallbacks.java
+++ b/Branch-SDK/src/main/java/io/branch/interfaces/IBranchLoggingCallbacks.java
@@ -1,0 +1,5 @@
+package io.branch.interfaces;
+
+public interface IBranchLoggingCallbacks {
+    void onBranchLog(String logMessage, String severityConstantName);
+}

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import io.branch.indexing.BranchUniversalObject;
+import io.branch.interfaces.IBranchLoggingCallbacks;
 import io.branch.referral.Defines.PreinstallKey;
 import io.branch.referral.ServerRequestGetLATD.BranchLastAttributedTouchDataListener;
 import io.branch.referral.network.BranchRemoteInterface;
@@ -1824,6 +1825,11 @@ public class Branch {
      * Enable Logging, independent of Debug Mode.
      */
     public static void enableLogging() {
+        enableLogging(null);
+    }
+
+    public static void enableLogging(IBranchLoggingCallbacks iBranchLogging){
+        BranchLogger.setLoggerCallback(iBranchLogging);
         BranchLogger.logAlways(GOOGLE_VERSION_TAG);
         BranchLogger.setLoggingEnabled(true);
     }
@@ -1833,6 +1839,7 @@ public class Branch {
      */
     public static void disableLogging() {
         BranchLogger.setLoggingEnabled(false);
+        BranchLogger.setLoggerCallback(null);
     }
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchLogger.kt
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchLogger.kt
@@ -1,6 +1,7 @@
 package io.branch.referral
 
 import android.util.Log
+import io.branch.interfaces.IBranchLoggingCallbacks
 
 object BranchLogger {
 
@@ -8,6 +9,11 @@ object BranchLogger {
 
     @JvmStatic
     var loggingEnabled = false
+    
+    @JvmStatic
+    var loggerCallback: IBranchLoggingCallbacks? = null
+
+    private val isDebug = BuildConfig.DEBUG;
 
     /**
      * <p>Creates a <b>Error</b> message in the debugger. If debugging is disabled, this will fail silently.</p>
@@ -17,7 +23,11 @@ object BranchLogger {
     @JvmStatic
     fun e(message: String) {
         if (loggingEnabled && message.isNotEmpty()) {
-            Log.e(TAG, message)
+            loggerCallback?.onBranchLog(message, "ERROR")
+
+            if(isDebug) {
+                Log.e(TAG, message)
+            }
         }
     }
 
@@ -29,7 +39,11 @@ object BranchLogger {
     @JvmStatic
     fun w(message: String) {
         if (loggingEnabled && message.isNotEmpty()) {
-            Log.w(TAG, message)
+            loggerCallback?.onBranchLog(message, "WARN")
+
+            if(isDebug) {
+                Log.w(TAG, message)
+            }
         }
     }
 
@@ -41,7 +55,11 @@ object BranchLogger {
     @JvmStatic
     fun i(message: String) {
         if (loggingEnabled && message.isNotEmpty()) {
-            Log.i(TAG, message)
+            loggerCallback?.onBranchLog(message, "INFO")
+
+            if(isDebug) {
+                Log.i(TAG, message)
+            }
         }
     }
 
@@ -53,7 +71,11 @@ object BranchLogger {
     @JvmStatic
     fun d(message: String?) {
         if (loggingEnabled && message?.isNotEmpty() == true) {
-            Log.d(TAG, message)
+            loggerCallback?.onBranchLog(message, "DEBUG")
+
+            if(isDebug) {
+                Log.d(TAG, message)
+            }
         }
     }
 
@@ -65,21 +87,33 @@ object BranchLogger {
     @JvmStatic
     fun v(message: String) {
         if (loggingEnabled && message.isNotEmpty()) {
-            Log.v(TAG, message)
+            loggerCallback?.onBranchLog(message, "VERBOSE")
+
+            if(isDebug) {
+                Log.v(TAG, message)
+            }
         }
     }
 
     @JvmStatic
     fun logAlways(message: String) {
         if (message.isNotEmpty()) {
-            Log.i(TAG, message)
+            loggerCallback?.onBranchLog(message, "INFO")
+
+            if(isDebug) {
+                Log.i(TAG, message)
+            }
         }
     }
 
     @JvmStatic
     fun logException(message: String, t: Exception?) {
         if (message.isNotEmpty()) {
-            Log.e(TAG, message, t)
+            loggerCallback?.onBranchLog(message, "ERROR")
+
+            if(isDebug) {
+                Log.e(TAG, message, t)
+            }
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.8.0
-VERSION_CODE=050800
+VERSION_NAME=5.7.5
+VERSION_CODE=050705
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.7.5
-VERSION_CODE=050705
+VERSION_NAME=5.8.0
+VERSION_CODE=050800
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.


### PR DESCRIPTION
## Reference
SDK-2186 -- [Android] External Logging interface

## Description
By design, logs are removed in production which can lead to some types of debugging infeasible. Additionally, requiring the app developer to listen on our own logging tag is a less than ideal experience when trying to correlate their app failures with the SDK's behavior.

We will add a callback that will echo whatever logging we currently have so that the app developer can be responsible for its implementation.

As an added protection, because it is possible that `enableLogging` could be left in production deploys, checking if the flavor is `DEBUG` to log. See https://source.android.com/docs/core/tests/debug/understanding-logging#log-level-guidelines

## Testing Instructions
Override the interface, see that it returns logs to your callback.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
