### PR TITLE
[INTENG-19664] Preserve previous logger behavior

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/interfaces/IBranchLoggingCallbacks.java
+++ b/Branch-SDK/src/main/java/io/branch/interfaces/IBranchLoggingCallbacks.java
@@ -1,5 +1,13 @@
 package io.branch.interfaces;
 
+/**
+ * A set of callbacks that interface with the SDK's internal logging.
+ */
 public interface IBranchLoggingCallbacks {
+    /**
+     * Callback method that returns each time a log is generated
+     * @param logMessage The log message
+     * @param severityConstantName any of DEBUG, ERROR, INFO, WARN, VERBOSE
+     */
     void onBranchLog(String logMessage, String severityConstantName);
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1828,6 +1828,11 @@ public class Branch {
         enableLogging(null);
     }
 
+    /**
+     * Optional interface. Implement a callback to receive logging from the SDK directly to your
+     * own logging solution. If null, and enabled, the default android.util.Log is used.
+     * @param iBranchLogging
+     */
     public static void enableLogging(IBranchLoggingCallbacks iBranchLogging){
         BranchLogger.setLoggerCallback(iBranchLogging);
         BranchLogger.logAlways(GOOGLE_VERSION_TAG);

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchLogger.kt
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchLogger.kt
@@ -13,8 +13,6 @@ object BranchLogger {
     @JvmStatic
     var loggerCallback: IBranchLoggingCallbacks? = null
 
-    private val isDebug = BuildConfig.DEBUG;
-
     /**
      * <p>Creates a <b>Error</b> message in the debugger. If debugging is disabled, this will fail silently.</p>
      *
@@ -23,9 +21,10 @@ object BranchLogger {
     @JvmStatic
     fun e(message: String) {
         if (loggingEnabled && message.isNotEmpty()) {
-            loggerCallback?.onBranchLog(message, "ERROR")
-
-            if(isDebug) {
+            if (useCustomLogger()) {
+                loggerCallback?.onBranchLog(message, "ERROR")
+            }
+            else {
                 Log.e(TAG, message)
             }
         }
@@ -39,9 +38,10 @@ object BranchLogger {
     @JvmStatic
     fun w(message: String) {
         if (loggingEnabled && message.isNotEmpty()) {
-            loggerCallback?.onBranchLog(message, "WARN")
-
-            if(isDebug) {
+            if (useCustomLogger()) {
+                loggerCallback?.onBranchLog(message, "WARN")
+            }
+            else {
                 Log.w(TAG, message)
             }
         }
@@ -55,9 +55,10 @@ object BranchLogger {
     @JvmStatic
     fun i(message: String) {
         if (loggingEnabled && message.isNotEmpty()) {
-            loggerCallback?.onBranchLog(message, "INFO")
-
-            if(isDebug) {
+            if(useCustomLogger()) {
+                loggerCallback?.onBranchLog(message, "INFO")
+            }
+            else {
                 Log.i(TAG, message)
             }
         }
@@ -71,9 +72,10 @@ object BranchLogger {
     @JvmStatic
     fun d(message: String?) {
         if (loggingEnabled && message?.isNotEmpty() == true) {
-            loggerCallback?.onBranchLog(message, "DEBUG")
-
-            if(isDebug) {
+            if (useCustomLogger()) {
+                loggerCallback?.onBranchLog(message, "DEBUG")
+            }
+            else {
                 Log.d(TAG, message)
             }
         }
@@ -87,9 +89,10 @@ object BranchLogger {
     @JvmStatic
     fun v(message: String) {
         if (loggingEnabled && message.isNotEmpty()) {
-            loggerCallback?.onBranchLog(message, "VERBOSE")
-
-            if(isDebug) {
+            if (useCustomLogger()) {
+                loggerCallback?.onBranchLog(message, "VERBOSE")
+            }
+            else {
                 Log.v(TAG, message)
             }
         }
@@ -98,9 +101,10 @@ object BranchLogger {
     @JvmStatic
     fun logAlways(message: String) {
         if (message.isNotEmpty()) {
-            loggerCallback?.onBranchLog(message, "INFO")
-
-            if(isDebug) {
+            if (useCustomLogger()) {
+                loggerCallback?.onBranchLog(message, "INFO")
+            }
+            else {
                 Log.i(TAG, message)
             }
         }
@@ -109,11 +113,20 @@ object BranchLogger {
     @JvmStatic
     fun logException(message: String, t: Exception?) {
         if (message.isNotEmpty()) {
-            loggerCallback?.onBranchLog(message, "ERROR")
-
-            if(isDebug) {
+            if (useCustomLogger()) {
+                loggerCallback?.onBranchLog(message, "ERROR")
+            }
+            else {
                 Log.e(TAG, message, t)
             }
         }
+    }
+
+    /**
+     * If an implementation of IBranchLoggingCallbacks is passed, forward logging messages to callback
+     * Else, maintain the original behavior of Branch.enableLogging().
+     */
+    private fun useCustomLogger(): Boolean {
+        return loggerCallback != null
     }
 }

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,8 @@
 # Branch Android SDK change log
+- v5.8.1
+  * _*Release Branch 5.8.1*_ - Dec 11, 2023
+    - Preserve logging to console when SDK is not in debug.
+
 - v5.8.0
   * _*Release Branch 5.8.0*_ - Dec 11, 2023
     - Fix a condition where the SDK would not init if the Google service was unavailable to provide the Ad ID.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.8.0
-VERSION_CODE=051000
+VERSION_NAME=5.8.1
+VERSION_CODE=051001
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.


### PR DESCRIPTION
## Reference
[INTENG-19664]

## Description
This change reverts the (sdk) debug check since it is always true when released publicly via maven. As before, the sdk will log if `Branch.enableLogging()` is invoked. If not null, `BranchLogger.kt` will only forward to the caller.

## Testing Instructions
Expectations:
- Logging appears in callback when not null
- Logging appears under `BranchSDK` namespace when invoked only as `Branch.enableLogging()` (previous behavior)

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.


[INTENG-19664]: https://branch.atlassian.net/browse/INTENG-19664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ