### PR TITLE
Add new field is_meta_ct field to v1/installs for Meta Install Referrer

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/coroutines/InstallReferrers.kt
+++ b/Branch-SDK/src/main/java/io/branch/coroutines/InstallReferrers.kt
@@ -308,7 +308,7 @@ private fun queryProvider(context: Context, provider: String): InstallReferrerRe
             return null
         }
 
-        BranchLogger.i("getMetaInstallReferrerDetails - Got Meta Install Referrer from provider $provider: $installReferrerString")
+        BranchLogger.i("getMetaInstallReferrerDetails - Got Meta Install Referrer as ${if (isClickThrough) "click-through" else "view-through"} from provider $provider: $installReferrerString")
 
         try {
             val json = JSONObject(utmContentValue)

--- a/Branch-SDK/src/main/java/io/branch/coroutines/InstallReferrers.kt
+++ b/Branch-SDK/src/main/java/io/branch/coroutines/InstallReferrers.kt
@@ -345,6 +345,9 @@ suspend fun fetchLatestInstallReferrer(context: Context): InstallReferrerResult?
         val allReferrers: List<InstallReferrerResult?> = listOf(googleReferrer.await(), huaweiReferrer.await(), samsungReferrer.await(), xiaomiReferrer.await(), metaReferrer.await())
         val latestReferrer = getLatestValidReferrerStore(allReferrers)
 
+        BranchLogger.v("All Install Referrers: $allReferrers")
+        BranchLogger.v("Latest Install Referrer: $latestReferrer")
+
         latestReferrer
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/coroutines/InstallReferrers.kt
+++ b/Branch-SDK/src/main/java/io/branch/coroutines/InstallReferrers.kt
@@ -360,11 +360,7 @@ fun getLatestValidReferrerStore(allReferrers: List<InstallReferrerResult?>): Ins
     }
 
     if (allReferrers.filterNotNull().any { it.appStore == Jsonkey.Meta_Install_Referrer.key }) {
-        val latestReferrer = handleMetaInstallReferrer(allReferrers, result!!)
-        if (latestReferrer?.appStore == Jsonkey.Meta_Install_Referrer.key) {
-            latestReferrer?.appStore = Jsonkey.Google_Play_Store.key
-        }
-        return latestReferrer
+        return handleMetaInstallReferrer(allReferrers, result!!)
     }
 
     return result

--- a/Branch-SDK/src/main/java/io/branch/referral/AppStoreReferrer.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/AppStoreReferrer.java
@@ -15,10 +15,15 @@ public class AppStoreReferrer {
     /* Link identifier on installing app from play store. */
     private static String installID_ = PrefHelper.NO_STRING_VALUE;
 
-    public static void processReferrerInfo(Context context, String rawReferrerString, long referrerClickTS, long installClickTS, String store) {
+    public static void processReferrerInfo(Context context, String rawReferrerString, long referrerClickTS, long installClickTS, String store, Boolean isClickThrough) {
         PrefHelper prefHelper = PrefHelper.getInstance(context);
         if(!TextUtils.isEmpty(store)){
             prefHelper.setAppStoreSource(store);
+
+            //Set the click through flag for Meta Install Referrers
+            if (store.equals(Defines.Jsonkey.Meta_Install_Referrer.getKey())) {
+                prefHelper.setIsMetaClickThrough(isClickThrough);
+            }
         }
         if (referrerClickTS > 0) {
             prefHelper.setLong(PrefHelper.KEY_REFERRER_CLICK_TS, referrerClickTS);

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -222,7 +222,8 @@ public class Defines {
         
         DMA_EEA("dma_eea"),
         DMA_Ad_Personalization("dma_ad_personalization"),
-        DMA_Ad_User_Data("dma_ad_user_data");
+        DMA_Ad_User_Data("dma_ad_user_data"),
+        Is_Meta_Click_Through("is_meta_ct");
 
         private final String key;
         

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -127,6 +127,8 @@ public class PrefHelper {
     static final String KEY_REFERRING_URL_QUERY_PARAMETERS = "bnc_referringUrlQueryParameters";
     static final String KEY_ANON_ID = "bnc_anon_id";
 
+    static final String KEY_IS_META_CLICKTHROUGH = "bnc_is_meta_clickthrough";
+
     /**
      * Internal static variable of own type {@link PrefHelper}. This variable holds the single
      * instance used when the class is instantiated via the Singleton pattern.
@@ -707,6 +709,14 @@ public class PrefHelper {
 
     public String getAppStoreSource(){
         return getString(KEY_APP_STORE_SOURCE);
+    }
+
+    public void setIsMetaClickThrough(boolean isMetaClickThrough) {
+        setBool(KEY_IS_META_CLICKTHROUGH, isMetaClickThrough);
+    }
+
+    public boolean getIsMetaClickThrough() {
+        return getBool(KEY_IS_META_CLICKTHROUGH);
     }
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -121,15 +121,7 @@ abstract class ServerRequestInitSession extends ServerRequest {
         String googlePlayReferrer = prefHelper_.getAppStoreReferrer();
         if (!googlePlayReferrer.equals(PrefHelper.NO_STRING_VALUE)) {
             try {
-
-                //Handle Meta Install Referrer by setting store as Google Play Store and adding is_meta_click_through
-                if (googlePlayReferrer.equals(Defines.Jsonkey.Meta_Install_Referrer.getKey())) {
-                    getPost().put(Defines.Jsonkey.GooglePlayInstallReferrer.getKey(), Defines.Jsonkey.Google_Play_Store.getKey());
-                    getPost().put(Defines.Jsonkey.Is_Meta_Click_Through.getKey(), prefHelper_.getIsMetaClickThrough());
-                } else {
-                    getPost().put(Defines.Jsonkey.GooglePlayInstallReferrer.getKey(), googlePlayReferrer);
-                }
-
+                getPost().put(Defines.Jsonkey.GooglePlayInstallReferrer.getKey(), googlePlayReferrer);
             } catch (JSONException e) {
                 BranchLogger.w("Caught JSONException " + e.getMessage());
             }
@@ -138,7 +130,13 @@ abstract class ServerRequestInitSession extends ServerRequest {
         String appStore = prefHelper_.getAppStoreSource();
         if(!PrefHelper.NO_STRING_VALUE.equals(appStore)) {
             try {
-                getPost().put(Defines.Jsonkey.App_Store.getKey(), appStore);
+                //Handle Meta Install Referrer by setting store as Google Play Store and adding is_meta_click_through
+                if (appStore.equals(Defines.Jsonkey.Meta_Install_Referrer.getKey())) {
+                    getPost().put(Defines.Jsonkey.App_Store.getKey(), Defines.Jsonkey.Google_Play_Store.getKey());
+                    getPost().put(Defines.Jsonkey.Is_Meta_Click_Through.getKey(), prefHelper_.getIsMetaClickThrough());
+                } else {
+                    getPost().put(Defines.Jsonkey.App_Store.getKey(), appStore);
+                }
             } catch (JSONException e) {
                 BranchLogger.w("Caught JSONException " + e.getMessage());
             }

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -121,7 +121,15 @@ abstract class ServerRequestInitSession extends ServerRequest {
         String googlePlayReferrer = prefHelper_.getAppStoreReferrer();
         if (!googlePlayReferrer.equals(PrefHelper.NO_STRING_VALUE)) {
             try {
-                getPost().put(Defines.Jsonkey.GooglePlayInstallReferrer.getKey(), googlePlayReferrer);
+
+                //Handle Meta Install Referrer by setting store as Google Play Store and adding is_meta_click_through
+                if (googlePlayReferrer.equals(Defines.Jsonkey.Meta_Install_Referrer.getKey())) {
+                    getPost().put(Defines.Jsonkey.GooglePlayInstallReferrer.getKey(), Defines.Jsonkey.Google_Play_Store.getKey());
+                    getPost().put(Defines.Jsonkey.Is_Meta_Click_Through.getKey(), prefHelper_.getIsMetaClickThrough());
+                } else {
+                    getPost().put(Defines.Jsonkey.GooglePlayInstallReferrer.getKey(), googlePlayReferrer);
+                }
+
             } catch (JSONException e) {
                 BranchLogger.w("Caught JSONException " + e.getMessage());
             }

--- a/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
@@ -602,7 +602,7 @@ abstract class SystemObserver {
                 public void resumeWith(@NonNull Object o) {
                     if (o != null) {
                         InstallReferrerResult latestReferrer = (InstallReferrerResult) o;
-                        AppStoreReferrer.processReferrerInfo(context_, latestReferrer.getLatestRawReferrer(), latestReferrer.getLatestClickTimestamp(), latestReferrer.getLatestInstallTimestamp(), latestReferrer.getAppStore());
+                        AppStoreReferrer.processReferrerInfo(context_, latestReferrer.getLatestRawReferrer(), latestReferrer.getLatestClickTimestamp(), latestReferrer.getLatestInstallTimestamp(), latestReferrer.getAppStore(), latestReferrer.isClickThrough());
                     }
                 }
             });

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 # Branch Android SDK change log
 - v5.10.1
-  * _*Master Release*_ - Mar 8, 2024
-    - Introduced Meta Install Referrer tracking
+  * _*Master Release*_ - Mar 11, 2024
+    - Fix for Meta Install Referrer tracking of view-through installs
 - v5.10.0
   * _*Master Release*_ - Mar 8, 2024
     - Introduced Meta Install Referrer tracking

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 # Branch Android SDK change log
 - v5.10.1
-  * _*Master Release*_ - Mar 11, 2024
-    - Fix for Meta Install Referrer tracking of view-through installs
+  * _*Master Release*_ - Mar 13, 2024
+    - Track Meta Install Referrer view-through installs
 - v5.10.0
   * _*Master Release*_ - Mar 8, 2024
     - Introduced Meta Install Referrer tracking

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,7 @@
 # Branch Android SDK change log
+- v5.10.1
+  * _*Master Release*_ - Mar 8, 2024
+    - Introduced Meta Install Referrer tracking
 - v5.10.0
   * _*Master Release*_ - Mar 8, 2024
     - Introduced Meta Install Referrer tracking

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.10.0
-VERSION_CODE=051200
+VERSION_NAME=5.10.1
+VERSION_CODE=051201
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.


### PR DESCRIPTION
## Description
<!-- SUFFICIENT DESCRIPTION TO EXPLAIN THE PROBLEM THAT IS BEING SOLVED -->
The server actually needs to know if a Meta Install Referrer was a click-through or view-through, so we need to pass it through in the install request.
To do this, we create a new field in install requests called `is_meta_ct`. It will only be included in installs where a Meta Install Referrer is being attached as well. 

## Testing Instructions
<!-- TESTING INSTRUCTIONS -->
Check that the field is being included in the request only when necessary and accurately. Also ensure no other logic is being broken by this change.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
