### PR TITLE
ci(gha): add timeout for launch emulator step

### DIFF
--- a/.github/workflows/unit-and-instrumented-tests-action.yml
+++ b/.github/workflows/unit-and-instrumented-tests-action.yml
@@ -45,6 +45,7 @@ jobs:
           echo "no" | $ANDROID_HOME/tools/bin/avdmanager --verbose create avd --force --name test --package "system-images;android-"$API_MIN";google_apis;x86_64"
       # boots and waits for the emulator to be ready
       - name: Launch Emulator
+        timeout-minutes: 30
         run: |
           echo "Starting emulator and waiting for boot to complete."
           nohup $ANDROID_HOME/tools/emulator -avd test -no-audio -no-boot-anim -camera-back none -camera-front none -qemu -m 2048 2>&1 &
@@ -84,6 +85,7 @@ jobs:
                   echo "no" | $ANDROID_HOME/tools/bin/avdmanager --verbose create avd --force --name test --package "system-images;android-"$API_MIN";google_apis;x86_64"
               # boots and waits for the emulator to be ready
               - name: Launch Emulator
+                timeout-minutes: 30
                 run: |
                   echo "Starting emulator and waiting for boot to complete."
                   nohup $ANDROID_HOME/tools/emulator -avd test -no-audio -no-boot-anim -camera-back none -camera-front none -qemu -m 2048 2>&1 &
@@ -142,6 +144,7 @@ jobs:
           echo "no" | $ANDROID_HOME/tools/bin/avdmanager --verbose create avd --force --name test --package "system-images;android-"$API_CURRENT";google_apis_playstore;x86_64"
       # boots and waits for the emulator to be ready
       - name: Launch Emulator
+        timeout-minutes: 30
         run: |
           echo "Starting emulator and waiting for boot to complete."
           nohup $ANDROID_HOME/tools/emulator -avd test -no-audio -no-boot-anim -camera-back none -camera-front none -qemu -m 2048 2>&1 &


### PR DESCRIPTION
ci(gha): add timeout for launch emulator step

## Reference
SDK-XXX -- <TITLE>.

## Description
Add timeout for launch emulator step 

## Testing Instructions
<!-- TESTING INSTRUCTIONS -->

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
