### PR TITLE
Reinstallation workflow Fix

### DIFF
--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -43,20 +43,21 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       # to reduce complexity, testbed app uses sdk as a project reference
       - name: Decode Keystore
-        if: ${{ !( github.ref == 'refs/heads/Reinstallationtest-workflow-fix-')}}
         env:
             ENCODED_STRING: ${{ secrets.KEYSTORE }}
         run: |
             cd sdk
             echo $ENCODED_STRING | base64 -d > ./Branch-SDK-Automation-TestBed/automationSigningKeys.jks
-            cp ./Branch-SDK-Automation-TestBed/automationSigningKeys.jks ../previousVersionSDK/Branch-SDK-Automation-TestBed/
-            ls -la
-            ls -la ./Branch-SDK-Automation-TestBed/
+     - name: Decode Keystore for Reinstallation
+        if: ${{ !( github.ref == 'refs/heads/Reinstallationtest-workflow-fix-')}}
+        env:
+            ENCODED_STRING: ${{ secrets.KEYSTORE }}
+        run: |
+            cd previousVersionSDK
+            echo $ENCODED_STRING | base64 -d > ./Branch-SDK-Automation-TestBed/automationSigningKeys.jks
       - name: Build testbed app and Link Click Test App
         run: |
           cd sdk
-          ls -la
-          ls -la ./Branch-SDK-Automation-TestBed/
           ./gradlew Branch-SDK-Automation-TestBed:assembleDebug
           ./gradlew branchsdk-link-clicktest:assembleDebug
         env:

--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -90,7 +90,7 @@ jobs:
         if: ${{ !( github.ref == 'refs/heads/master')}}
         run: |
           response=$(curl -X POST https://api-cloud.browserstack.com/app-automate/upload -u "${{ secrets.BROWSER_STACK_USER }}:${{ secrets.BROWSER_STACK_KEY }}"  -F "file=@previousVersionSDK/Branch-SDK-Automation-TestBed/build/outputs/apk/debug/Branch-SDK-Automation-TestBed-debug.apk")
-          parsed=$(echo $response | jq ".app_url")
+          parsed=$(echo $response | jq -r ".app_url")
           echo "::add-mask::$parsed"
           echo "BrowserStackAndroidOldBuildKey=$parsed" >> "$GITHUB_ENV"
       # automation is compatible with java 11

--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -33,7 +33,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: qa
-          ref: Update-Test-Data
           repository: BranchMetrics/qentelli-saas-sdk-testing-automation
           token: ${{ secrets.BRANCHLET_ACCESS_TOKEN_PUBLIC }}
       # repo's gradle is configured to run on java 17

--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -77,7 +77,8 @@ jobs:
         run: |
           response=$(curl -X POST https://api-cloud.browserstack.com/app-automate/upload -u "${{ secrets.BROWSER_STACK_USER }}:${{ secrets.BROWSER_STACK_KEY }}"  -F "file=@sdk/Branch-SDK-Automation-TestBed/build/outputs/apk/debug/Branch-SDK-Automation-TestBed-debug.apk")
           parsed=$(echo $response | jq ".app_url")
-          echo "::add-mask::$parsed"
+          echo "New App is ========="
+          echo "$parsed"
           echo "BrowserStackAndroidNewBuildKey=$parsed" >> "$GITHUB_ENV"
       - name: Upload Link Click Test App APK to BrowserStack
         run: |
@@ -90,7 +91,8 @@ jobs:
         run: |
           response=$(curl -X POST https://api-cloud.browserstack.com/app-automate/upload -u "${{ secrets.BROWSER_STACK_USER }}:${{ secrets.BROWSER_STACK_KEY }}"  -F "file=@previousVersionSDK/Branch-SDK-Automation-TestBed/build/outputs/apk/debug/Branch-SDK-Automation-TestBed-debug.apk")
           parsed=$(echo $response | jq ".app_url")
-          echo "::add-mask::$parsed"
+          echo "Old app is ========="
+          echo "$parsed"
           echo "BrowserStackAndroidOldBuildKey=$parsed" >> "$GITHUB_ENV"
       # automation is compatible with java 11
       - name: Setup java for automation

--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -25,7 +25,7 @@ jobs:
       # point to automation master branch by default
       - name: Checkout Master SDK repo with testbed app for Reinstallation tests
         uses: actions/checkout@v3
-        if: ${{ !( github.ref == 'refs/heads/Reinstallationtest-workflow-fix-')}}
+        if: ${{ !( github.ref == 'refs/heads/master')}}
         with:
           path: previousVersionSDK
           ref: master
@@ -49,7 +49,7 @@ jobs:
             cd sdk
             echo $ENCODED_STRING | base64 -d > ./Branch-SDK-Automation-TestBed/automationSigningKeys.jks
       - name: Decode Keystore for Reinstallation
-        if: ${{ !( github.ref == 'refs/heads/Reinstallationtest-workflow-fix-')}}
+        if: ${{ !( github.ref == 'refs/heads/master')}}
         env:
             ENCODED_STRING: ${{ secrets.KEYSTORE }}
         run: |
@@ -65,7 +65,7 @@ jobs:
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
           SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
       - name: Build Master testbed app for Reinstallation tests
-        if: ${{ !( github.ref == 'refs/heads/Reinstallationtest-workflow-fix-')}}
+        if: ${{ !( github.ref == 'refs/heads/master')}}
         run: |
           cd previousVersionSDK
           ./gradlew Branch-SDK-Automation-TestBed:assembleDebug
@@ -86,7 +86,7 @@ jobs:
           echo "::add-mask::$parsed"
           echo "BrowserStackLinkClickAppURL=$parsed" >> "$GITHUB_ENV"
       - name: Upload APK from Master branch to BrowserStack for Reinstallation tests
-        if: ${{ !( github.ref == 'refs/heads/Reinstallationtest-workflow-fix-')}}
+        if: ${{ !( github.ref == 'refs/heads/master')}}
         run: |
           response=$(curl -X POST https://api-cloud.browserstack.com/app-automate/upload -u "${{ secrets.BROWSER_STACK_USER }}:${{ secrets.BROWSER_STACK_KEY }}"  -F "file=@previousVersionSDK/Branch-SDK-Automation-TestBed/build/outputs/apk/debug/Branch-SDK-Automation-TestBed-debug.apk")
           parsed=$(echo $response | jq ".app_url")

--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -84,16 +84,15 @@ jobs:
         run: |
           response=$(curl -X POST https://api-cloud.browserstack.com/app-automate/upload -u "${{ secrets.BROWSER_STACK_USER }}:${{ secrets.BROWSER_STACK_KEY }}"  -F "file=@sdk/branchsdk-link-clicktest/build/outputs/apk/debug/branchsdk-link-clicktest-debug.apk")
           parsed=$(echo $response | jq ".app_url")
-          echo "::add-mask::$parsed"
           echo "BrowserStackLinkClickAppURL=$parsed" >> "$GITHUB_ENV"
       - name: Upload APK from Master branch to BrowserStack for Reinstallation tests
         if: ${{ !( github.ref == 'refs/heads/master')}}
         run: |
           response=$(curl -X POST https://api-cloud.browserstack.com/app-automate/upload -u "${{ secrets.BROWSER_STACK_USER }}:${{ secrets.BROWSER_STACK_KEY }}"  -F "file=@previousVersionSDK/Branch-SDK-Automation-TestBed/build/outputs/apk/debug/Branch-SDK-Automation-TestBed-debug.apk")
-          parsed=$(echo $response | jq ".app_url")
+          parsed2=$(echo $response | jq ".app_url")
           echo "Old app is ========="
-          echo "$parsed"
-          echo "BrowserStackAndroidOldBuildKey=$parsed" >> "$GITHUB_ENV"
+          echo "$parsed2"
+          echo "BrowserStackAndroidOldBuildKey=$parsed2" >> "$GITHUB_ENV"
       # automation is compatible with java 11
       - name: Setup java for automation
         uses: actions/setup-java@v3

--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
             cd sdk
             echo $ENCODED_STRING | base64 -d > ./Branch-SDK-Automation-TestBed/automationSigningKeys.jks
-     - name: Decode Keystore for Reinstallation
+      - name: Decode Keystore for Reinstallation
         if: ${{ !( github.ref == 'refs/heads/Reinstallationtest-workflow-fix-')}}
         env:
             ENCODED_STRING: ${{ secrets.KEYSTORE }}

--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -77,13 +77,13 @@ jobs:
       - name: Upload APK to BrowserStack
         run: |
           response=$(curl -X POST https://api-cloud.browserstack.com/app-automate/upload -u "${{ secrets.BROWSER_STACK_USER }}:${{ secrets.BROWSER_STACK_KEY }}"  -F "file=@sdk/Branch-SDK-Automation-TestBed/build/outputs/apk/debug/Branch-SDK-Automation-TestBed-debug.apk")
-          parsed=$(echo $response | jq ".app_url")
+          parsed=$(echo $response | jq -r ".app_url")
           echo "::add-mask::$parsed"
           echo "BrowserStackAndroidNewBuildKey=$parsed" >> "$GITHUB_ENV"
       - name: Upload Link Click Test App APK to BrowserStack
         run: |
           response=$(curl -X POST https://api-cloud.browserstack.com/app-automate/upload -u "${{ secrets.BROWSER_STACK_USER }}:${{ secrets.BROWSER_STACK_KEY }}"  -F "file=@sdk/branchsdk-link-clicktest/build/outputs/apk/debug/branchsdk-link-clicktest-debug.apk")
-          parsed=$(echo $response | jq ".app_url")
+          parsed=$(echo $response | jq -r ".app_url")
           echo "::add-mask::$parsed"
           echo "BrowserStackLinkClickAppURL=$parsed" >> "$GITHUB_ENV"
       - name: Upload APK from Master branch to BrowserStack for Reinstallation tests

--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -78,6 +78,7 @@ jobs:
           response=$(curl -X POST https://api-cloud.browserstack.com/app-automate/upload -u "${{ secrets.BROWSER_STACK_USER }}:${{ secrets.BROWSER_STACK_KEY }}"  -F "file=@sdk/Branch-SDK-Automation-TestBed/build/outputs/apk/debug/Branch-SDK-Automation-TestBed-debug.apk")
           parsed=$(echo $response | jq ".app_url")
           echo "New App is ========="
+          echo "$response"
           echo "$parsed"
           echo "BrowserStackAndroidNewBuildKey=$parsed" >> "$GITHUB_ENV"
       - name: Upload Link Click Test App APK to BrowserStack
@@ -91,6 +92,7 @@ jobs:
           response=$(curl -X POST https://api-cloud.browserstack.com/app-automate/upload -u "${{ secrets.BROWSER_STACK_USER }}:${{ secrets.BROWSER_STACK_KEY }}"  -F "file=@previousVersionSDK/Branch-SDK-Automation-TestBed/build/outputs/apk/debug/Branch-SDK-Automation-TestBed-debug.apk")
           parsed2=$(echo $response | jq ".app_url")
           echo "Old app is ========="
+          echo "$response"
           echo "$parsed2"
           echo "BrowserStackAndroidOldBuildKey=$parsed2" >> "$GITHUB_ENV"
       # automation is compatible with java 11

--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: qa
+          ref: Update-Test-Data
           repository: BranchMetrics/qentelli-saas-sdk-testing-automation
           token: ${{ secrets.BRANCHLET_ACCESS_TOKEN_PUBLIC }}
       # repo's gradle is configured to run on java 17
@@ -77,24 +78,21 @@ jobs:
         run: |
           response=$(curl -X POST https://api-cloud.browserstack.com/app-automate/upload -u "${{ secrets.BROWSER_STACK_USER }}:${{ secrets.BROWSER_STACK_KEY }}"  -F "file=@sdk/Branch-SDK-Automation-TestBed/build/outputs/apk/debug/Branch-SDK-Automation-TestBed-debug.apk")
           parsed=$(echo $response | jq ".app_url")
-          echo "New App is ========="
-          echo "$response"
-          echo "$parsed"
+          echo "::add-mask::$parsed"
           echo "BrowserStackAndroidNewBuildKey=$parsed" >> "$GITHUB_ENV"
       - name: Upload Link Click Test App APK to BrowserStack
         run: |
           response=$(curl -X POST https://api-cloud.browserstack.com/app-automate/upload -u "${{ secrets.BROWSER_STACK_USER }}:${{ secrets.BROWSER_STACK_KEY }}"  -F "file=@sdk/branchsdk-link-clicktest/build/outputs/apk/debug/branchsdk-link-clicktest-debug.apk")
           parsed=$(echo $response | jq ".app_url")
+          echo "::add-mask::$parsed"
           echo "BrowserStackLinkClickAppURL=$parsed" >> "$GITHUB_ENV"
       - name: Upload APK from Master branch to BrowserStack for Reinstallation tests
         if: ${{ !( github.ref == 'refs/heads/master')}}
         run: |
           response=$(curl -X POST https://api-cloud.browserstack.com/app-automate/upload -u "${{ secrets.BROWSER_STACK_USER }}:${{ secrets.BROWSER_STACK_KEY }}"  -F "file=@previousVersionSDK/Branch-SDK-Automation-TestBed/build/outputs/apk/debug/Branch-SDK-Automation-TestBed-debug.apk")
-          parsed2=$(echo $response | jq ".app_url")
-          echo "Old app is ========="
-          echo "$response"
-          echo "$parsed2"
-          echo "BrowserStackAndroidOldBuildKey=$parsed2" >> "$GITHUB_ENV"
+          parsed=$(echo $response | jq ".app_url")
+          echo "::add-mask::$parsed"
+          echo "BrowserStackAndroidOldBuildKey=$parsed" >> "$GITHUB_ENV"
       # automation is compatible with java 11
       - name: Setup java for automation
         uses: actions/setup-java@v3

--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -25,7 +25,7 @@ jobs:
       # point to automation master branch by default
       - name: Checkout Master SDK repo with testbed app for Reinstallation tests
         uses: actions/checkout@v3
-        if: ${{ !( github.ref == 'refs/heads/master')}}
+        if: ${{ !( github.ref == 'refs/heads/Reinstallationtest-workflow-fix-')}}
         with:
           path: previousVersionSDK
           ref: master

--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -43,6 +43,7 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       # to reduce complexity, testbed app uses sdk as a project reference
       - name: Decode Keystore
+        if: ${{ !( github.ref == 'refs/heads/Reinstallationtest-workflow-fix-')}}
         env:
             ENCODED_STRING: ${{ secrets.KEYSTORE }}
         run: |
@@ -63,7 +64,7 @@ jobs:
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
           SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
       - name: Build Master testbed app for Reinstallation tests
-        if: ${{ !( github.ref == 'refs/heads/master')}}
+        if: ${{ !( github.ref == 'refs/heads/Reinstallationtest-workflow-fix-')}}
         run: |
           cd previousVersionSDK
           ./gradlew Branch-SDK-Automation-TestBed:assembleDebug
@@ -84,7 +85,7 @@ jobs:
           echo "::add-mask::$parsed"
           echo "BrowserStackLinkClickAppURL=$parsed" >> "$GITHUB_ENV"
       - name: Upload APK from Master branch to BrowserStack for Reinstallation tests
-        if: ${{ !( github.ref == 'refs/heads/master')}}
+        if: ${{ !( github.ref == 'refs/heads/Reinstallationtest-workflow-fix-')}}
         run: |
           response=$(curl -X POST https://api-cloud.browserstack.com/app-automate/upload -u "${{ secrets.BROWSER_STACK_USER }}:${{ secrets.BROWSER_STACK_KEY }}"  -F "file=@previousVersionSDK/Branch-SDK-Automation-TestBed/build/outputs/apk/debug/Branch-SDK-Automation-TestBed-debug.apk")
           parsed=$(echo $response | jq ".app_url")

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -29,8 +29,6 @@ class DeviceInfo {
     private final SystemObserver systemObserver_;
     private final Context context_;
 
-    private final int  test;
-
     /**
      * Get the singleton instance for this class
      *
@@ -45,7 +43,6 @@ class DeviceInfo {
     DeviceInfo(Context context) {
         context_ = context;
         systemObserver_ = new SystemObserverInstance();
-        test = 123;
     }
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -29,6 +29,8 @@ class DeviceInfo {
     private final SystemObserver systemObserver_;
     private final Context context_;
 
+    private final int  test;
+
     /**
      * Get the singleton instance for this class
      *
@@ -43,6 +45,7 @@ class DeviceInfo {
     DeviceInfo(Context context) {
         context_ = context;
         systemObserver_ = new SystemObserverInstance();
+        test = 123;
     }
 
     /**


### PR DESCRIPTION
## Reference
QSS-112 - Reinstallation Scenario
https://branch.atlassian.net/browse/QSS-112

## Description
Re-installation test was failing, when ran using Github action, because of extra quotes in envirnoment variables and missing check for signing.

## Testing Instructions
Run appium tests and validate that Re-installation test runs. However, with current branch test will fail, because SDK and Automation Test Bed binaries are exactly same to the one in master branch. So browserstack will not load binary from this branch. Its a duplicate binary. In order to pass test, make some changes in SDK and then run. 

Example : I had added a variable and initalized it. So that binary in this branch is not duplicate to the one in master branch.

```
private final int test;

DeviceInfo(Context context) {
        context_ = context;
        systemObserver_ = new SystemObserverInstance();
        test = 123;
    }

```

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [ X] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

cc @BranchMetrics/saas-sdk-devs for visibility.
