### PR TITLE
[SDK-2329] Added apiUrl check in BranchJSONConfig

### DIFF
--- a/Branch-SDK-TestBed/src/main/assets/branch.json
+++ b/Branch-SDK-TestBed/src/main/assets/branch.json
@@ -1,3 +1,3 @@
-{ 
-
+{
+  "apiUrl": "https://api3.branch.io"
 }

--- a/Branch-SDK-TestBed/src/main/assets/branch.json
+++ b/Branch-SDK-TestBed/src/main/assets/branch.json
@@ -1,3 +1,2 @@
 {
-  "apiUrl": "https://api3.branch.io"
 }

--- a/Branch-SDK-TestBed/src/main/assets/branch.json
+++ b/Branch-SDK-TestBed/src/main/assets/branch.json
@@ -1,0 +1,3 @@
+{ 
+    "apiUrl": "https://api3.branch.io"
+}

--- a/Branch-SDK-TestBed/src/main/assets/branch.json
+++ b/Branch-SDK-TestBed/src/main/assets/branch.json
@@ -1,3 +1,3 @@
 { 
-    "apiUrl": "https://api3.branch.io"
+
 }

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
@@ -655,7 +655,7 @@ public class MainActivity extends Activity {
         Branch.getInstance().addFacebookPartnerParameterWithName("ph", getHashedValue("6516006060"));
         Log.d("BranchSDK_Tester", "initSession");
 
-        initSessionsWithTests();
+        //initSessionsWithTests();
 
         // Branch integration validation: Validate Branch integration with your app
         // NOTE : The below method will run few checks for verifying correctness of the Branch integration.

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/SettingsActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/SettingsActivity.java
@@ -61,7 +61,7 @@ public class SettingsActivity extends Activity {
         apiUrlText.setOnEditorActionListener((textView, i, keyEvent) -> {
             if (i == EditorInfo.IME_ACTION_DONE) {
                 String newApiUrl = textView.getText().toString();
-                Branch.setAPIUrl("https://myapi.com/");
+                Branch.setAPIUrl(newApiUrl);
 
                 InputMethodManager imm = (InputMethodManager)getSystemService(INPUT_METHOD_SERVICE);
                 imm.hideSoftInputFromWindow(apiUrlText.getWindowToken(), 0);

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/SettingsActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/SettingsActivity.java
@@ -61,7 +61,7 @@ public class SettingsActivity extends Activity {
         apiUrlText.setOnEditorActionListener((textView, i, keyEvent) -> {
             if (i == EditorInfo.IME_ACTION_DONE) {
                 String newApiUrl = textView.getText().toString();
-                Branch.setAPIUrl(newApiUrl);
+                Branch.setAPIUrl("https://myapi.com/");
 
                 InputMethodManager imm = (InputMethodManager)getSystemService(INPUT_METHOD_SERVICE);
                 imm.hideSoftInputFromWindow(apiUrlText.getWindowToken(), 0);

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -514,6 +514,7 @@ public class Branch {
      */
     public static void setAPIUrl(String url) {
         PrefHelper.setAPIUrl(url);
+        BranchLogger.v("setAPIUrl: Branch API URL was set to " + url);
     }
     /**
      * <p>Sets a custom CDN base URL.</p>

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -507,8 +507,16 @@ public class Branch {
      * @param url The {@link String} URL base URL that the Branch API uses.
      */
     public static void setAPIUrl(String url) {
-        PrefHelper.setAPIUrl(url);
-        BranchLogger.v("setAPIUrl: Branch API URL was set to " + url);
+        if (!TextUtils.isEmpty(url)) {
+            if (!url.endsWith("/")) {
+                url = url + "/";
+            }
+
+            PrefHelper.setAPIUrl(url);
+            BranchLogger.v("setAPIUrl: Branch API URL was set to " + url);
+        } else {
+            BranchLogger.w("setAPIUrl: URL cannot be empty or null");
+        }
     }
     /**
      * <p>Sets a custom CDN base URL.</p>

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -411,7 +411,7 @@ public class Branch {
 
             String apiUrl = BranchJsonConfig.getInstance(context).getAPIUrl();
             if (!TextUtils.isEmpty(apiUrl)) {
-                setAPIUrl(apiUrl);
+                setAPIUrl(apiUrl + "/");
             }
 
             BranchUtil.setTestMode(BranchUtil.checkTestMode(context));

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -379,7 +379,7 @@ public class Branch {
 
             String apiUrl = BranchJsonConfig.getInstance(context).getAPIUrl();
             if (!TextUtils.isEmpty(apiUrl)) {
-                setAPIUrl(apiUrl);
+                setAPIUrl(apiUrl + "/");
             }
 
             BranchUtil.setTestMode(BranchUtil.checkTestMode(context));

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -377,6 +377,11 @@ public class Branch {
             // Should only be set in json config
             deferInitForPluginRuntime(BranchUtil.getDeferInitForPluginRuntimeConfig(context));
 
+            String apiUrl = BranchJsonConfig.getInstance(context).getAPIUrl();
+            if (!TextUtils.isEmpty(apiUrl)) {
+                setAPIUrl(apiUrl);
+            }
+
             BranchUtil.setTestMode(BranchUtil.checkTestMode(context));
             branchReferral_ = initBranchSDK(context, BranchUtil.readBranchKey(context));
             getPreinstallSystemData(branchReferral_, context);
@@ -403,6 +408,11 @@ public class Branch {
 
             // Should only be set in json config
             deferInitForPluginRuntime(BranchUtil.getDeferInitForPluginRuntimeConfig(context));
+
+            String apiUrl = BranchJsonConfig.getInstance(context).getAPIUrl();
+            if (!TextUtils.isEmpty(apiUrl)) {
+                setAPIUrl(apiUrl);
+            }
 
             BranchUtil.setTestMode(BranchUtil.checkTestMode(context));
             // If a Branch key is passed already use it. Else read the key

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -377,10 +377,7 @@ public class Branch {
             // Should only be set in json config
             deferInitForPluginRuntime(BranchUtil.getDeferInitForPluginRuntimeConfig(context));
 
-            String apiUrl = BranchJsonConfig.getInstance(context).getAPIUrl();
-            if (!TextUtils.isEmpty(apiUrl)) {
-                setAPIUrl(apiUrl + "/");
-            }
+            BranchUtil.setAPIBaseUrlFromConfig(context);
 
             BranchUtil.setTestMode(BranchUtil.checkTestMode(context));
             branchReferral_ = initBranchSDK(context, BranchUtil.readBranchKey(context));
@@ -409,10 +406,7 @@ public class Branch {
             // Should only be set in json config
             deferInitForPluginRuntime(BranchUtil.getDeferInitForPluginRuntimeConfig(context));
 
-            String apiUrl = BranchJsonConfig.getInstance(context).getAPIUrl();
-            if (!TextUtils.isEmpty(apiUrl)) {
-                setAPIUrl(apiUrl + "/");
-            }
+            BranchUtil.setAPIBaseUrlFromConfig(context);
 
             BranchUtil.setTestMode(BranchUtil.checkTestMode(context));
             // If a Branch key is passed already use it. Else read the key

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchJsonConfig.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchJsonConfig.java
@@ -169,8 +169,8 @@ public class BranchJsonConfig {
         if (mConfiguration == null) return null;
 
         try {
-            if (!mConfiguration.has("testKey")) return null;
-            return mConfiguration.getString("testKey");
+            if (!mConfiguration.has(BranchJsonKey.testKey.toString())) return null;
+            return mConfiguration.getString(BranchJsonKey.testKey.toString());
         }
         catch (JSONException exception) {
             Log.e(TAG, "Error parsing branch.json: " + exception.getMessage());
@@ -194,8 +194,8 @@ public class BranchJsonConfig {
         if (mConfiguration == null) return null;
 
         try {
-            if (!mConfiguration.has("apiUrl")) return null;
-            return mConfiguration.getString("apiUrl");
+            if (!mConfiguration.has(BranchJsonKey.apiUrl.toString())) return null;
+            return mConfiguration.getString(BranchJsonKey.apiUrl.toString());
         }
         catch (JSONException exception) {
             Log.e(TAG, "Error parsing branch.json: " + exception.getMessage());

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchJsonConfig.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchJsonConfig.java
@@ -29,7 +29,8 @@ public class BranchJsonConfig {
         liveKey,
         useTestInstance,
         enableLogging,
-        deferInitForPluginRuntime
+        deferInitForPluginRuntime,
+        apiUrl
     }
 
     /*
@@ -44,7 +45,8 @@ public class BranchJsonConfig {
             "liveKey":"key_live_hcnegAumkH7Kv18M8AOHhfgiohpXq5tB",
             "useTestInstance": true,
             "enableLogging": true,
-            "deferInitForPluginRuntime": true
+            "deferInitForPluginRuntime": true,
+            "apiUrl": "https://api.branch.io"
        }
     */
 
@@ -184,6 +186,20 @@ public class BranchJsonConfig {
         } catch (JSONException exception) {
             Log.e(TAG, "Error parsing branch.json: " + exception.getMessage());
             return false;
+        }
+    }
+
+    @Nullable
+    public String getAPIUrl() {
+        if (mConfiguration == null) return null;
+
+        try {
+            if (!mConfiguration.has("apiUrl")) return null;
+            return mConfiguration.getString("apiUrl");
+        }
+        catch (JSONException exception) {
+            Log.e(TAG, "Error parsing branch.json: " + exception.getMessage());
+            return null;
         }
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchJsonConfig.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchJsonConfig.java
@@ -46,7 +46,7 @@ public class BranchJsonConfig {
             "useTestInstance": true,
             "enableLogging": true,
             "deferInitForPluginRuntime": true,
-            "apiUrl": "https://api.branch.io"
+            "apiUrl": "https://api2.branch.io"
        }
     */
 

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
@@ -10,6 +10,7 @@ import android.os.Build;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 
+import android.text.TextUtils;
 import android.util.DisplayMetrics;
 
 import org.json.JSONArray;
@@ -137,6 +138,14 @@ public class BranchUtil {
         }
 
         return deferInitForPluginRuntime;
+    }
+
+    public static void setAPIBaseUrlFromConfig(Context context) {
+        BranchJsonConfig jsonConfig = BranchJsonConfig.getInstance(context);
+        String apiUrl = jsonConfig.getAPIUrl();
+        if (!TextUtils.isEmpty(apiUrl)) {
+            Branch.setAPIUrl(apiUrl + "/");
+        }
     }
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
@@ -144,7 +144,7 @@ public class BranchUtil {
         BranchJsonConfig jsonConfig = BranchJsonConfig.getInstance(context);
         String apiUrl = jsonConfig.getAPIUrl();
         if (!TextUtils.isEmpty(apiUrl)) {
-            Branch.setAPIUrl(apiUrl + "/");
+            Branch.setAPIUrl(apiUrl);
         }
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
@@ -143,9 +143,7 @@ public class BranchUtil {
     public static void setAPIBaseUrlFromConfig(Context context) {
         BranchJsonConfig jsonConfig = BranchJsonConfig.getInstance(context);
         String apiUrl = jsonConfig.getAPIUrl();
-        if (!TextUtils.isEmpty(apiUrl)) {
-            Branch.setAPIUrl(apiUrl);
-        }
+        Branch.setAPIUrl(apiUrl);
     }
 
     /**


### PR DESCRIPTION
## Reference
SDK-2329 -- Support setting Branch API URL in Branch.json

## Description
<!-- SUFFICIENT DESCRIPTION TO EXPLAIN THE PROBLEM THAT IS BEING SOLVED -->
Added a new field to branch.json for setting the Branch API URL. The config check and setAPIUrl call are done in the getAutoInstance in the same place as the deferInitForPluginRuntime() check.
One quirk is that all of the base URL's are stored with a "/" at the end, so we need to add that to the provided URL when making the setAPIUrl call. We don't want to have a URL ending with a "/" in the branch.json itself though since on iOS, the base URLs are stored without the "/".

## Testing Instructions
<!-- TESTING INSTRUCTIONS -->
Add `"apiUrl": "https://api.branch.io"` to a branch.json file and observe the API URL properly change for each request.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
