### PR TITLE
[Android] Initialisation callback is never called when Google ad ID is not available

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
@@ -468,27 +468,27 @@ abstract class SystemObserver {
 
                 @Override
                 public void resumeWith(Object o) {
-                    if (o != null) {
-                        try {
-                            com.huawei.hms.ads.identifier.AdvertisingIdClient.Info info = (com.huawei.hms.ads.identifier.AdvertisingIdClient.Info) o;
+                    try {
+                        if (o != null) {
+                                com.huawei.hms.ads.identifier.AdvertisingIdClient.Info info = (com.huawei.hms.ads.identifier.AdvertisingIdClient.Info) o;
 
-                            boolean lat = info.isLimitAdTrackingEnabled();
-                            String aid = null;
+                                boolean lat = info.isLimitAdTrackingEnabled();
+                                String aid = null;
 
-                            if(!lat) {
-                                aid = info.getId();
+                                if(!lat) {
+                                    aid = info.getId();
+                                }
+
+                                setLAT(lat ? 1 : 0);
+                                setGAID(aid);
                             }
-
-                            setLAT(lat ? 1 : 0);
-                            setGAID(aid);
                         }
-                        catch (Exception e) {
-                            BranchLogger.d("Error in continuation: " + e);
-                        }
-                        finally {
-                            if (callback != null) {
-                                callback.onAdsParamsFetchFinished();
-                            }
+                    catch (Exception e) {
+                        BranchLogger.d("Error in continuation: " + e);
+                    }
+                    finally {
+                        if (callback != null) {
+                            callback.onAdsParamsFetchFinished();
                         }
                     }
                 }
@@ -517,8 +517,8 @@ abstract class SystemObserver {
 
                 @Override
                 public void resumeWith(Object o) {
-                    if (o != null) {
-                        try {
+                    try {
+                        if (o != null) {
                             AdvertisingIdClient.Info info = (AdvertisingIdClient.Info) o;
 
                             boolean lat = info.isLimitAdTrackingEnabled();
@@ -531,13 +531,13 @@ abstract class SystemObserver {
                             setLAT(lat ? 1 : 0);
                             setGAID(aid);
                         }
-                        catch (Exception e) {
-                            BranchLogger.d("Error in continuation: " + e);
-                        }
-                        finally {
-                            if (callback != null) {
-                                callback.onAdsParamsFetchFinished();
-                            }
+                    }
+                    catch (Exception e) {
+                        BranchLogger.d("Error in continuation: " + e);
+                    }
+                    finally {
+                        if (callback != null) {
+                            callback.onAdsParamsFetchFinished();
                         }
                     }
                 }

--- a/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
@@ -470,19 +470,19 @@ abstract class SystemObserver {
                 public void resumeWith(Object o) {
                     try {
                         if (o != null) {
-                                com.huawei.hms.ads.identifier.AdvertisingIdClient.Info info = (com.huawei.hms.ads.identifier.AdvertisingIdClient.Info) o;
+                            com.huawei.hms.ads.identifier.AdvertisingIdClient.Info info = (com.huawei.hms.ads.identifier.AdvertisingIdClient.Info) o;
 
-                                boolean lat = info.isLimitAdTrackingEnabled();
-                                String aid = null;
+                            boolean lat = info.isLimitAdTrackingEnabled();
+                            String aid = null;
 
-                                if(!lat) {
-                                    aid = info.getId();
-                                }
-
-                                setLAT(lat ? 1 : 0);
-                                setGAID(aid);
+                            if (!lat) {
+                                aid = info.getId();
                             }
+
+                            setLAT(lat ? 1 : 0);
+                            setGAID(aid);
                         }
+                    }
                     catch (Exception e) {
                         BranchLogger.d("Error in continuation: " + e);
                     }


### PR DESCRIPTION
## Reference
SDK-2197 -- Initialisation callback is never called when Google ad ID is not available

## Description
Previously the logic to retrieve and set the Google Advertising ID relied on the Google Services always being present. When it is not, we will return a null object to the coroutine continuation. When that object is null we do not execute the `onAdsParamsFetchFinished` callback. 

This fix is to move the try/catch/finally such that null/not null logic is moved down inside of the try, and the finally executes regardless, lifting the initialization lock in the callback. 

The same is done for Huawei Ad Id if also imported, but service not available.

## Testing Instructions
Ensure no regressions. Reset ad id on device/emulator and see that it is still set if enabled.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
