### PR TITLE
SDK-2223-DMA-Consent-Params-Implementation

### DIFF
--- a/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
@@ -314,4 +314,24 @@ public class PrefHelperTest extends BranchTest {
             Assert.fail();
         }
     }
+
+    @Test
+    public void testSetDMAParamsForEEA(){
+
+        Assert.assertEquals(prefHelper.isDMAParamsInitialized(),false);
+
+        Branch.getInstance().setDMAParamsForEEA(true, false,true);
+
+        Assert.assertEquals(prefHelper.isDMAParamsInitialized(),true);
+        Assert.assertEquals(prefHelper.getEEARegion(),true);
+        Assert.assertEquals(prefHelper.getAdPersonalizationConsent(),false);
+        Assert.assertEquals(prefHelper.getAdUserDataUsageConsent(),true);
+
+        // check by flipping values - if they are overwritten
+        Branch.getInstance().setDMAParamsForEEA(false, true,false);
+
+        Assert.assertEquals(prefHelper.getEEARegion(),false);
+        Assert.assertEquals(prefHelper.getAdPersonalizationConsent(),true);
+        Assert.assertEquals(prefHelper.getAdUserDataUsageConsent(),false);
+    }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1,6 +1,5 @@
 package io.branch.referral;
 
-import static io.branch.referral.BranchError.ERR_BRANCH_TASK_TIMEOUT;
 import static io.branch.referral.BranchError.ERR_IMPROPER_REINITIALIZATION;
 import static io.branch.referral.BranchPreinstall.getPreinstallSystemData;
 import static io.branch.referral.BranchUtil.isTestModeEnabled;
@@ -20,7 +19,6 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
-import android.os.Looper;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
@@ -37,7 +35,6 @@ import java.io.UnsupportedEncodingException;
 import java.lang.ref.WeakReference;
 import java.net.HttpURLConnection;
 import java.net.URLEncoder;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -54,7 +51,6 @@ import io.branch.referral.network.BranchRemoteInterface;
 import io.branch.referral.network.BranchRemoteInterfaceUrlConnection;
 import io.branch.referral.util.BRANCH_STANDARD_EVENT;
 import io.branch.referral.util.BranchEvent;
-import io.branch.referral.util.CommerceEvent;
 import io.branch.referral.util.LinkProperties;
 
 /**
@@ -710,6 +706,19 @@ public class Branch {
      */
     public void setLimitFacebookTracking(boolean isLimitFacebookTracking) {
         prefHelper_.setLimitFacebookTracking(isLimitFacebookTracking);
+    }
+
+    /**
+     * Sets the value of parameters required by Google Conversion APIs for DMA Compliance in EEA region.
+     *
+     * @param eeaRegion {@code true} If European regulations, including the DMA, apply to this user and conversion.
+     * @param adPersonalizationConsent {@code true} If End user has granted/denied ads personalization consent.
+     * @param adUserDataUsageConsent {@code true} If User has granted/denied consent for 3P transmission of user level data for ads.
+     */
+    public void setDMAParamsForEEA(boolean eeaRegion, boolean adPersonalizationConsent, boolean adUserDataUsageConsent) {
+        prefHelper_.setEEARegion(eeaRegion);
+        prefHelper_.setAdPersonalizationConsent(adPersonalizationConsent);
+        prefHelper_.setAdUserDataUsageConsent(adUserDataUsageConsent);
     }
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -218,9 +218,9 @@ public class Defines {
         Huawei_App_Gallery("AppGallery"),
         Samsung_Galaxy_Store("GalaxyStore"),
         Xiaomi_Get_Apps("GetApps"),
-        DMA_EEA_Region("dma_eea_region"),
-        DMA_Ad_Personalization_Consent("dma_ad_personalization_consent"),
-        DMA_Ad_User_Data_Usage_Consent("dma_ad_user_data_usage_consent");
+        DMA_EEA("dma_eea"),
+        DMA_Ad_Personalization("dma_ad_personalization"),
+        DMA_Ad_User_Data("dma_ad_user_data");
 
         private final String key;
         

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -217,7 +217,10 @@ public class Defines {
         Google_Play_Store("PlayStore"),
         Huawei_App_Gallery("AppGallery"),
         Samsung_Galaxy_Store("GalaxyStore"),
-        Xiaomi_Get_Apps("GetApps");
+        Xiaomi_Get_Apps("GetApps"),
+        DMA_EEA_Region("dma_eea_region"),
+        DMA_Ad_Personalization_Consent("dma_ad_personalization_consent"),
+        DMA_Ad_User_Data_Usage_Consent("dma_ad_user_data_usage_consent");
 
         private final String key;
         

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -1,13 +1,16 @@
 package io.branch.referral;
 
+import static io.branch.referral.BranchUtil.isTestModeEnabled;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.os.Build;
-import androidx.annotation.NonNull;
 import android.text.TextUtils;
 import android.webkit.URLUtil;
+
+import androidx.annotation.NonNull;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -17,8 +20,6 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
-import static io.branch.referral.BranchUtil.isTestModeEnabled;
 
 /**
  * <p>A class that uses the helper pattern to provide regularly referenced static values and
@@ -108,6 +109,9 @@ public class PrefHelper {
     private static final String KEY_INSTALL_REFERRER = "bnc_install_referrer";
     private static final String KEY_IS_FULL_APP_CONVERSION = "bnc_is_full_app_conversion";
     private static final String KEY_LIMIT_FACEBOOK_TRACKING = "bnc_limit_facebook_tracking";
+    private static final String KEY_EEA_REGION = "bnc_eea_region";
+    private static final String KEY_AD_PERSONALIZATION_CONSENT = "bnc_ad_personalization_consent";
+    private static final String KEY_AD_USER_DATA_USAGE_CONSENT = "bnc_ad_user_data_usage_consent";
     private static final String KEY_LOG_IAP_AS_EVENTS = "bnc_log_iap_as_events";
 
     static final String KEY_ORIGINAL_INSTALL_TIME = "bnc_original_install_time";
@@ -950,7 +954,53 @@ public class PrefHelper {
     boolean isAppTrackingLimited() {
         return getBool(KEY_LIMIT_FACEBOOK_TRACKING);
     }
-    
+
+    /**
+     * Returns true if DMA params - KEY_EEA_REGION value exist in pref helper.
+     */
+    boolean isDMAParamsInitialized() {
+        if(hasPrefValue(KEY_EEA_REGION)){
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * <p>Internal setter/getter func for key eea_region </p>
+     */
+    void setEEARegion(boolean isEEARegion) {
+        setBool(KEY_EEA_REGION, isEEARegion);
+    }
+
+    boolean getEEARegion() {
+        return getBool(KEY_EEA_REGION);
+    }
+
+     /**
+     * <p>Sets value of consent granted/denied by end user for ads personalization.</p>
+     *  @param hasAdPersonalizationConsent {@code true} if user has given consent.
+     */
+    void setAdPersonalizationConsent(boolean hasAdPersonalizationConsent) {
+        setBool(KEY_AD_PERSONALIZATION_CONSENT, hasAdPersonalizationConsent);
+    }
+
+    boolean getAdPersonalizationConsent() {
+        return getBool(KEY_AD_PERSONALIZATION_CONSENT);
+    }
+
+    /**
+     * <p>Sets value of consent granted/denied for 3P transmission of user level data for ads.</p>
+     *  @param hasAdUserDataUsageConsent {@code true} if user has given consent.
+     */
+    void setAdUserDataUsageConsent(boolean hasAdUserDataUsageConsent) {
+        setBool(KEY_AD_USER_DATA_USAGE_CONSENT, hasAdUserDataUsageConsent);
+    }
+
+    boolean getAdUserDataUsageConsent() {
+        return getBool(KEY_AD_USER_DATA_USAGE_CONSENT);
+    }
+
+
     /**
      * <p>Resets the user-related values that have been stored in preferences. This will cause a
      * sync to occur whenever a method reads any of the values and finds the value to be 0 or unset.</p>

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -109,9 +109,9 @@ public class PrefHelper {
     private static final String KEY_INSTALL_REFERRER = "bnc_install_referrer";
     private static final String KEY_IS_FULL_APP_CONVERSION = "bnc_is_full_app_conversion";
     private static final String KEY_LIMIT_FACEBOOK_TRACKING = "bnc_limit_facebook_tracking";
-    private static final String KEY_EEA_REGION = "bnc_eea_region";
-    private static final String KEY_AD_PERSONALIZATION_CONSENT = "bnc_ad_personalization_consent";
-    private static final String KEY_AD_USER_DATA_USAGE_CONSENT = "bnc_ad_user_data_usage_consent";
+    private static final String KEY_DMA_EEA = "bnc_dma_eea";
+    private static final String KEY_DMA_AD_PERSONALIZATION = "bnc_dma_ad_personalization";
+    private static final String KEY_DMA_AD_USER_DATA = "bnc_dma_ad_user_data";
     private static final String KEY_LOG_IAP_AS_EVENTS = "bnc_log_iap_as_events";
 
     static final String KEY_ORIGINAL_INSTALL_TIME = "bnc_original_install_time";
@@ -959,7 +959,7 @@ public class PrefHelper {
      * Returns true if DMA params - KEY_EEA_REGION value exist in pref helper.
      */
     boolean isDMAParamsInitialized() {
-        if(hasPrefValue(KEY_EEA_REGION)){
+        if(hasPrefValue(KEY_DMA_EEA)){
             return true;
         }
         return false;
@@ -969,11 +969,11 @@ public class PrefHelper {
      * <p>Internal setter/getter func for key eea_region </p>
      */
     void setEEARegion(boolean isEEARegion) {
-        setBool(KEY_EEA_REGION, isEEARegion);
+        setBool(KEY_DMA_EEA, isEEARegion);
     }
 
     boolean getEEARegion() {
-        return getBool(KEY_EEA_REGION);
+        return getBool(KEY_DMA_EEA);
     }
 
      /**
@@ -981,11 +981,11 @@ public class PrefHelper {
      *  @param hasAdPersonalizationConsent {@code true} if user has given consent.
      */
     void setAdPersonalizationConsent(boolean hasAdPersonalizationConsent) {
-        setBool(KEY_AD_PERSONALIZATION_CONSENT, hasAdPersonalizationConsent);
+        setBool(KEY_DMA_AD_PERSONALIZATION, hasAdPersonalizationConsent);
     }
 
     boolean getAdPersonalizationConsent() {
-        return getBool(KEY_AD_PERSONALIZATION_CONSENT);
+        return getBool(KEY_DMA_AD_PERSONALIZATION);
     }
 
     /**
@@ -993,11 +993,11 @@ public class PrefHelper {
      *  @param hasAdUserDataUsageConsent {@code true} if user has given consent.
      */
     void setAdUserDataUsageConsent(boolean hasAdUserDataUsageConsent) {
-        setBool(KEY_AD_USER_DATA_USAGE_CONSENT, hasAdUserDataUsageConsent);
+        setBool(KEY_DMA_AD_USER_DATA, hasAdUserDataUsageConsent);
     }
 
     boolean getAdUserDataUsageConsent() {
-        return getBool(KEY_AD_USER_DATA_USAGE_CONSENT);
+        return getBool(KEY_DMA_AD_USER_DATA);
     }
 
 

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -1,10 +1,11 @@
 package io.branch.referral;
 
+import static io.branch.referral.ServerRequestInitSession.INITIATED_BY_CLIENT;
+
 import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.text.TextUtils;
-import android.util.Log;
 
 import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
@@ -15,13 +16,8 @@ import org.json.JSONObject;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
-import static io.branch.referral.ServerRequestInitSession.INITIATED_BY_CLIENT;
-
-import io.branch.referral.util.BranchEvent;
 
 /**
  * Abstract class defining the structure of a Branch Server request.
@@ -161,7 +157,52 @@ public abstract class ServerRequest {
     protected boolean shouldUpdateLimitFacebookTracking() {
         return false;
     }
-    
+
+    /**
+     * <p>
+     * Specifies whether this request should have DMA params.
+     * By default it will return false. Subclasses can override this function, if the corresponding request type
+     * requires DMA params.
+     * </p>
+     *
+     * @return A {@link Boolean} with value false if this request does NOT need DMA params.
+     */
+    protected boolean shouldAddDMAParams() {
+        return false;
+    }
+
+    /**
+     * Adds the google DMA Compliance parameters.
+     */
+    void addDMAParams() {
+        if (prefHelper_.isDMAParamsInitialized()) {
+            try {
+               boolean isEEARegion = prefHelper_.getEEARegion();
+               boolean hasAdPersonalizationConsent = prefHelper_.getAdPersonalizationConsent();
+               boolean hasAdUserDataUsageConsent = prefHelper_.getAdUserDataUsageConsent();
+
+                params_.put(Defines.Jsonkey.DMA_EEA_Region.getKey(), isEEARegion);
+
+                if (isEEARegion) {
+                    params_.put(Defines.Jsonkey.DMA_Ad_Personalization_Consent.getKey(), hasAdPersonalizationConsent);
+                    params_.put(Defines.Jsonkey.DMA_Ad_User_Data_Usage_Consent.getKey(), hasAdUserDataUsageConsent);
+                } else {
+                    if (!hasAdPersonalizationConsent) {
+                        params_.put(Defines.Jsonkey.DMA_Ad_Personalization_Consent.getKey(), false);
+                    }
+
+                    if (!hasAdUserDataUsageConsent) {
+                        params_.put(Defines.Jsonkey.DMA_Ad_User_Data_Usage_Consent.getKey(), false);
+                    }
+                }
+
+            } catch (JSONException e) {
+                BranchLogger.d(e.getMessage());
+            }
+        }
+    }
+
+
     /**
      * <p>Provides the path to server for this request.
      * see {@link Defines.RequestPath} <p>
@@ -581,6 +622,9 @@ public abstract class ServerRequest {
         updateRequestMetadata();
         if (shouldUpdateLimitFacebookTracking()) {
             updateLimitFacebookTracking();
+        }
+        if (shouldAddDMAParams()) {
+            addDMAParams();
         }
     }
     

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -177,9 +177,19 @@ public abstract class ServerRequest {
     void addDMAParams() {
         if (prefHelper_.isDMAParamsInitialized()) {
             try {
-                params_.put(Defines.Jsonkey.DMA_EEA.getKey(), prefHelper_.getEEARegion());
-                params_.put(Defines.Jsonkey.DMA_Ad_Personalization.getKey(), prefHelper_.getAdPersonalizationConsent());
-                params_.put(Defines.Jsonkey.DMA_Ad_User_Data.getKey(), prefHelper_.getAdUserDataUsageConsent());
+                BRANCH_API_VERSION version = getBranchRemoteAPIVersion();
+                if (version == BRANCH_API_VERSION.V1) {
+                    params_.put(Defines.Jsonkey.DMA_EEA.getKey(), prefHelper_.getEEARegion());
+                    params_.put(Defines.Jsonkey.DMA_Ad_Personalization.getKey(), prefHelper_.getAdPersonalizationConsent());
+                    params_.put(Defines.Jsonkey.DMA_Ad_User_Data.getKey(), prefHelper_.getAdUserDataUsageConsent());
+                } else {
+                    JSONObject userDataObj = params_.optJSONObject(Defines.Jsonkey.UserData.getKey());
+                    if (userDataObj != null) {
+                        userDataObj.put(Defines.Jsonkey.DMA_EEA.getKey(), prefHelper_.getEEARegion());
+                        userDataObj.put(Defines.Jsonkey.DMA_Ad_Personalization.getKey(), prefHelper_.getAdPersonalizationConsent());
+                        userDataObj.put(Defines.Jsonkey.DMA_Ad_User_Data.getKey(), prefHelper_.getAdUserDataUsageConsent());
+                    }
+                }
             } catch (JSONException e) {
                 BranchLogger.d(e.getMessage());
             }

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -177,25 +177,9 @@ public abstract class ServerRequest {
     void addDMAParams() {
         if (prefHelper_.isDMAParamsInitialized()) {
             try {
-               boolean isEEARegion = prefHelper_.getEEARegion();
-               boolean hasAdPersonalizationConsent = prefHelper_.getAdPersonalizationConsent();
-               boolean hasAdUserDataUsageConsent = prefHelper_.getAdUserDataUsageConsent();
-
-                params_.put(Defines.Jsonkey.DMA_EEA_Region.getKey(), isEEARegion);
-
-                if (isEEARegion) {
-                    params_.put(Defines.Jsonkey.DMA_Ad_Personalization_Consent.getKey(), hasAdPersonalizationConsent);
-                    params_.put(Defines.Jsonkey.DMA_Ad_User_Data_Usage_Consent.getKey(), hasAdUserDataUsageConsent);
-                } else {
-                    if (!hasAdPersonalizationConsent) {
-                        params_.put(Defines.Jsonkey.DMA_Ad_Personalization_Consent.getKey(), false);
-                    }
-
-                    if (!hasAdUserDataUsageConsent) {
-                        params_.put(Defines.Jsonkey.DMA_Ad_User_Data_Usage_Consent.getKey(), false);
-                    }
-                }
-
+                params_.put(Defines.Jsonkey.DMA_EEA.getKey(), prefHelper_.getEEARegion());
+                params_.put(Defines.Jsonkey.DMA_Ad_Personalization.getKey(), prefHelper_.getAdPersonalizationConsent());
+                params_.put(Defines.Jsonkey.DMA_Ad_User_Data.getKey(), prefHelper_.getAdUserDataUsageConsent());
             } catch (JSONException e) {
                 BranchLogger.d(e.getMessage());
             }

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -1,15 +1,10 @@
 package io.branch.referral;
 
-import android.app.Activity;
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.text.TextUtils;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-
-
-import java.util.Objects;
 
 import io.branch.referral.validators.DeepLinkRoutingValidator;
 
@@ -69,6 +64,11 @@ abstract class ServerRequestInitSession extends ServerRequest {
 
     @Override
     protected boolean shouldUpdateLimitFacebookTracking() {
+        return true;
+    }
+
+    @Override
+    protected boolean shouldAddDMAParams() {
         return true;
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestLogEvent.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestLogEvent.java
@@ -92,6 +92,11 @@ public class ServerRequestLogEvent extends ServerRequest {
         return true;
     }
 
+    @Override
+    protected boolean shouldAddDMAParams() {
+        return true;
+    }
+
     public boolean shouldRetryOnFail() {
         return true; // Branch event need to be retried on failure.
     }


### PR DESCRIPTION
## Reference
SDK-2223 -- Design and implement key/values to represent consent param
https://branch.atlassian.net/browse/SDK-2223

## Description
* Added following API in Branch Class.
`public void setDMAParamsForEEA(boolean eeaRegion, boolean adPersonalizationConsent, boolean adUserDataUsageConsent) ;`
* Branch SDK will save DMA Compliance Parameters, set by developer using above API, and will send to server with install, open and event requests.
* Added unit test for testing above API.

## Testing Instructions
* All unit tests should pass.
* Call API setDMAParamsForEEA and check
-- SDK is sending value of eeaRegion, with every /v1/install , /v1/open, /v2/event , v1/pageview request.
-- SDK is sending value of adPersonalizationConsent / adUserDataUsageConsent with every /v1/install , /v1/open, /v2/event , v1/pageview request only if -
               - eeaRegion is true **OR**
               - eeaRegion is false and adPersonalizationConsent / adUserDataUsageConsent is also set to false
Ref : https://www.notion.so/brancheng/Google-DMA-Compliance-c19ed28d2ea74b2b9fa4d2d77f8cdcbe

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]

LOW

- [ X] I, the PR creator, have tested — integration, unit, or otherwise — this code.

cc @BranchMetrics/saas-sdk-devs for visibility.
