### PR TITLE
Move optional synchronous user agent fetch out of start up

### DIFF
--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
@@ -18,7 +18,7 @@ public final class CustomBranchApp extends Application {
             }
         };
         Branch.enableLogging(); // Pass in iBranchLoggingCallbacks to enable logging redirects
-        Branch.setIsUserAgentSync(true);
+        Branch.setIsUserAgentSync(false);
         Branch.getAutoInstance(this);
     }
 }

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
@@ -18,6 +18,7 @@ public final class CustomBranchApp extends Application {
             }
         };
         Branch.enableLogging(); // Pass in iBranchLoggingCallbacks to enable logging redirects
+        Branch.setIsUserAgentSync(true);
         Branch.getAutoInstance(this);
     }
 }

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
@@ -18,7 +18,6 @@ public final class CustomBranchApp extends Application {
             }
         };
         Branch.enableLogging(); // Pass in iBranchLoggingCallbacks to enable logging redirects
-        Branch.setIsUserAgentSync(false);
         Branch.getAutoInstance(this);
     }
 }

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
@@ -654,6 +654,35 @@ public class MainActivity extends Activity {
         Branch.getInstance().addFacebookPartnerParameterWithName("em", getHashedValue("sdkadmin@branch.io"));
         Branch.getInstance().addFacebookPartnerParameterWithName("ph", getHashedValue("6516006060"));
         Log.d("BranchSDK_Tester", "initSession");
+
+        initSessionsWithTests();
+
+        // Branch integration validation: Validate Branch integration with your app
+        // NOTE : The below method will run few checks for verifying correctness of the Branch integration.
+        // Please look for "BranchSDK_Doctor" in the logcat to see the results.
+        // IMP : Do not make this call in your production app
+
+        //IntegrationValidator.validate(MainActivity.this);
+    }
+
+
+    private void initSessionsWithTests() {
+        boolean testUserAgent = true;
+        userAgentTests(testUserAgent, 10);
+    }
+
+    // Enqueue several v2 events prior to init to simulate worst timing conditions for user agent fetch
+    // TODO Add to automation.
+    //  Check that all events up to Event N-1 complete with user agent string.
+    private void userAgentTests(boolean userAgentSync, int n) {
+        Branch.setIsUserAgentSync(userAgentSync);
+        Log.i("BranchSDK_Tester", "Beginning stress tests with IsUserAgentSync" + Branch.getIsUserAgentSync());
+
+        for (int i = 0; i < n; i++) {
+            BranchEvent event = new BranchEvent("Event " + i);
+            event.logEvent(this);
+        }
+
         Branch.sessionBuilder(this).withCallback(new Branch.BranchUniversalReferralInitListener() {
             @Override
             public void onInitFinished(BranchUniversalObject branchUniversalObject, LinkProperties linkProperties, BranchError error) {
@@ -677,17 +706,8 @@ public class MainActivity extends Activity {
                 // QA purpose only
                 // TrackingControlTestRoutines.runTrackingControlTest(MainActivity.this);
                 // BUOTestRoutines.TestBUOFunctionalities(MainActivity.this);
-
             }
         }).withData(this.getIntent().getData()).init();
-
-        // Branch integration validation: Validate Branch integration with your app
-        // NOTE : The below method will run few checks for verifying correctness of the Branch integration.
-        // Please look for "BranchSDK_Doctor" in the logcat to see the results.
-        // IMP : Do not make this call in your production app
-
-        //IntegrationValidator.validate(MainActivity.this);
-
     }
 
     @Override
@@ -704,8 +724,6 @@ public class MainActivity extends Activity {
                 }
             }
         }).reInit();
-
-
     }
 
     @Override

--- a/Branch-SDK/src/main/java/io/branch/coroutines/DeviceSignals.kt
+++ b/Branch-SDK/src/main/java/io/branch/coroutines/DeviceSignals.kt
@@ -1,0 +1,65 @@
+package io.branch.coroutines
+
+import android.content.Context
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
+import android.os.Handler
+import android.os.Looper
+import android.webkit.WebSettings
+import android.webkit.WebView
+import io.branch.referral.BranchLogger.e
+import io.branch.referral.BranchLogger.v
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+
+/**
+ * Returns the user agent string on a background thread via static class WebSettings
+ */
+suspend fun getUserAgentAsync(context: Context): String? {
+    return withContext(Dispatchers.Default) {
+        var result: String? = null
+        try {
+            v("Retrieving userAgent string from WebSettings on thread " + Thread.currentThread())
+            result = WebSettings.getDefaultUserAgent(context)
+        }
+        catch (exception: Exception) {
+            e("Failed to retrieve userAgent string. " + exception.message)
+        }
+
+        result
+    }
+}
+
+fun getUserAgentSync(context: Context): String?{
+    var result: String? = null
+
+    if(isMainThread){
+        result = getWebViewUserAgent(context)
+    }
+    else {
+        Handler(Looper.getMainLooper()).post {
+            result = getWebViewUserAgent(context)
+        }
+    }
+
+    return result
+}
+
+var isMainThread =
+    if (VERSION.SDK_INT >= VERSION_CODES.M) {
+        Looper.getMainLooper().isCurrentThread
+    }
+    else {
+        Thread.currentThread() === Looper.getMainLooper().thread
+    }
+
+fun getWebViewUserAgent(context: Context): String? {
+    val result: String?
+    v("Retrieving user agent from WebView instance on " + Thread.currentThread())
+    val w = WebView(context)
+    result = w.settings.userAgentString
+    w.destroy()
+
+    return result
+}

--- a/Branch-SDK/src/main/java/io/branch/coroutines/DeviceSignals.kt
+++ b/Branch-SDK/src/main/java/io/branch/coroutines/DeviceSignals.kt
@@ -1,52 +1,84 @@
 package io.branch.coroutines
 
 import android.content.Context
+import android.text.TextUtils
 import android.webkit.WebSettings
 import android.webkit.WebView
+import io.branch.referral.Branch
 import io.branch.referral.BranchLogger.e
 import io.branch.referral.BranchLogger.v
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
+val mutex = Mutex()
 
 /**
  * Returns the user agent string on a background thread via static class WebSettings
+ * This is the default behavior.
+ *
+ * Use a mutex to ensure only one is executed at a time.
+ * Successive calls will return the cached value.
+ *
+ * For performance, this is called at the end of the init, or while awaiting init if enqueued prior.
  */
 suspend fun getUserAgentAsync(context: Context): String? {
     return withContext(Dispatchers.Default) {
-        v("Begin getUserAgentAsync " + Thread.currentThread())
+        mutex.withLock {
+            var result: String? = null
 
-        var result: String? = null
-        try {
-            result = WebSettings.getDefaultUserAgent(context)
-        }
-        catch (exception: Exception) {
-            e("Failed to retrieve userAgent string. " + exception.message)
-        }
+            if (!TextUtils.isEmpty(Branch._userAgentString)) {
+                v("UserAgent cached " + Branch._userAgentString)
+                result = Branch._userAgentString
+            }
+            else {
+                try {
+                    v("Begin getUserAgentAsync " + Thread.currentThread())
+                    result = WebSettings.getDefaultUserAgent(context)
+                    v("End getUserAgentAsync " + Thread.currentThread() + " " + result)
+                }
+                catch (exception: Exception) {
+                    e("Failed to retrieve userAgent string. " + exception.message)
+                }
+            }
 
-        v("End getUserAgentAsync " + Thread.currentThread() + " " + result)
-        result
+            result
+        }
     }
 }
 
 /**
  * Returns the user agent string on the main thread via WebView instance.
+ * Use when facing errors with the WebSettings static API.
+ * https://bugs.chromium.org/p/chromium/issues/detail?id=1279562
+ * https://bugs.chromium.org/p/chromium/issues/detail?id=1271617
+ *
+ *
+ * Because there is only one main thread, this function will only execute one at a time.
+ * Successive calls will return the cached value.
  */
 suspend fun getUserAgentSync(context: Context): String?{
     return withContext(Dispatchers.Main){
-        v("Begin getUserAgentSync " + Thread.currentThread())
-
         var result: String? = null
-        try {
-            val w = WebView(context)
-            result = w.settings.userAgentString
-            w.destroy()
+
+        if(!TextUtils.isEmpty(Branch._userAgentString)){
+            v("UserAgent cached " + Branch._userAgentString)
+            result = Branch._userAgentString
         }
-        catch (ex: Exception){
-            e("Failed to retrieve userAgent string. " + ex.message)
+        else {
+            try {
+                v("Begin getUserAgentSync " + Thread.currentThread())
+                val w = WebView(context)
+                result = w.settings.userAgentString
+                w.destroy()
+                v("End getUserAgentSync " + Thread.currentThread() + " " + result)
+            }
+            catch (ex: Exception) {
+                e("Failed to retrieve userAgent string. " + ex.message)
+            }
         }
 
-        v("End getUserAgentSync " + Thread.currentThread() + " " + result)
         result
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -196,7 +196,7 @@ public class Branch {
     /**
      * Package private user agent string cached to save on repeated queries
      */
-    static String _userAgentString = "";
+    public static String _userAgentString = "";
 
     /* Json object containing key-value pairs for debugging deep linking */
     private JSONObject deeplinkDebugParams_;

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -355,11 +355,6 @@ public class Branch {
             branchReferral_.setActivityLifeCycleObserver((Application) context);
         }
 
-        // Cache the user agent from a webview instance if needed
-        if(userAgentSync && DeviceInfo.getInstance() != null){
-            DeviceInfo.getInstance().getUserAgentStringSync(context);
-        }
-
         return branchReferral_;
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -773,7 +773,11 @@ public class Branch {
     public static void setIsUserAgentSync(boolean sync){
         userAgentSync = sync;
     }
-    
+
+    public static boolean getIsUserAgentSync(){
+        return userAgentSync;
+    }
+
     /*
      * <p>Closes the current session. Should be called by on getting the last actvity onStop() event.
      * </p>

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -252,33 +252,34 @@ class DeviceInfo {
                 Branch.getInstance().requestQueue_.processNextQueueItem("setPostUserAgent");
             }
             else {
-                BranchLogger.v("Start invoking getUserAgentSync from thread " + Thread.currentThread().getName());
-
-                DeviceSignalsKt.getUserAgentSync(context_, new Continuation<String>() {
-                    @NonNull
-                    @Override
-                    public CoroutineContext getContext() {
-                        return EmptyCoroutineContext.INSTANCE;
-                    }
-
-                    @Override
-                    public void resumeWith(@NonNull Object o) {
-                        if(o != null){
-                            Branch._userAgentString = (String) o;
-                            BranchLogger.v("onUserAgentStringFetchFinished, releasing lock");
-
-                            try {
-                                userDataObj.put(Defines.Jsonkey.UserAgent.getKey(), Branch._userAgentString);
-                            }
-                            catch (JSONException e) {
-                                BranchLogger.w("Caught JSONException " + e.getMessage());
-                            }
+                // If user agent sync is false, then the async coroutine is executed instead but may not have finished yet.
+                if(Branch.userAgentSync) {
+                    BranchLogger.v("Start invoking getUserAgentSync from thread " + Thread.currentThread().getName());
+                    DeviceSignalsKt.getUserAgentSync(context_, new Continuation<String>() {
+                        @NonNull
+                        @Override
+                        public CoroutineContext getContext() {
+                            return EmptyCoroutineContext.INSTANCE;
                         }
 
-                        Branch.getInstance().requestQueue_.unlockProcessWait(ServerRequest.PROCESS_WAIT_LOCK.USER_AGENT_STRING_LOCK);
-                        Branch.getInstance().requestQueue_.processNextQueueItem("onUserAgentStringFetchFinished");
-                    }
-                });
+                        @Override
+                        public void resumeWith(@NonNull Object o) {
+                            if (o != null) {
+                                Branch._userAgentString = (String) o;
+                                BranchLogger.v("onUserAgentStringFetchFinished, releasing lock");
+
+                                try {
+                                    userDataObj.put(Defines.Jsonkey.UserAgent.getKey(), Branch._userAgentString);
+                                } catch (JSONException e) {
+                                    BranchLogger.w("Caught JSONException " + e.getMessage());
+                                }
+                            }
+
+                            Branch.getInstance().requestQueue_.unlockProcessWait(ServerRequest.PROCESS_WAIT_LOCK.USER_AGENT_STRING_LOCK);
+                            Branch.getInstance().requestQueue_.processNextQueueItem("onUserAgentStringFetchFinished");
+                        }
+                    });
+                }
             }
         }
         catch (Exception exception){

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -42,8 +42,8 @@ public abstract class ServerRequest {
     private final Context context_;
 
     // Various process wait locks for Branch server request
-    enum PROCESS_WAIT_LOCK {
-        SDK_INIT_WAIT_LOCK, GAID_FETCH_WAIT_LOCK, INTENT_PENDING_WAIT_LOCK, USER_SET_WAIT_LOCK, INSTALL_REFERRER_FETCH_WAIT_LOCK
+    public enum PROCESS_WAIT_LOCK {
+        SDK_INIT_WAIT_LOCK, GAID_FETCH_WAIT_LOCK, INTENT_PENDING_WAIT_LOCK, USER_SET_WAIT_LOCK, INSTALL_REFERRER_FETCH_WAIT_LOCK, USER_AGENT_STRING_LOCK
     }
     
     // Set for holding any active wait locks

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -97,7 +97,7 @@ abstract class ServerRequestInitSession extends ServerRequest {
         branch.updateSkipURLFormats();
 
         // Run this after session init, ahead of any V2 event, in the background.
-        if (!Branch.userAgentSync) {
+        if (!Branch.userAgentSync && !TextUtils.isEmpty(Branch._userAgentString)) {
             DeviceSignalsKt.getUserAgentAsync(branch.getApplicationContext(), new Continuation<String>() {
                 @NonNull
                 @Override

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestQueue.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestQueue.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Handler;
 import android.os.Looper;
+import android.text.TextUtils;
 
 import androidx.annotation.Nullable;
 


### PR DESCRIPTION
## Reference
SDK-XXX -- <TITLE>.

## Description
Due to an external bug, an alternative to the original user agent string method was introduced to mitigate these crashes. However, the alternative method had some impact on app start up due to the limitation that it needed the main thread in order to access webview instance's settings.

To mitigate the performance impact of the workaround, the fetch routines have been refactored into coroutines to be invoked at more opportune times. 

- `getUserAgentAsync` executes immediately **after** the session initialization in the background. 
  - If a v2 event were immediately enqueued, the event will have a lock awaiting its completion
- `getUserAgentSync` executes immediately **before** a v2 event is enqueued only if the public boolean `Branch.setIsUserAgentSync(true);` has been set 

Thereafter, the result of either operation is cached in memory as was before.

Because of the queueing mechanism, regardless of the thread, the request object must still be alerted when an operation completes. This is done in the continuation from the coroutines. Regardless of the result of the fetch, either a valid string or null, the lock is removed to not dead lock the SDK.

## Testing Instructions
Integrate in both main thread and backgrounded implementations. The SDK should never lock up.

Refer to logs for the following cases:

### 1. Sync True, Main thread
02:08:26.237  V  Queue is: io.branch.referral.ServerRequestRegisterOpen@92ddee5 with locks []
02:08:26.237  V  onRequestSucceeded io.branch.referral.ServerRequestRegisterOpen@92ddee5 io.branch.referral.ServerResponse@b7afecc on callback io.branch.referral.BranchUniversalReferralInitWrapper@283f6b0
02:08:26.239  D  branch init complete!
**02:08:26.240  V  Deferring userAgent string call for sync retrieval**
02:08:26.240  V  onInitSessionCompleted on thread main

{send event}

02:08:43.589  V  Start invoking **getUserAgentSync** from thread main
02:08:43.597  V  Preparing V2 event, user agent is 
02:08:43.597  V  handleNewRequest adding process wait lock USER_AGENT_STRING_LOCK
02:08:43.598  D  handleNewRequest io.branch.referral.util.BranchEvent$1@6ca2d85
02:08:43.603  V  processNextQueueItem handleNewRequest
02:08:43.604  V  Queue is: io.branch.referral.util.BranchEvent$1@6ca2d85 with locks [USER_AGENT_STRING_LOCK]
02:08:43.604  D  processNextQueueItem, req io.branch.referral.util.BranchEvent$1@6ca2d85
02:08:43.606  V  **Begin getUserAgentSync Thread[main,5,main]**
02:08:43.979  V  **End getUserAgentSync Thread[main,5,main]** Mozilla/5.0 (Linux; Android 14; sdk_gphone64_x86_64 Build/UE1A.230829.036.A1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/122.0.6261.120 Mobile Safari/537.36
02:08:43.979  V  **onUserAgentStringFetchFinished, releasing lock**
02:08:43.979  V  **processNextQueueItem onUserAgentStringFetchFinished**

### 2. Sync false, Main Thread
02:20:38.631  V  onRequestSucceeded io.branch.referral.ServerRequestRegisterOpen@9f3ebc8 io.branch.referral.ServerResponse@1b41e1b on callback io.branch.referral.BranchUniversalReferralInitWrapper@b6ad24f
02:20:38.635  D  branch init complete!
02:20:38.638  V  onInitSessionCompleted on thread main
02:20:38.638  V  **Begin getUserAgentAsync Thread[DefaultDispatcher-worker-1,5,main]**
02:20:38.638  V  processNextQueueItem onPostExecuteInner
02:20:38.640  V  Queue is: 
02:20:39.009  V  **End getUserAgentAsync Thread[DefaultDispatcher-worker-1,5,main]** Mozilla/5.0 (Linux; Android 14; sdk_gphone64_x86_64 Build/UE1A.230829.036.A1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/122.0.6261.120 Mobile Safari/537.36
02:20:39.009  V  **onInitSessionCompleted resumeWith userAgent** Mozilla/5.0 (Linux; Android 14; sdk_gphone64_x86_64 Build/UE1A.230829.036.A1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/122.0.6261.120 Mobile Safari/537.36 on thread DefaultDispatcher-worker-1
02:20:39.009  V  processNextQueueItem getUserAgentAsync resumeWith
02:20:39.009  V  Queue is: 

{send event}

02:21:13.581  V  userAgent was cached: Mozilla/5.0 (Linux; Android 14; sdk_gphone64_x86_64 Build/UE1A.230829.036.A1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/122.0.6261.120 Mobile Safari/537.36
02:21:13.581  V  processNextQueueItem setPostUserAgent
02:21:13.581  V  Queue is: 
02:21:13.585  V  **Preparing V2 event, user agent is Mozilla/5.0 (Linux; Android 14; sdk_gphone64_x86_64 Build/UE1A.230829.036.A1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/122.0.6261.120 Mobile Safari/537.36**
02:21:13.586  D  handleNewRequest io.branch.referral.util.BranchEvent$1@25278e

### 3. Sync true, Background thread
02:23:14.740 V  Deferring userAgent string call for sync retrieval
02:23:14.743 V  onInitSessionCompleted on thread main
02:23:14.745 V  processNextQueueItem onPostExecuteInner
02:23:14.746 V  Queue is: 

{send event}

02:23:35.130 V  Start invoking getUserAgentSync from thread **RxNewThreadScheduler-2**
02:23:35.138 V  Preparing V2 event, user agent is 
02:23:35.138 V  handleNewRequest adding process wait lock USER_AGENT_STRING_LOCK
02:23:35.139 D  handleNewRequest io.branch.referral.util.BranchEvent$1@e38e414
02:23:35.140 V  **Begin getUserAgentSync Thread[main,5,main]**
02:23:35.141 V  processNextQueueItem handleNewRequest
02:23:35.142 V  Queue is: io.branch.referral.util.BranchEvent$1@e38e414 with **locks [USER_AGENT_STRING_LOCK]**
02:23:35.142 D  processNextQueueItem, req io.branch.referral.util.BranchEvent$1@e38e414
02:23:35.601 V  **End getUserAgentSync Thread[main,5,main]** Mozilla/5.0 (Linux; Android 14; sdk_gphone64_x86_64 Build/UE1A.230829.036.A1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/122.0.6261.120 Mobile Safari/537.36
02:23:35.602 V  **onUserAgentStringFetchFinished, releasing lock**

{send event 2}

02:27:03.399 V  **userAgent was cached**: Mozilla/5.0 (Linux; Android 14; sdk_gphone64_x86_64 Build/UE1A.230829.036.A1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/122.0.6261.120 Mobile Safari/537.36
02:27:03.401 V  processNextQueueItem setPostUserAgent
02:27:03.402 V  Queue is: 
02:27:03.409 V  **Preparing V2 event, user agent is Mozilla/5.0 (Linux; Android 14; sdk_gphone64_x86_64 Build/UE1A.230829.036.A1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/122.0.6261.120 Mobile Safari/537.36**
02:27:03.409 D  handleNewRequest io.branch.referral.util.BranchEvent$1@8e0cc59
02:27:03.414 V  processNextQueueItem handleNewRequest
02:27:03.415 V  Queue is: io.branch.referral.util.BranchEvent$1@8e0cc59 **with locks []**

### 4. Sync false, Background thread
02:35:39.574 V  onInitSessionCompleted on thread main
02:35:39.574 V  **Begin getUserAgentAsync Thread[DefaultDispatcher-worker-1,5,main]**
02:35:39.608 V  processNextQueueItem onPostExecuteInner
02:35:39.609 V  Queue is: 
02:35:40.041 V  **End getUserAgentAsync Thread[DefaultDispatcher-worker-1,5,main]** Mozilla/5.0 (Linux; Android 14; sdk_gphone64_x86_64 Build/UE1A.230829.036.A1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/122.0.6261.120 Mobile Safari/537.36
02:35:40.042 V  onInitSessionCompleted resumeWith userAgent Mozilla/5.0 (Linux; Android 14; sdk_gphone64_x86_64 Build/UE1A.230829.036.A1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/122.0.6261.120 Mobile Safari/537.36 on **thread DefaultDispatcher-worker-1**

{send event}

02:36:06.028 V  **userAgent was cached**: Mozilla/5.0 (Linux; Android 14; sdk_gphone64_x86_64 Build/UE1A.230829.036.A1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/122.0.6261.120 Mobile Safari/537.36
02:36:06.028 V  processNextQueueItem setPostUserAgent
02:36:06.029 V  Queue is: 
02:36:06.039 V  **Preparing V2 event, user agent is** Mozilla/5.0 (Linux; Android 14; sdk_gphone64_x86_64 Build/UE1A.230829.036.A1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/122.0.6261.120 Mobile Safari/537.36
02:36:06.040 D  handleNewRequest io.branch.referral.util.BranchEvent$1@b68c11a
02:36:06.042 V  processNextQueueItem handleNewRequest
02:36:06.043 V  Queue is: io.branch.referral.util.BranchEvent$1@b68c11a with **locks []**


## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
