### PR TITLE
[SDK-2384] Add BranchLogLevel for setting minimum logging level

### DIFF
--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
@@ -5,6 +5,7 @@ import android.util.Log;
 
 import io.branch.interfaces.IBranchLoggingCallbacks;
 import io.branch.referral.Branch;
+import io.branch.referral.BranchLogger;
 
 public final class CustomBranchApp extends Application {
     @Override
@@ -17,7 +18,7 @@ public final class CustomBranchApp extends Application {
                 Log.v( "CustomTag", logMessage);
             }
         };
-        Branch.enableLogging(); // Pass in iBranchLoggingCallbacks to enable logging redirects
+        Branch.enableLogging(BranchLogger.BranchLogLevel.VERBOSE); // Pass in iBranchLoggingCallbacks to enable logging redirects
         Branch.getAutoInstance(this);
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1900,21 +1900,34 @@ public class Branch {
     }
 
     /**
-     * Enable Logging, independent of Debug Mode.
+     * Enable logging with a specific log level, independent of Debug Mode.
+     *
+     * @param iBranchLogging Optional interface to receive logging from the SDK.
+     * @param level The minimum log level for logging output.
      */
-    public static void enableLogging() {
-        enableLogging(null);
+    public static void enableLogging(IBranchLoggingCallbacks iBranchLogging, BranchLogger.BranchLogLevel level) {
+        BranchLogger.setLoggerCallback(iBranchLogging);
+        BranchLogger.setMinimumLogLevel(level);
+        BranchLogger.setLoggingEnabled(true);
+        BranchLogger.logAlways(GOOGLE_VERSION_TAG);
     }
 
     /**
-     * Optional interface. Implement a callback to receive logging from the SDK directly to your
-     * own logging solution. If null, and enabled, the default android.util.Log is used.
-     * @param iBranchLogging
+     * Enable Logging, independent of Debug Mode. Defaults to DEBUG level.
      */
-    public static void enableLogging(IBranchLoggingCallbacks iBranchLogging){
-        BranchLogger.setLoggerCallback(iBranchLogging);
-        BranchLogger.logAlways(GOOGLE_VERSION_TAG);
-        BranchLogger.setLoggingEnabled(true);
+    public static void enableLogging() {
+        enableLogging(null, BranchLogger.BranchLogLevel.DEBUG);
+    }
+
+    /**
+     * Enable Logging, independent of Debug Mode. Defaults to DEBUG level.
+     * Implement a callback to receive logging from the SDK directly to your
+     * own logging solution. If null, and enabled, the default android.util.Log is used.
+     *
+     * @param iBranchLogging Optional interface to receive logging from the SDK.
+     */
+    public static void enableLogging(IBranchLoggingCallbacks iBranchLogging) {
+        enableLogging(iBranchLogging, BranchLogger.BranchLogLevel.DEBUG);
     }
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1905,9 +1905,9 @@ public class Branch {
      * @param iBranchLogging Optional interface to receive logging from the SDK.
      * @param level The minimum log level for logging output.
      */
-    public static void enableLogging(IBranchLoggingCallbacks iBranchLogging, BranchLogger.BranchLogLevel level) {
+    private static void enableLogging(IBranchLoggingCallbacks iBranchLogging, BranchLogger.BranchLogLevel level) {
         BranchLogger.setLoggerCallback(iBranchLogging);
-        BranchLogger.setMinimumLogLevel(level);
+        BranchLogger.setLogLevel(level);
         BranchLogger.setLoggingEnabled(true);
         BranchLogger.logAlways(GOOGLE_VERSION_TAG);
     }
@@ -1920,14 +1920,24 @@ public class Branch {
     }
 
     /**
-     * Enable Logging, independent of Debug Mode. Defaults to DEBUG level.
+     * Enable Logging, independent of Debug Mode. Set to VERBOSE level.
      * Implement a callback to receive logging from the SDK directly to your
      * own logging solution. If null, and enabled, the default android.util.Log is used.
      *
      * @param iBranchLogging Optional interface to receive logging from the SDK.
      */
     public static void enableLogging(IBranchLoggingCallbacks iBranchLogging) {
-        enableLogging(iBranchLogging, BranchLogger.BranchLogLevel.DEBUG);
+        enableLogging(iBranchLogging, BranchLogger.BranchLogLevel.VERBOSE);
+    }
+
+    /**
+     * Enable logging with a specific log level.
+     *
+     * @param level The minimum log level for logging output.
+     */
+    public static void enableLogging(BranchLogger.BranchLogLevel level) {
+        enableLogging(null, level);
+
     }
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1907,7 +1907,7 @@ public class Branch {
      */
     private static void enableLogging(IBranchLoggingCallbacks iBranchLogging, BranchLogger.BranchLogLevel level) {
         BranchLogger.setLoggerCallback(iBranchLogging);
-        BranchLogger.setLogLevel(level);
+        BranchLogger.setLoggingLevel(level);
         BranchLogger.setLoggingEnabled(true);
         BranchLogger.logAlways(GOOGLE_VERSION_TAG);
     }

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchLogger.kt
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchLogger.kt
@@ -10,11 +10,20 @@ object BranchLogger {
 
     private const val TAG = "BranchSDK"
 
+    enum class BranchLogLevel(val level: Int) {
+        ERROR(1), WARN(2), INFO(3), DEBUG(4), VERBOSE(5)
+    }
+
+    @JvmStatic
+    var minimumLogLevel: BranchLogLevel = BranchLogLevel.DEBUG
+
     @JvmStatic
     var loggingEnabled = false
     
     @JvmStatic
     var loggerCallback: IBranchLoggingCallbacks? = null
+
+    private fun shouldLog(level: BranchLogLevel): Boolean = level.level <= minimumLogLevel.level
 
     /**
      * <p>Creates a <b>Error</b> message in the debugger. If debugging is disabled, this will fail silently.</p>
@@ -23,11 +32,10 @@ object BranchLogger {
      */
     @JvmStatic
     fun e(message: String) {
-        if (loggingEnabled && message.isNotEmpty()) {
+        if (loggingEnabled && shouldLog(BranchLogLevel.ERROR) && message.isNotEmpty()) {
             if (useCustomLogger()) {
                 loggerCallback?.onBranchLog(message, "ERROR")
-            }
-            else {
+            } else {
                 Log.e(TAG, message)
             }
         }
@@ -40,11 +48,10 @@ object BranchLogger {
      */
     @JvmStatic
     fun w(message: String) {
-        if (loggingEnabled && message.isNotEmpty()) {
+        if (loggingEnabled && shouldLog(BranchLogLevel.WARN) && message.isNotEmpty()) {
             if (useCustomLogger()) {
                 loggerCallback?.onBranchLog(message, "WARN")
-            }
-            else {
+            } else {
                 Log.w(TAG, message)
             }
         }
@@ -57,11 +64,10 @@ object BranchLogger {
      */
     @JvmStatic
     fun i(message: String) {
-        if (loggingEnabled && message.isNotEmpty()) {
+        if (loggingEnabled && shouldLog(BranchLogLevel.INFO) && message.isNotEmpty()) {
             if(useCustomLogger()) {
                 loggerCallback?.onBranchLog(message, "INFO")
-            }
-            else {
+            } else {
                 Log.i(TAG, message)
             }
         }
@@ -74,11 +80,10 @@ object BranchLogger {
      */
     @JvmStatic
     fun d(message: String?) {
-        if (loggingEnabled && message?.isNotEmpty() == true) {
+        if (loggingEnabled && shouldLog(BranchLogLevel.DEBUG) && message?.isNotEmpty() == true) {
             if (useCustomLogger()) {
                 loggerCallback?.onBranchLog(message, "DEBUG")
-            }
-            else {
+            } else {
                 Log.d(TAG, message)
             }
         }
@@ -91,11 +96,10 @@ object BranchLogger {
      */
     @JvmStatic
     fun v(message: String) {
-        if (loggingEnabled && message.isNotEmpty()) {
+        if (loggingEnabled && shouldLog(BranchLogLevel.VERBOSE) && message.isNotEmpty()) {
             if (useCustomLogger()) {
                 loggerCallback?.onBranchLog(message, "VERBOSE")
-            }
-            else {
+            } else {
                 Log.v(TAG, message)
             }
         }
@@ -106,8 +110,7 @@ object BranchLogger {
         if (message.isNotEmpty()) {
             if (useCustomLogger()) {
                 loggerCallback?.onBranchLog(message, "INFO")
-            }
-            else {
+            } else {
                 Log.i(TAG, message)
             }
         }

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchLogger.kt
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchLogger.kt
@@ -15,7 +15,7 @@ object BranchLogger {
     }
 
     @JvmStatic
-    var logLevel: BranchLogLevel = BranchLogLevel.DEBUG
+    var loggingLevel: BranchLogLevel = BranchLogLevel.DEBUG
 
     @JvmStatic
     var loggingEnabled = false
@@ -23,7 +23,7 @@ object BranchLogger {
     @JvmStatic
     var loggerCallback: IBranchLoggingCallbacks? = null
 
-    private fun shouldLog(level: BranchLogLevel): Boolean = level.level <= logLevel.level
+    private fun shouldLog(level: BranchLogLevel): Boolean = level.level <= loggingLevel.level
 
     /**
      * <p>Creates a <b>Error</b> message in the debugger. If debugging is disabled, this will fail silently.</p>

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchLogger.kt
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchLogger.kt
@@ -15,7 +15,7 @@ object BranchLogger {
     }
 
     @JvmStatic
-    var minimumLogLevel: BranchLogLevel = BranchLogLevel.DEBUG
+    var logLevel: BranchLogLevel = BranchLogLevel.DEBUG
 
     @JvmStatic
     var loggingEnabled = false
@@ -23,7 +23,7 @@ object BranchLogger {
     @JvmStatic
     var loggerCallback: IBranchLoggingCallbacks? = null
 
-    private fun shouldLog(level: BranchLogLevel): Boolean = level.level <= minimumLogLevel.level
+    private fun shouldLog(level: BranchLogLevel): Boolean = level.level <= logLevel.level
 
     /**
      * <p>Creates a <b>Error</b> message in the debugger. If debugging is disabled, this will fail silently.</p>

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestQueue.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestQueue.java
@@ -184,7 +184,7 @@ public class ServerRequestQueue {
 
     public void printQueue(){
         // Only print the queue if the log level is verbose
-        if (BranchLogger.getMinimumLogLevel().getLevel() == BranchLogger.BranchLogLevel.VERBOSE.getLevel()) {
+        if (BranchLogger.getLogLevel().getLevel() == BranchLogger.BranchLogLevel.VERBOSE.getLevel()) {
             synchronized (reqQueueLockObject) {
                 StringBuilder stringBuilder = new StringBuilder();
                 for (int i = 0; i < queue.size(); i++) {

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestQueue.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestQueue.java
@@ -7,7 +7,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Handler;
 import android.os.Looper;
-import android.text.TextUtils;
 
 import androidx.annotation.Nullable;
 
@@ -15,12 +14,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.ConcurrentModificationException;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -184,7 +179,7 @@ public class ServerRequestQueue {
 
     public void printQueue(){
         // Only print the queue if the log level is verbose
-        if (BranchLogger.getLogLevel().getLevel() == BranchLogger.BranchLogLevel.VERBOSE.getLevel()) {
+        if (BranchLogger.getLoggingLevel().getLevel() == BranchLogger.BranchLogLevel.VERBOSE.getLevel()) {
             synchronized (reqQueueLockObject) {
                 StringBuilder stringBuilder = new StringBuilder();
                 for (int i = 0; i < queue.size(); i++) {

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestQueue.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestQueue.java
@@ -183,12 +183,15 @@ public class ServerRequestQueue {
     }
 
     public void printQueue(){
-        synchronized (reqQueueLockObject){
-            StringBuilder stringBuilder = new StringBuilder();
-            for(int i = 0; i < queue.size(); i++){
-                stringBuilder.append(queue.get(i)).append(" with locks ").append(queue.get(i).printWaitLocks()).append("\n");
+        // Only print the queue if the log level is verbose
+        if (BranchLogger.getMinimumLogLevel().getLevel() == BranchLogger.BranchLogLevel.VERBOSE.getLevel()) {
+            synchronized (reqQueueLockObject) {
+                StringBuilder stringBuilder = new StringBuilder();
+                for (int i = 0; i < queue.size(); i++) {
+                    stringBuilder.append(queue.get(i)).append(" with locks ").append(queue.get(i).printWaitLocks()).append("\n");
+                }
+                BranchLogger.v("Queue is: " + stringBuilder);
             }
-            BranchLogger.v("Queue is: " + stringBuilder);
         }
     }
     


### PR DESCRIPTION
## Reference
SDK-2384 -- Add setting log levels to BranchLogger

## Description
Add a new way to set the minimum log level in the BranchLogger class by creating BranchLogLevel. This allows us to add log level checks throughout the SDK and gives clients the ability to reduce logs if desired.

## Testing Instructions
Call the new enabledLogging methods with the various BranchLogLevels and observe that only the correct logs are appearing.

## Risk Assessment [ `LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
