### PR TITLE
Fix logic bug for optimized user agent string

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -97,7 +97,7 @@ abstract class ServerRequestInitSession extends ServerRequest {
         branch.updateSkipURLFormats();
 
         // Run this after session init, ahead of any V2 event, in the background.
-        if (!Branch.userAgentSync && !TextUtils.isEmpty(Branch._userAgentString)) {
+        if (!Branch.userAgentSync && TextUtils.isEmpty(Branch._userAgentString)) {
             DeviceSignalsKt.getUserAgentAsync(branch.getApplicationContext(), new Continuation<String>() {
                 @NonNull
                 @Override


### PR DESCRIPTION
## Reference
SDK-XXX -- <TITLE>.

## Description
An additional case was added to take advantage of the backgrounded nature of this fetch, but this logic bug was hidden as the fetch that occurs prior to the v2 event would execute successfully. User agent string was incorrectly being checked as not empty, when it should be checking for empty to proceed. Fixing so that the best case will execute.

## Testing Instructions
Same instructions as previous. Ensure optimized case runs.

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
