### PR TITLE
[SDK-2444] Support for setting FB App ID through branch.json

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -379,6 +379,8 @@ public class Branch {
 
             BranchUtil.setAPIBaseUrlFromConfig(context);
 
+            BranchUtil.setFbAppIdFromConfig(context);
+
             BranchUtil.setTestMode(BranchUtil.checkTestMode(context));
             branchReferral_ = initBranchSDK(context, BranchUtil.readBranchKey(context));
             getPreinstallSystemData(branchReferral_, context);
@@ -407,7 +409,7 @@ public class Branch {
             deferInitForPluginRuntime(BranchUtil.getDeferInitForPluginRuntimeConfig(context));
 
             BranchUtil.setAPIBaseUrlFromConfig(context);
-
+            BranchUtil.setFbAppIdFromConfig(context);
             BranchUtil.setTestMode(BranchUtil.checkTestMode(context));
             // If a Branch key is passed already use it. Else read the key
             if (!isValidBranchKey(branchKey)) {
@@ -2561,7 +2563,17 @@ public class Branch {
         PrefHelper.useEUEndpoint(true);
     }
 
+    /**
+     * Sets the Facebook App ID for the Branch instance.
+     *
+     * @param fbAppID The Facebook App ID as a {@link String}.
+     */
     public static void setFBAppID(String fbAppID) {
-        PrefHelper.fbAppId_ = fbAppID;
+        if (!TextUtils.isEmpty(fbAppID)) {
+            PrefHelper.fbAppId_ = fbAppID;
+            BranchLogger.v("setFBAppID to " + fbAppID);
+        } else {
+            BranchLogger.w("setFBAppID: fbAppID cannot be empty or null");
+        }
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchJsonConfig.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchJsonConfig.java
@@ -207,10 +207,15 @@ public class BranchJsonConfig {
 
     @Nullable
     public String getFbAppId() {
-        if (mConfiguration == null) return null;
+        if (mConfiguration == null) {
+            return null;
+        }
 
         try {
-            if (!mConfiguration.has(BranchJsonKey.fbAppId.toString())) return null;
+            if (!mConfiguration.has(BranchJsonKey.fbAppId.toString())) {
+                return null;
+            }
+            
             return mConfiguration.getString(BranchJsonKey.fbAppId.toString());
         }
         catch (JSONException exception) {

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchJsonConfig.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchJsonConfig.java
@@ -30,7 +30,8 @@ public class BranchJsonConfig {
         useTestInstance,
         enableLogging,
         deferInitForPluginRuntime,
-        apiUrl
+        apiUrl,
+        fbAppId
     }
 
     /*
@@ -46,7 +47,8 @@ public class BranchJsonConfig {
             "useTestInstance": true,
             "enableLogging": true,
             "deferInitForPluginRuntime": true,
-            "apiUrl": "https://api2.branch.io"
+            "apiUrl": "https://api2.branch.io",
+            "fbAppId": "xyz123456789"
        }
     */
 
@@ -196,6 +198,20 @@ public class BranchJsonConfig {
         try {
             if (!mConfiguration.has(BranchJsonKey.apiUrl.toString())) return null;
             return mConfiguration.getString(BranchJsonKey.apiUrl.toString());
+        }
+        catch (JSONException exception) {
+            Log.e(TAG, "Error parsing branch.json: " + exception.getMessage());
+            return null;
+        }
+    }
+
+    @Nullable
+    public String getFbAppId() {
+        if (mConfiguration == null) return null;
+
+        try {
+            if (!mConfiguration.has(BranchJsonKey.fbAppId.toString())) return null;
+            return mConfiguration.getString(BranchJsonKey.fbAppId.toString());
         }
         catch (JSONException exception) {
             Log.e(TAG, "Error parsing branch.json: " + exception.getMessage());

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
@@ -143,7 +143,17 @@ public class BranchUtil {
     public static void setAPIBaseUrlFromConfig(Context context) {
         BranchJsonConfig jsonConfig = BranchJsonConfig.getInstance(context);
         String apiUrl = jsonConfig.getAPIUrl();
-        Branch.setAPIUrl(apiUrl);
+        if (!TextUtils.isEmpty(apiUrl)) {
+            Branch.setAPIUrl(apiUrl);
+        }
+    }
+
+    public static void setFbAppIdFromConfig(Context context) {
+        BranchJsonConfig jsonConfig = BranchJsonConfig.getInstance(context);
+        String fbAppId = jsonConfig.getFbAppId();
+        if (!TextUtils.isEmpty(fbAppId)) {
+            Branch.setFBAppID(fbAppId);
+        }
     }
 
     /**


### PR DESCRIPTION
## Reference
SDK-2444 -- Support setting FB App ID through branch.json

## Description
To support Meta Install Referrers on plugins, we need to enable clients to set the FB App ID before the install request is sent. Instead of using `setFBAppId()` directly, clients can now set it in the branch.json file.

This update also resolves a minor bug where `setAPIUrl()` was called every time, resulting in a warning message: "setAPIUrl: URL cannot be empty or null". This issue occurred because the method was invoked every time the JSON was checked, even if it was empty. Now, `setAPIUrl()` is only called when apiUrl is present in branch.json

## Testing Instructions
<!-- TESTING INSTRUCTIONS -->
Set fbAppId in branch.json and check if its being proper set and used.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
