### PR TITLE
[SDK-2459] Implement Consumer Protection Preferences

### DIFF
--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           path: qa
           repository: BranchMetrics/qentelli-saas-sdk-testing-automation
+          ref: SDK-2465
           token: ${{ secrets.BRANCHLET_ACCESS_TOKEN_PUBLIC }}
       # repo's gradle is configured to run on java 17
       - name: Setup java for gradle

--- a/.github/workflows/appium-automation.yml
+++ b/.github/workflows/appium-automation.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           path: qa
           repository: BranchMetrics/qentelli-saas-sdk-testing-automation
-          ref: SDK-2465
           token: ${{ secrets.BRANCHLET_ACCESS_TOKEN_PUBLIC }}
       # repo's gradle is configured to run on java 17
       - name: Setup java for gradle

--- a/Branch-SDK-Automation-TestBed/src/main/java/io/branch/branchandroiddemo/BranchWrapper.java
+++ b/Branch-SDK-Automation-TestBed/src/main/java/io/branch/branchandroiddemo/BranchWrapper.java
@@ -1,10 +1,5 @@
 package io.branch.branchandroiddemo;
 
-import static android.content.Intent.getIntent;
-import static androidx.core.content.ContextCompat.startActivity;
-
-import static java.security.AccessController.getContext;
-
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -12,20 +7,17 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
-import android.text.TextUtils;
 import android.util.Log;
 
 import org.json.JSONObject;
 
 import java.io.IOException;
-import java.util.Objects;
 
 import io.branch.branchandroiddemo.activities.LogDataActivity;
 import io.branch.branchandroiddemo.activities.ShowQRCodeActivity;
 import io.branch.indexing.BranchUniversalObject;
 import io.branch.referral.Branch;
 import io.branch.referral.BranchError;
-import io.branch.referral.Defines;
 import io.branch.referral.QRCode.BranchQRCode;
 import io.branch.referral.util.BranchEvent;
 import io.branch.referral.util.LinkProperties;
@@ -250,28 +242,6 @@ public class BranchWrapper {
             }
         } else {
             showLogWindow("Test Data : Null", true, ctx, Constants.CREATE_QR_CODE);
-        }
-    }
-
-    public void setAttributionLevel(Intent intent){
-        Common.getInstance().clearLog();
-        String testDataStr = intent.getStringExtra("testData");
-        Log.d("Branch SDK", "Intent extra 'testData:'\n" + testDataStr);
-        if (testDataStr != null) {
-
-            TestData testDataObj = new TestData();
-            String level = testDataObj.getParamValue(testDataStr,"cpp_level");
-
-            //Set the level based on the level value
-            try {
-                Defines.BranchAttributionLevel attributionLevel = Defines.BranchAttributionLevel.valueOf(level.toUpperCase());
-                Branch.getInstance().setConsumerProtectionAttributionLevel(attributionLevel);
-            } catch (IllegalArgumentException e) {
-                showLogWindow("Invalid cpp_level", true, ctx, Constants.SET_ATTRIBUTION_LEVEL);
-            }
-
-        } else {
-            showLogWindow( "Test Data: Null" , true, ctx,Constants.SET_ATTRIBUTION_LEVEL);
         }
     }
 }

--- a/Branch-SDK-Automation-TestBed/src/main/java/io/branch/branchandroiddemo/BranchWrapper.java
+++ b/Branch-SDK-Automation-TestBed/src/main/java/io/branch/branchandroiddemo/BranchWrapper.java
@@ -260,24 +260,18 @@ public class BranchWrapper {
         if (testDataStr != null) {
 
             TestData testDataObj = new TestData();
-            String level = testDataObj.getParamValue(testDataStr,"consumer_protection_attribution_level");
+            String level = testDataObj.getParamValue(testDataStr,"cpp_level");
 
             //Set the level based on the level value
-            if (Objects.equals(level, "0")) {
-                Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel.FULL);
-            } else if (Objects.equals(level, "1")) {
-                Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel.REDUCED);
-            } else if (Objects.equals(level, "2")) {
-                Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel.MINIMAL);
-            } else if (Objects.equals(level, "3")) {
-                Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel.NONE);
-            } else {
-                showLogWindow("Invalid consumer_protection_attribution_level", true, ctx, Constants.SET_ATTRIBUTION_LEVEL);
+            try {
+                Defines.BranchAttributionLevel attributionLevel = Defines.BranchAttributionLevel.valueOf(level.toUpperCase());
+                Branch.getInstance().setConsumerProtectionAttributionLevel(attributionLevel);
+            } catch (IllegalArgumentException e) {
+                showLogWindow("Invalid cpp_level", true, ctx, Constants.SET_ATTRIBUTION_LEVEL);
             }
 
-
         } else {
-            showLogWindow( "Test Data : Null" , true, ctx,Constants.SET_ATTRIBUTION_LEVEL);
+            showLogWindow( "Test Data: Null" , true, ctx,Constants.SET_ATTRIBUTION_LEVEL);
         }
     }
 }

--- a/Branch-SDK-Automation-TestBed/src/main/java/io/branch/branchandroiddemo/BranchWrapper.java
+++ b/Branch-SDK-Automation-TestBed/src/main/java/io/branch/branchandroiddemo/BranchWrapper.java
@@ -18,12 +18,14 @@ import android.util.Log;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import io.branch.branchandroiddemo.activities.LogDataActivity;
 import io.branch.branchandroiddemo.activities.ShowQRCodeActivity;
 import io.branch.indexing.BranchUniversalObject;
 import io.branch.referral.Branch;
 import io.branch.referral.BranchError;
+import io.branch.referral.Defines;
 import io.branch.referral.QRCode.BranchQRCode;
 import io.branch.referral.util.BranchEvent;
 import io.branch.referral.util.LinkProperties;
@@ -248,6 +250,34 @@ public class BranchWrapper {
             }
         } else {
             showLogWindow("Test Data : Null", true, ctx, Constants.CREATE_QR_CODE);
+        }
+    }
+
+    public void setAttributionLevel(Intent intent){
+        Common.getInstance().clearLog();
+        String testDataStr = intent.getStringExtra("testData");
+        Log.d("Branch SDK", "Intent extra 'testData:'\n" + testDataStr);
+        if (testDataStr != null) {
+
+            TestData testDataObj = new TestData();
+            String level = testDataObj.getParamValue(testDataStr,"consumer_protection_attribution_level");
+
+            //Set the level based on the level value
+            if (Objects.equals(level, "0")) {
+                Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel.FULL);
+            } else if (Objects.equals(level, "1")) {
+                Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel.REDUCED);
+            } else if (Objects.equals(level, "2")) {
+                Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel.MINIMAL);
+            } else if (Objects.equals(level, "3")) {
+                Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel.NONE);
+            } else {
+                showLogWindow("Invalid consumer_protection_attribution_level", true, ctx, Constants.SET_ATTRIBUTION_LEVEL);
+            }
+
+
+        } else {
+            showLogWindow( "Test Data : Null" , true, ctx,Constants.SET_ATTRIBUTION_LEVEL);
         }
     }
 }

--- a/Branch-SDK-Automation-TestBed/src/main/java/io/branch/branchandroiddemo/Constants.java
+++ b/Branch-SDK-Automation-TestBed/src/main/java/io/branch/branchandroiddemo/Constants.java
@@ -21,7 +21,5 @@ public interface Constants {
     String CREATE_QR_CODE = "CreateQRCode";
     String SET_DMA_Params = "SetDMAParams";
     String INIT_SESSION = "InitSession";
-
-    String SET_ATTRIBUTION_LEVEL = "SetAttributionLevel";
     String UNKNOWN = "Unknown";
 }

--- a/Branch-SDK-Automation-TestBed/src/main/java/io/branch/branchandroiddemo/Constants.java
+++ b/Branch-SDK-Automation-TestBed/src/main/java/io/branch/branchandroiddemo/Constants.java
@@ -21,5 +21,7 @@ public interface Constants {
     String CREATE_QR_CODE = "CreateQRCode";
     String SET_DMA_Params = "SetDMAParams";
     String INIT_SESSION = "InitSession";
+
+    String SET_ATTRIBUTION_LEVEL = "SetAttributionLevel";
     String UNKNOWN = "Unknown";
 }

--- a/Branch-SDK-Automation-TestBed/src/main/java/io/branch/branchandroiddemo/activities/MainActivity.java
+++ b/Branch-SDK-Automation-TestBed/src/main/java/io/branch/branchandroiddemo/activities/MainActivity.java
@@ -26,7 +26,7 @@ import io.branch.branchandroiddemo.TestData;
 
 public class MainActivity extends AppCompatActivity implements View.OnClickListener {
     private Button  btCreateDeepLink, btNativeShare, btTrackUser,
-             btCreateQrCode, btSetDMAParams, btLogEvent, btReadLogs, btInitSession, btSetAttributionLevel;
+             btCreateQrCode, btSetDMAParams, btLogEvent, btReadLogs, btInitSession;
     private TextView tvMessage, tvUrl;
     ToggleButton trackingCntrlBtn;
 
@@ -43,7 +43,6 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         btTrackUser = findViewById(R.id.bt_track_user);
         btInitSession = findViewById(R.id.bt_init_session);
         trackingCntrlBtn = findViewById(R.id.tracking_cntrl_btn);
-        btSetAttributionLevel = findViewById(R.id.bt_set_attribution_level);
 
         btCreateDeepLink.setOnClickListener(this);
         btNativeShare.setOnClickListener(this);
@@ -53,7 +52,6 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         btReadLogs.setOnClickListener(this);
         btTrackUser.setOnClickListener(this);
         btInitSession.setOnClickListener(this);
-        btSetAttributionLevel.setOnClickListener(this);
     }
 
     @Override
@@ -91,9 +89,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             branchWrapper.showLogWindow("",false, this, Constants.LOG_DATA);
         } else if (view == btCreateQrCode) {
             branchWrapper.getQRCode(this, getIntent(), MainActivity.this);
-        } else if (view == btSetAttributionLevel) {
-            branchWrapper.setAttributionLevel(getIntent());
-        }else {
+        } else {
             branchWrapper.showLogWindow("",false, this, Constants.UNKNOWN);
         }
     }

--- a/Branch-SDK-Automation-TestBed/src/main/java/io/branch/branchandroiddemo/activities/MainActivity.java
+++ b/Branch-SDK-Automation-TestBed/src/main/java/io/branch/branchandroiddemo/activities/MainActivity.java
@@ -26,7 +26,7 @@ import io.branch.branchandroiddemo.TestData;
 
 public class MainActivity extends AppCompatActivity implements View.OnClickListener {
     private Button  btCreateDeepLink, btNativeShare, btTrackUser,
-             btCreateQrCode, btSetDMAParams, btLogEvent, btReadLogs, btInitSession;
+             btCreateQrCode, btSetDMAParams, btLogEvent, btReadLogs, btInitSession, btSetAttributionLevel;
     private TextView tvMessage, tvUrl;
     ToggleButton trackingCntrlBtn;
 
@@ -43,6 +43,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         btTrackUser = findViewById(R.id.bt_track_user);
         btInitSession = findViewById(R.id.bt_init_session);
         trackingCntrlBtn = findViewById(R.id.tracking_cntrl_btn);
+        btSetAttributionLevel = findViewById(R.id.bt_set_attribution_level);
 
         btCreateDeepLink.setOnClickListener(this);
         btNativeShare.setOnClickListener(this);
@@ -52,6 +53,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         btReadLogs.setOnClickListener(this);
         btTrackUser.setOnClickListener(this);
         btInitSession.setOnClickListener(this);
+        btSetAttributionLevel.setOnClickListener(this);
     }
 
     @Override
@@ -89,6 +91,8 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             branchWrapper.showLogWindow("",false, this, Constants.LOG_DATA);
         } else if (view == btCreateQrCode) {
             branchWrapper.getQRCode(this, getIntent(), MainActivity.this);
+        } else if (view == btSetAttributionLevel) {
+            branchWrapper.setAttributionLevel(getIntent());
         }else {
             branchWrapper.showLogWindow("",false, this, Constants.UNKNOWN);
         }

--- a/Branch-SDK-Automation-TestBed/src/main/res/layout/activity_main.xml
+++ b/Branch-SDK-Automation-TestBed/src/main/res/layout/activity_main.xml
@@ -114,6 +114,18 @@
             android:layout_marginBottom="@dimen/_2sdp"
             android:text="Send Standard Event"
             android:textAllCaps="false" />
+
+        <Button
+            android:id="@+id/bt_set_attribution_level"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/_15sdp"
+            android:layout_marginTop="@dimen/_2sdp"
+            android:layout_marginEnd="@dimen/_15sdp"
+            android:layout_marginBottom="@dimen/_2sdp"
+            android:text="Set Attribution Level"
+            android:textAllCaps="false" />
+
         <Button
             android:id="@+id/bt_Read_Logs"
             android:layout_width="match_parent"

--- a/Branch-SDK-Automation-TestBed/src/main/res/layout/activity_main.xml
+++ b/Branch-SDK-Automation-TestBed/src/main/res/layout/activity_main.xml
@@ -116,17 +116,6 @@
             android:textAllCaps="false" />
 
         <Button
-            android:id="@+id/bt_set_attribution_level"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/_15sdp"
-            android:layout_marginTop="@dimen/_2sdp"
-            android:layout_marginEnd="@dimen/_15sdp"
-            android:layout_marginBottom="@dimen/_2sdp"
-            android:text="Set Attribution Level"
-            android:textAllCaps="false" />
-
-        <Button
             android:id="@+id/bt_Read_Logs"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/Branch-SDK-TestBed/src/main/AndroidManifest.xml
+++ b/Branch-SDK-TestBed/src/main/AndroidManifest.xml
@@ -114,7 +114,7 @@
         </activity>
 
         <activity android:name="io.branch.branchandroidtestbed.SettingsActivity" />
-
+        <activity android:name="io.branch.branchandroidtestbed.LogOutputActivity" />
         <activity android:name="io.branch.branchandroidtestbed.AutoDeepLinkTestActivity">
             <!-- Keys for auto deep linking this activity -->
             <meta-data

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import io.branch.interfaces.IBranchLoggingCallbacks;
 import io.branch.referral.Branch;
 import io.branch.referral.BranchLogger;
+import io.branch.referral.Defines;
 
 public final class CustomBranchApp extends Application {
     @Override
@@ -20,5 +21,8 @@ public final class CustomBranchApp extends Application {
         };
         Branch.enableLogging(BranchLogger.BranchLogLevel.VERBOSE); // Pass in iBranchLoggingCallbacks to enable logging redirects
         Branch.getAutoInstance(this);
+
+        Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel.MINIMAL);
+
     }
 }

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
@@ -17,15 +17,12 @@ public final class CustomBranchApp extends Application {
     public void onCreate() {
         super.onCreate();
 
-        IBranchLoggingCallbacks loggingCallbacks = new IBranchLoggingCallbacks() {
-            @Override
-            public void onBranchLog(String tag, String message) {
-                String logMessage = tag + ": " + message;
-                Log.d("BranchTestbed", logMessage);
-                saveLogToFile(logMessage);
-            }
+        IBranchLoggingCallbacks loggingCallbacks = (message, tag) -> {
+            Log.d("BranchTestbed", message);
+            saveLogToFile(message);
         };
         Branch.enableLogging(loggingCallbacks);
+
         Branch.getAutoInstance(this);
     }
 

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
@@ -3,6 +3,10 @@ package io.branch.branchandroidtestbed;
 import android.app.Application;
 import android.util.Log;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+
 import io.branch.interfaces.IBranchLoggingCallbacks;
 import io.branch.referral.Branch;
 import io.branch.referral.BranchLogger;
@@ -12,14 +16,37 @@ public final class CustomBranchApp extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-      
-        IBranchLoggingCallbacks iBranchLoggingCallbacks = new IBranchLoggingCallbacks() {
+
+        IBranchLoggingCallbacks loggingCallbacks = new IBranchLoggingCallbacks() {
             @Override
-            public void onBranchLog(String logMessage, String severityConstantName) {
-                Log.v( "CustomTag", logMessage);
+            public void onBranchLog(String tag, String message) {
+                String logMessage = tag + ": " + message;
+                Log.d("BranchTestbed", logMessage);
+                saveLogToFile(logMessage);
             }
         };
-        Branch.enableLogging(BranchLogger.BranchLogLevel.VERBOSE); // Pass in iBranchLoggingCallbacks to enable logging redirects
+        Branch.enableLogging(loggingCallbacks);
         Branch.getAutoInstance(this);
     }
+
+    private void saveLogToFile(String logMessage) {
+        File logFile = new File(getFilesDir(), "branchlogs.txt");
+
+        try {
+            if (!logFile.exists()) {
+                boolean fileCreated = logFile.createNewFile();
+                Log.d("BranchTestbed", "Log file created: " + fileCreated);
+            }
+
+            try (FileOutputStream fos = new FileOutputStream(logFile, true);
+                 OutputStreamWriter writer = new OutputStreamWriter(fos)) {
+                writer.write(logMessage + "\n");
+            }
+
+        } catch (Exception e) {
+            Log.e("BranchTestbed", "Error writing to log file", e);
+        }
+    }
+
+
 }

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
@@ -21,8 +21,5 @@ public final class CustomBranchApp extends Application {
         };
         Branch.enableLogging(BranchLogger.BranchLogLevel.VERBOSE); // Pass in iBranchLoggingCallbacks to enable logging redirects
         Branch.getAutoInstance(this);
-
-        Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel.MINIMAL);
-
     }
 }

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/LogOutputActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/LogOutputActivity.java
@@ -1,0 +1,77 @@
+package io.branch.branchandroidtestbed;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+
+public class LogOutputActivity extends Activity {
+    private TextView logOutputTextView;
+    private File logFile;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_log_output);
+
+        logOutputTextView = findViewById(R.id.logOutputTextView);
+        logFile = new File(getFilesDir(), "branchlogs.txt");
+        displayLogs();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.menu_log_output, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.action_clear_logs) {
+            clearLogs();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void displayLogs() {
+        if (logFile.exists()) {
+            StringBuilder logContent = new StringBuilder();
+
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(logFile)))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    logContent.append(line).append("\n");
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                logContent.append("Error reading log file.");
+            }
+
+            logOutputTextView.setText(logContent.toString());
+        } else {
+            logOutputTextView.setText("Log file not found.");
+        }
+    }
+
+    private void clearLogs() {
+        if (logFile.exists()) {
+            if (logFile.delete()) {
+                Toast.makeText(this, "Logs cleared.", Toast.LENGTH_SHORT).show();
+                logOutputTextView.setText("Logs cleared.");
+                finish();
+            } else {
+                Toast.makeText(this, "Failed to clear logs.", Toast.LENGTH_SHORT).show();
+            }
+        } else {
+            Toast.makeText(this, "No log file to clear.", Toast.LENGTH_SHORT).show();
+        }
+    }
+}

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
@@ -598,8 +598,18 @@ public class MainActivity extends Activity {
                         .setSearchQuery("product name")
                         .addCustomDataProperty("Custom_Event_Property_Key1", "Custom_Event_Property_val1")
                         .addContentItems(branchUniversalObject)
-                        .logEvent(MainActivity.this);
-                Toast.makeText(getApplicationContext(), "Sent Branch Content Event", Toast.LENGTH_SHORT).show();
+                        .logEvent(MainActivity.this, new BranchEvent.BranchLogEventCallback() {
+                            @Override
+                            public void onSuccess(int responseCode) {
+                                Toast.makeText(getApplicationContext(), "Sent Branch Content Event: " + responseCode, Toast.LENGTH_SHORT).show();
+                            }
+
+                            @Override
+                            public void onFailure(Exception e) {
+                                Log.d("BranchSDK_Tester", e.toString());
+                                Toast.makeText(getApplicationContext(), "Error sending Branch Content Event: " + e.toString(), Toast.LENGTH_SHORT).show();
+                            }
+                        });
             }
         });
 
@@ -613,8 +623,18 @@ public class MainActivity extends Activity {
                         .setDescription("User created an account")
                         .addCustomDataProperty("registrationID", "12345")
                         .addContentItems(branchUniversalObject)
-                        .logEvent(MainActivity.this);
-                Toast.makeText(getApplicationContext(), "Sent Branch Lifecycle Event", Toast.LENGTH_SHORT).show();
+                        .logEvent(MainActivity.this, new BranchEvent.BranchLogEventCallback() {
+                            @Override
+                            public void onSuccess(int responseCode) {
+                                Toast.makeText(getApplicationContext(), "Sent Branch Lifecycle Event: " + responseCode, Toast.LENGTH_SHORT).show();
+                            }
+
+                            @Override
+                            public void onFailure(Exception e) {
+                                Log.d("BranchSDK_Tester", e.toString());
+                                Toast.makeText(getApplicationContext(), "Error sending Branch Lifecycle Event: " + e.toString(), Toast.LENGTH_SHORT).show();
+                            }
+                        });
             }
         });
 

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
@@ -461,6 +461,33 @@ public class MainActivity extends Activity {
             });
         });
 
+        findViewById(R.id.cmdConsumerProtectionPreference).setOnClickListener(v -> {
+            final String[] options = {"Full Attribution", "Privacy Attribution", "Analytics Only", "Tracking Disabled"};
+            AlertDialog.Builder builder = new AlertDialog.Builder(MainActivity.this);
+            builder.setTitle("Select Consumer Protection Preference")
+                    .setItems(options, (dialog, which) -> {
+                        Defines.BranchConsumerProtectionPreference preference;
+                        switch (which) {
+                            case 1:
+                                preference = Defines.BranchConsumerProtectionPreference.PRIVACY_ATTRIBUTION;
+                                break;
+                            case 2:
+                                preference = Defines.BranchConsumerProtectionPreference.ANALYTICS_ONLY;
+                                break;
+                            case 3:
+                                preference = Defines.BranchConsumerProtectionPreference.TRACKING_DISABLED;
+                                break;
+                            case 0:
+                            default:
+                                preference = Defines.BranchConsumerProtectionPreference.FULL_ATTRIBUTION;
+                                break;
+                        }
+                        Branch.getInstance().setConsumerProtectionPreference(preference);
+                        Toast.makeText(MainActivity.this, "Consumer Protection Preference set to " + options[which], Toast.LENGTH_SHORT).show();
+                    });
+            builder.create().show();
+        });
+
         findViewById(R.id.qrCode_btn).setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
@@ -414,6 +414,13 @@ public class MainActivity extends Activity {
             }
         });
 
+        findViewById(R.id.viewLogsButton).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent intent = new Intent(MainActivity.this, LogOutputActivity.class);
+                startActivity(intent);
+            }
+        });
 
         findViewById(R.id.notif_btn).setOnClickListener(new OnClickListener() {
             @Override

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
@@ -127,7 +127,7 @@ public class MainActivity extends Activity {
                                         if (error != null) {
                                             Log.e("BranchSDK_Tester", "branch set Identity failed. Caused by -" + error.getMessage());
                                         }
-                                        Toast.makeText(getApplicationContext(), "Set Identity to " + userID, Toast.LENGTH_SHORT).show();
+                                        Toast.makeText(getApplicationContext(), "Set Identity to " + userID, Toast.LENGTH_LONG).show();
 
 
                                     }
@@ -153,10 +153,10 @@ public class MainActivity extends Activity {
                     public void onLogoutFinished(boolean loggedOut, BranchError error) {
                         if (error != null) {
                             Log.e("BranchSDK_Tester", "onLogoutFinished Error: " + error);
-                            Toast.makeText(getApplicationContext(), "Error Logging Out: " + error.getMessage(), Toast.LENGTH_SHORT).show();
+                            Toast.makeText(getApplicationContext(), "Error Logging Out: " + error.getMessage(), Toast.LENGTH_LONG).show();
                         } else {
                             Log.d("BranchSDK_Tester", "onLogoutFinished succeeded: " + loggedOut);
-                            Toast.makeText(getApplicationContext(), "Cleared User ID: " + currentUserId, Toast.LENGTH_SHORT).show();
+                            Toast.makeText(getApplicationContext(), "Cleared User ID: " + currentUserId, Toast.LENGTH_LONG).show();
                         }
                     }
                 });
@@ -460,9 +460,9 @@ public class MainActivity extends Activity {
         ((ToggleButton) findViewById(R.id.tracking_cntrl_btn)).setOnCheckedChangeListener((buttonView, isChecked) -> {
             Branch.getInstance().disableTracking(isChecked, (trackingDisabled, referringParams, error) -> {
                 if (trackingDisabled) {
-                    Toast.makeText(getApplicationContext(), "Disabled Tracking", Toast.LENGTH_SHORT).show();
+                    Toast.makeText(getApplicationContext(), "Disabled Tracking", Toast.LENGTH_LONG).show();
                 } else {
-                    Toast.makeText(getApplicationContext(), "Enabled Tracking", Toast.LENGTH_SHORT).show();
+                    Toast.makeText(getApplicationContext(), "Enabled Tracking", Toast.LENGTH_LONG).show();
                 }
             });
         });
@@ -489,7 +489,7 @@ public class MainActivity extends Activity {
                                 break;
                         }
                         Branch.getInstance().setConsumerProtectionAttributionLevel(preference);
-                        Toast.makeText(MainActivity.this, "Consumer Protection Preference set to " + options[which], Toast.LENGTH_SHORT).show();
+                        Toast.makeText(MainActivity.this, "Consumer Protection Preference set to " + options[which], Toast.LENGTH_LONG).show();
                     });
             builder.create().show();
         });
@@ -574,13 +574,13 @@ public class MainActivity extends Activity {
                         .logEvent(MainActivity.this, new BranchEvent.BranchLogEventCallback() {
                             @Override
                             public void onSuccess(int responseCode) {
-                                Toast.makeText(getApplicationContext(), "Sent Branch Commerce Event: " + responseCode, Toast.LENGTH_SHORT).show();
+                                Toast.makeText(getApplicationContext(), "Sent Branch Commerce Event: " + responseCode, Toast.LENGTH_LONG).show();
                             }
 
                             @Override
                             public void onFailure(Exception e) {
                                 Log.d("BranchSDK_Tester", e.toString());
-                                Toast.makeText(getApplicationContext(), "Error sending Branch Commerce Event: " + e.toString(), Toast.LENGTH_SHORT).show();
+                                Toast.makeText(getApplicationContext(), "Error sending Branch Commerce Event: " + e.toString(), Toast.LENGTH_LONG).show();
                             }
                         });
 
@@ -601,13 +601,13 @@ public class MainActivity extends Activity {
                         .logEvent(MainActivity.this, new BranchEvent.BranchLogEventCallback() {
                             @Override
                             public void onSuccess(int responseCode) {
-                                Toast.makeText(getApplicationContext(), "Sent Branch Content Event: " + responseCode, Toast.LENGTH_SHORT).show();
+                                Toast.makeText(getApplicationContext(), "Sent Branch Content Event: " + responseCode, Toast.LENGTH_LONG).show();
                             }
 
                             @Override
                             public void onFailure(Exception e) {
                                 Log.d("BranchSDK_Tester", e.toString());
-                                Toast.makeText(getApplicationContext(), "Error sending Branch Content Event: " + e.toString(), Toast.LENGTH_SHORT).show();
+                                Toast.makeText(getApplicationContext(), "Error sending Branch Content Event: " + e.toString(), Toast.LENGTH_LONG).show();
                             }
                         });
             }
@@ -626,13 +626,13 @@ public class MainActivity extends Activity {
                         .logEvent(MainActivity.this, new BranchEvent.BranchLogEventCallback() {
                             @Override
                             public void onSuccess(int responseCode) {
-                                Toast.makeText(getApplicationContext(), "Sent Branch Lifecycle Event: " + responseCode, Toast.LENGTH_SHORT).show();
+                                Toast.makeText(getApplicationContext(), "Sent Branch Lifecycle Event: " + responseCode, Toast.LENGTH_LONG).show();
                             }
 
                             @Override
                             public void onFailure(Exception e) {
                                 Log.d("BranchSDK_Tester", e.toString());
-                                Toast.makeText(getApplicationContext(), "Error sending Branch Lifecycle Event: " + e.toString(), Toast.LENGTH_SHORT).show();
+                                Toast.makeText(getApplicationContext(), "Error sending Branch Lifecycle Event: " + e, Toast.LENGTH_LONG).show();
                             }
                         });
             }
@@ -645,7 +645,7 @@ public class MainActivity extends Activity {
                     @Override
                     public void onLogoutFinished(boolean loggedOut, BranchError error) {
                         Log.d("BranchSDK_Tester", "onLogoutFinished " + loggedOut + " errorMessage " + error);
-                        Toast.makeText(getApplicationContext(), "Logged Out", Toast.LENGTH_SHORT).show();
+                        Toast.makeText(getApplicationContext(), "Logged Out", Toast.LENGTH_LONG).show();
                     }
                 });
 

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
@@ -465,20 +465,20 @@ public class MainActivity extends Activity {
             AlertDialog.Builder builder = new AlertDialog.Builder(MainActivity.this);
             builder.setTitle("Select Consumer Protection Attribution Level")
                     .setItems(options, (dialog, which) -> {
-                        Defines.BranchConsumerProtectionAttributionLevel preference;
+                        Defines.BranchAttributionLevel preference;
                         switch (which) {
                             case 1:
-                                preference = Defines.BranchConsumerProtectionAttributionLevel.REDUCED;
+                                preference = Defines.BranchAttributionLevel.REDUCED;
                                 break;
                             case 2:
-                                preference = Defines.BranchConsumerProtectionAttributionLevel.MINIMAL;
+                                preference = Defines.BranchAttributionLevel.MINIMAL;
                                 break;
                             case 3:
-                                preference = Defines.BranchConsumerProtectionAttributionLevel.NONE;
+                                preference = Defines.BranchAttributionLevel.NONE;
                                 break;
                             case 0:
                             default:
-                                preference = Defines.BranchConsumerProtectionAttributionLevel.FULL;
+                                preference = Defines.BranchAttributionLevel.FULL;
                                 break;
                         }
                         Branch.getInstance().setConsumerProtectionAttributionLevel(preference);

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
@@ -13,7 +13,6 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
 import android.view.View.OnClickListener;
-import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.Toast;
@@ -462,27 +461,27 @@ public class MainActivity extends Activity {
         });
 
         findViewById(R.id.cmdConsumerProtectionPreference).setOnClickListener(v -> {
-            final String[] options = {"Full Attribution", "Privacy Attribution", "Analytics Only", "Tracking Disabled"};
+            final String[] options = {"Full", "Reduced", "Minimal", "None"};
             AlertDialog.Builder builder = new AlertDialog.Builder(MainActivity.this);
-            builder.setTitle("Select Consumer Protection Preference")
+            builder.setTitle("Select Consumer Protection Attribution Level")
                     .setItems(options, (dialog, which) -> {
-                        Defines.BranchConsumerProtectionPreference preference;
+                        Defines.BranchConsumerProtectionAttributionLevel preference;
                         switch (which) {
                             case 1:
-                                preference = Defines.BranchConsumerProtectionPreference.PRIVACY_ATTRIBUTION;
+                                preference = Defines.BranchConsumerProtectionAttributionLevel.REDUCED;
                                 break;
                             case 2:
-                                preference = Defines.BranchConsumerProtectionPreference.ANALYTICS_ONLY;
+                                preference = Defines.BranchConsumerProtectionAttributionLevel.MINIMAL;
                                 break;
                             case 3:
-                                preference = Defines.BranchConsumerProtectionPreference.TRACKING_DISABLED;
+                                preference = Defines.BranchConsumerProtectionAttributionLevel.NONE;
                                 break;
                             case 0:
                             default:
-                                preference = Defines.BranchConsumerProtectionPreference.FULL_ATTRIBUTION;
+                                preference = Defines.BranchConsumerProtectionAttributionLevel.FULL;
                                 break;
                         }
-                        Branch.getInstance().setConsumerProtectionPreference(preference);
+                        Branch.getInstance().setConsumerProtectionAttributionLevel(preference);
                         Toast.makeText(MainActivity.this, "Consumer Protection Preference set to " + options[which], Toast.LENGTH_SHORT).show();
                     });
             builder.create().show();

--- a/Branch-SDK-TestBed/src/main/res/drawable/baseline_document_scanner_24.xml
+++ b/Branch-SDK-TestBed/src/main/res/drawable/baseline_document_scanner_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M7,3H4v3H2V1h5V3zM22,6V1h-5v2h3v3H22zM7,21H4v-3H2v5h5V21zM20,18v3h-3v2h5v-5H20zM19,18c0,1.1 -0.9,2 -2,2H7c-1.1,0 -2,-0.9 -2,-2V6c0,-1.1 0.9,-2 2,-2h10c1.1,0 2,0.9 2,2V18zM15,8H9v2h6V8zM15,11H9v2h6V11zM15,14H9v2h6V14z"/>
+    
+</vector>

--- a/Branch-SDK-TestBed/src/main/res/drawable/ic_baseline_security_24.xml
+++ b/Branch-SDK-TestBed/src/main/res/drawable/ic_baseline_security_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,1L3,5v6c0,5.55 3.84,10.74 9,12 5.16,-1.26 9,-6.45 9,-12L21,5l-9,-4zM12,11.99h7c-0.53,4.12 -3.28,7.79 -7,8.94L12,12L5,12L5,6.3l7,-3.11v8.8z"/>
+    
+</vector>

--- a/Branch-SDK-TestBed/src/main/res/layout/activity_log_output.xml
+++ b/Branch-SDK-TestBed/src/main/res/layout/activity_log_output.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/logOutputTextView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="16dp"
+        android:textSize="14sp"
+        android:text="Logs will appear here" />
+</RelativeLayout>

--- a/Branch-SDK-TestBed/src/main/res/layout/activity_log_output.xml
+++ b/Branch-SDK-TestBed/src/main/res/layout/activity_log_output.xml
@@ -3,11 +3,16 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/logOutputTextView"
+    <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:padding="16dp"
-        android:textSize="14sp"
-        android:text="Logs will appear here" />
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/logOutputTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:text="Logs will appear here" />
+    </ScrollView>
 </RelativeLayout>

--- a/Branch-SDK-TestBed/src/main/res/layout/main_activity.xml
+++ b/Branch-SDK-TestBed/src/main/res/layout/main_activity.xml
@@ -90,6 +90,12 @@
                 android:textOff="Disable Tracking"
                 android:textOn="Enable Tracking" />
 
+            <Button
+                android:id="@+id/cmdConsumerProtectionPreference"
+                style="@style/testbed_button_style"
+                android:drawableStart="@drawable/ic_baseline_security_24"
+                android:text="Consumer Protection Preference" />
+
             <TextView
                 style="@style/testbed_text_view"
                 android:text="Events"

--- a/Branch-SDK-TestBed/src/main/res/layout/main_activity.xml
+++ b/Branch-SDK-TestBed/src/main/res/layout/main_activity.xml
@@ -134,6 +134,13 @@
                 />
 
             <Button
+                android:id="@+id/viewLogsButton"
+                style="@style/testbed_button_style"
+                android:drawableStart="@drawable/baseline_document_scanner_24"
+                android:text="Load Branch Logs" />
+
+
+            <Button
                 android:id="@+id/notif_btn"
                 style="@style/testbed_button_style"
                 android:drawableStart="@drawable/ic_baseline_doorbell_24"

--- a/Branch-SDK-TestBed/src/main/res/menu/menu_log_output.xml
+++ b/Branch-SDK-TestBed/src/main/res/menu/menu_log_output.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/action_clear_logs"
+        android:title="Clear Logs"
+        android:showAsAction="always" />
+</menu>

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchApiTests.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchApiTests.java
@@ -349,7 +349,7 @@ public class BranchApiTests extends BranchTest {
     }
 
     @Test
-    public void testTrackingLevel() {
+    public void testConsumerProtectionPreference() {
         Branch.getInstance().setConsumerProtectionPreference(Defines.BranchConsumerProtectionPreference.ANALYTICS_ONLY);
         Assert.assertEquals(Defines.BranchConsumerProtectionPreference.ANALYTICS_ONLY, prefHelper.getConsumerProtectionPreference());
     }

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchApiTests.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchApiTests.java
@@ -1,7 +1,6 @@
 package io.branch.referral;
 
 import android.content.Context;
-import android.util.Log;
 
 import androidx.annotation.Nullable;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -15,10 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -350,6 +346,12 @@ public class BranchApiTests extends BranchTest {
     public void testSdkVersion() {
         Assert.assertNotNull(Branch.getSdkVersionNumber());
         Assert.assertEquals(io.branch.referral.BuildConfig.VERSION_NAME, Branch.getSdkVersionNumber());
+    }
+
+    @Test
+    public void testTrackingLevel() {
+        Branch.getInstance().setConsumerProtectionPreference(Defines.BranchConsumerProtectionPreference.ANALYTICS_ONLY);
+        Assert.assertEquals(Defines.BranchConsumerProtectionPreference.ANALYTICS_ONLY, prefHelper.getConsumerProtectionPreference());
     }
 
     private void getFBUrl(final FBUrl res) throws InterruptedException {

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchApiTests.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchApiTests.java
@@ -348,12 +348,6 @@ public class BranchApiTests extends BranchTest {
         Assert.assertEquals(io.branch.referral.BuildConfig.VERSION_NAME, Branch.getSdkVersionNumber());
     }
 
-    @Test
-    public void testConsumerProtectionPreference() {
-        Branch.getInstance().setConsumerProtectionPreference(Defines.BranchConsumerProtectionPreference.ANALYTICS_ONLY);
-        Assert.assertEquals(Defines.BranchConsumerProtectionPreference.ANALYTICS_ONLY, prefHelper.getConsumerProtectionPreference());
-    }
-
     private void getFBUrl(final FBUrl res) throws InterruptedException {
         getFBUrl(res, null, null);
     }

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
@@ -334,4 +334,13 @@ public class PrefHelperTest extends BranchTest {
         Assert.assertEquals(prefHelper.getAdPersonalizationConsent(),true);
         Assert.assertEquals(prefHelper.getAdUserDataUsageConsent(),false);
     }
+
+    @Test
+    public void testSetConsumerProtectionPreference() {
+        Branch.getInstance().setConsumerProtectionPreference(Defines.BranchConsumerProtectionPreference.ANALYTICS_ONLY);
+        Assert.assertEquals(prefHelper.getConsumerProtectionPreference(), Defines.BranchConsumerProtectionPreference.ANALYTICS_ONLY);
+
+        Branch.getInstance().setConsumerProtectionPreference(Defines.BranchConsumerProtectionPreference.FULL);
+        Assert.assertEquals(prefHelper.getConsumerProtectionPreference(), Defines.BranchConsumerProtectionPreference.FULL);
+    }
 }

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
@@ -336,11 +336,18 @@ public class PrefHelperTest extends BranchTest {
     }
 
     @Test
-    public void testSetConsumerProtectionPreference() {
-        Branch.getInstance().setConsumerProtectionPreference(Defines.BranchConsumerProtectionPreference.ANALYTICS_ONLY);
-        Assert.assertEquals(prefHelper.getConsumerProtectionPreference(), Defines.BranchConsumerProtectionPreference.ANALYTICS_ONLY);
+    public void testConsumerProtectionAttributionLevel() {
+        Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchConsumerProtectionAttributionLevel.REDUCED);
+        Assert.assertEquals(Defines.BranchConsumerProtectionAttributionLevel.REDUCED, prefHelper.getConsumerProtectionAttributionLevel());
 
-        Branch.getInstance().setConsumerProtectionPreference(Defines.BranchConsumerProtectionPreference.FULL);
-        Assert.assertEquals(prefHelper.getConsumerProtectionPreference(), Defines.BranchConsumerProtectionPreference.FULL);
+        Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchConsumerProtectionAttributionLevel.MINIMAL);
+        Assert.assertEquals(Defines.BranchConsumerProtectionAttributionLevel.MINIMAL, prefHelper.getConsumerProtectionAttributionLevel());
+
+        Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchConsumerProtectionAttributionLevel.NONE);
+        Assert.assertEquals(Defines.BranchConsumerProtectionAttributionLevel.NONE, prefHelper.getConsumerProtectionAttributionLevel());
+
+        Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchConsumerProtectionAttributionLevel.FULL);
+        Assert.assertEquals(Defines.BranchConsumerProtectionAttributionLevel.FULL, prefHelper.getConsumerProtectionAttributionLevel());
     }
+
 }

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/PrefHelperTest.java
@@ -337,17 +337,17 @@ public class PrefHelperTest extends BranchTest {
 
     @Test
     public void testConsumerProtectionAttributionLevel() {
-        Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchConsumerProtectionAttributionLevel.REDUCED);
-        Assert.assertEquals(Defines.BranchConsumerProtectionAttributionLevel.REDUCED, prefHelper.getConsumerProtectionAttributionLevel());
+        Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel.REDUCED);
+        Assert.assertEquals(Defines.BranchAttributionLevel.REDUCED, prefHelper.getConsumerProtectionAttributionLevel());
 
-        Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchConsumerProtectionAttributionLevel.MINIMAL);
-        Assert.assertEquals(Defines.BranchConsumerProtectionAttributionLevel.MINIMAL, prefHelper.getConsumerProtectionAttributionLevel());
+        Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel.MINIMAL);
+        Assert.assertEquals(Defines.BranchAttributionLevel.MINIMAL, prefHelper.getConsumerProtectionAttributionLevel());
 
-        Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchConsumerProtectionAttributionLevel.NONE);
-        Assert.assertEquals(Defines.BranchConsumerProtectionAttributionLevel.NONE, prefHelper.getConsumerProtectionAttributionLevel());
+        Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel.NONE);
+        Assert.assertEquals(Defines.BranchAttributionLevel.NONE, prefHelper.getConsumerProtectionAttributionLevel());
 
-        Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchConsumerProtectionAttributionLevel.FULL);
-        Assert.assertEquals(Defines.BranchConsumerProtectionAttributionLevel.FULL, prefHelper.getConsumerProtectionAttributionLevel());
+        Branch.getInstance().setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel.FULL);
+        Assert.assertEquals(Defines.BranchAttributionLevel.FULL, prefHelper.getConsumerProtectionAttributionLevel());
     }
 
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2576,4 +2576,15 @@ public class Branch {
             BranchLogger.w("setFBAppID: fbAppID cannot be empty or null");
         }
     }
+
+    /**
+     * Sets the consumer protection preference
+     *
+     * @param preference The consumer protection preference {@link Defines.BranchConsumerProtectionPreference}.
+     */
+    public void setConsumerProtectionPreference(Defines.BranchConsumerProtectionPreference preference) {
+        prefHelper_.setConsumerProtectionPreference(preference);
+
+        BranchLogger.v("Set Consumer Protection Preference to " + preference);
+    }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -540,7 +540,7 @@ public class Branch {
      *                 the change in tracking state. This parameter can be {@code null} if no callback actions are needed.
      * @deprecated Use {@link #setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel)} instead.
      */
-    public void disableTracking(boolean disableTracking, @Nullable TrackingStateCallback callback) {
+    @Deprecated public void disableTracking(boolean disableTracking, @Nullable TrackingStateCallback callback) {
         trackingController.disableTracking(context_, disableTracking, callback);
     }
 
@@ -553,7 +553,7 @@ public class Branch {
      *                        ({@code false}).
      * @deprecated Use {@link #setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel)} instead.
      */
-    public void disableTracking(boolean disableTracking) {
+    @Deprecated public void disableTracking(boolean disableTracking) {
         disableTracking(disableTracking, null);
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -539,7 +539,7 @@ public class Branch {
      * @param callback An optional {@link TrackingStateCallback} instance for receiving callback notifications about
      *                 the change in tracking state. This parameter can be {@code null} if no callback actions are needed.
      * @deprecated Use {@link #setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel)}
-     * with {@code Defines.BranchAttributionLevel.NONE} instead to disable tracking.
+     * with {@link Defines.BranchAttributionLevel#NONE} instead to disable tracking.
      * */
     @Deprecated public void disableTracking(boolean disableTracking, @Nullable TrackingStateCallback callback) {
         trackingController.disableTracking(context_, disableTracking, callback);
@@ -553,7 +553,7 @@ public class Branch {
      * @param disableTracking A boolean value indicating whether tracking should be disabled ({@code true}) or enabled
      *                        ({@code false}).
      * @deprecated Use {@link #setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel)}
-     * with {@code Defines.BranchAttributionLevel.NONE} instead to disable tracking.
+     * with {@link Defines.BranchAttributionLevel#NONE} instead to disable tracking.
      * */
     @Deprecated public void disableTracking(boolean disableTracking) {
         disableTracking(disableTracking, null);

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -538,8 +538,9 @@ public class Branch {
      *                        ({@code false}).
      * @param callback An optional {@link TrackingStateCallback} instance for receiving callback notifications about
      *                 the change in tracking state. This parameter can be {@code null} if no callback actions are needed.
-     * @deprecated Use {@link #setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel)} instead.
-     */
+     * @deprecated Use {@link #setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel)}
+     * with {@code Defines.BranchAttributionLevel.NONE} instead to disable tracking.
+     * */
     @Deprecated public void disableTracking(boolean disableTracking, @Nullable TrackingStateCallback callback) {
         trackingController.disableTracking(context_, disableTracking, callback);
     }
@@ -551,8 +552,9 @@ public class Branch {
      *
      * @param disableTracking A boolean value indicating whether tracking should be disabled ({@code true}) or enabled
      *                        ({@code false}).
-     * @deprecated Use {@link #setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel)} instead.
-     */
+     * @deprecated Use {@link #setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel)}
+     * with {@code Defines.BranchAttributionLevel.NONE} instead to disable tracking.
+     * */
     @Deprecated public void disableTracking(boolean disableTracking) {
         disableTracking(disableTracking, null);
     }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2603,7 +2603,7 @@ public class Branch {
         if (level == Defines.BranchAttributionLevel.NONE) {
             trackingController.disableTracking(context_, true, null);
         } else {
-            if (initState_ != SESSION_STATE.INITIALISED) {
+            if (trackingController.isTrackingDisabled()) {
                 trackingController.disableTracking(context_, false, null);
             }
         }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -538,10 +538,21 @@ public class Branch {
      *                        ({@code false}).
      * @param callback An optional {@link TrackingStateCallback} instance for receiving callback notifications about
      *                 the change in tracking state. This parameter can be {@code null} if no callback actions are needed.
+     * @deprecated Use {@link #setConsumerProtectionPreference(Defines.BranchConsumerProtectionPreference)} instead.
      */
     public void disableTracking(boolean disableTracking, @Nullable TrackingStateCallback callback) {
         trackingController.disableTracking(context_, disableTracking, callback);
     }
+
+    /**
+     * Toggles the tracking state of the SDK. When tracking is disabled, the SDK will not track any user data or state,
+     * and it will not initiate any network calls except for deep linking operations.
+     * Re-enabling tracking will reinitialize the Branch session and resume normal SDK operations.
+     *
+     * @param disableTracking A boolean value indicating whether tracking should be disabled ({@code true}) or enabled
+     *                        ({@code false}).
+     * @deprecated Use {@link #setConsumerProtectionPreference(Defines.BranchConsumerProtectionPreference)} instead.
+     */
     public void disableTracking(boolean disableTracking) {
         disableTracking(disableTracking, null);
     }
@@ -2584,6 +2595,12 @@ public class Branch {
      */
     public void setConsumerProtectionPreference(Defines.BranchConsumerProtectionPreference preference) {
         prefHelper_.setConsumerProtectionPreference(preference);
+
+        if (preference == Defines.BranchConsumerProtectionPreference.TRACKING_DISABLED) {
+            trackingController.disableTracking(context_, true, null);
+        } else {
+            trackingController.disableTracking(context_, false, null);
+        }
 
         BranchLogger.v("Set Consumer Protection Preference to " + preference);
     }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -538,7 +538,7 @@ public class Branch {
      *                        ({@code false}).
      * @param callback An optional {@link TrackingStateCallback} instance for receiving callback notifications about
      *                 the change in tracking state. This parameter can be {@code null} if no callback actions are needed.
-     * @deprecated Use {@link #setConsumerProtectionPreference(Defines.BranchConsumerProtectionPreference)} instead.
+     * @deprecated Use {@link #setConsumerProtectionAttributionLevel(Defines.BranchConsumerProtectionAttributionLevel)} instead.
      */
     public void disableTracking(boolean disableTracking, @Nullable TrackingStateCallback callback) {
         trackingController.disableTracking(context_, disableTracking, callback);
@@ -551,7 +551,7 @@ public class Branch {
      *
      * @param disableTracking A boolean value indicating whether tracking should be disabled ({@code true}) or enabled
      *                        ({@code false}).
-     * @deprecated Use {@link #setConsumerProtectionPreference(Defines.BranchConsumerProtectionPreference)} instead.
+     * @deprecated Use {@link #setConsumerProtectionAttributionLevel(Defines.BranchConsumerProtectionAttributionLevel)} instead.
      */
     public void disableTracking(boolean disableTracking) {
         disableTracking(disableTracking, null);
@@ -2589,19 +2589,19 @@ public class Branch {
     }
 
     /**
-     * Sets the consumer protection preference
+     * Sets the consumer protection attribution level
      *
-     * @param preference The consumer protection preference {@link Defines.BranchConsumerProtectionPreference}.
+     * @param level The consumer protection attribution level {@link Defines.BranchConsumerProtectionAttributionLevel}.
      */
-    public void setConsumerProtectionPreference(Defines.BranchConsumerProtectionPreference preference) {
-        prefHelper_.setConsumerProtectionPreference(preference);
+    public void setConsumerProtectionAttributionLevel(Defines.BranchConsumerProtectionAttributionLevel level) {
+        prefHelper_.setConsumerProtectionAttributionLevel(level);
 
-        if (preference == Defines.BranchConsumerProtectionPreference.TRACKING_DISABLED) {
+        if (level == Defines.BranchConsumerProtectionAttributionLevel.NONE) {
             trackingController.disableTracking(context_, true, null);
         } else {
             trackingController.disableTracking(context_, false, null);
         }
 
-        BranchLogger.v("Set Consumer Protection Preference to " + preference);
+        BranchLogger.v("Set Consumer Protection Preference to " + level);
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2592,21 +2592,32 @@ public class Branch {
     }
 
     /**
-     * Sets the consumer protection attribution level
+     * Sets the consumer protection attribution level.
      *
      * @param level The consumer protection attribution level {@link Defines.BranchAttributionLevel}.
      */
     public void setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel level) {
+        setConsumerProtectionAttributionLevel(level, null);
+    }
+
+    /**
+     * Sets the consumer protection attribution level with an optional callback.
+     *
+     * @param level    The consumer protection attribution level {@link Defines.BranchAttributionLevel}.
+     * @param callback An optional {@link TrackingStateCallback} for receiving notifications about
+     *                 the change in tracking state. This parameter can be {@code null} if no callback actions are needed.
+     */
+    public void setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel level, @Nullable TrackingStateCallback callback) {
         prefHelper_.setConsumerProtectionAttributionLevel(level);
         BranchLogger.v("Set Consumer Protection Preference to " + level);
 
         if (level == Defines.BranchAttributionLevel.NONE) {
-            trackingController.disableTracking(context_, true, null);
+            trackingController.disableTracking(context_, true, callback);
         } else {
             if (trackingController.isTrackingDisabled()) {
-                trackingController.disableTracking(context_, false, null);
+                trackingController.disableTracking(context_, false, callback);
             }
         }
-
     }
+
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -715,7 +715,7 @@ public class Branch {
     /**
      * Returns true if reading device id is disabled
      *
-     * @return {@link Boolean} with value true to disable reading Andoid ID
+     * @return {@link Boolean} with value true to disable reading Android ID
      */
     public static boolean isDeviceIDFetchDisabled() {
         return disableDeviceIDFetch_;

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2596,13 +2596,15 @@ public class Branch {
      */
     public void setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel level) {
         prefHelper_.setConsumerProtectionAttributionLevel(level);
+        BranchLogger.v("Set Consumer Protection Preference to " + level);
 
         if (level == Defines.BranchAttributionLevel.NONE) {
             trackingController.disableTracking(context_, true, null);
         } else {
-            trackingController.disableTracking(context_, false, null);
+            if (initState_ != SESSION_STATE.INITIALISED) {
+                trackingController.disableTracking(context_, false, null);
+            }
         }
 
-        BranchLogger.v("Set Consumer Protection Preference to " + level);
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -538,7 +538,7 @@ public class Branch {
      *                        ({@code false}).
      * @param callback An optional {@link TrackingStateCallback} instance for receiving callback notifications about
      *                 the change in tracking state. This parameter can be {@code null} if no callback actions are needed.
-     * @deprecated Use {@link #setConsumerProtectionAttributionLevel(Defines.BranchConsumerProtectionAttributionLevel)} instead.
+     * @deprecated Use {@link #setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel)} instead.
      */
     public void disableTracking(boolean disableTracking, @Nullable TrackingStateCallback callback) {
         trackingController.disableTracking(context_, disableTracking, callback);
@@ -551,7 +551,7 @@ public class Branch {
      *
      * @param disableTracking A boolean value indicating whether tracking should be disabled ({@code true}) or enabled
      *                        ({@code false}).
-     * @deprecated Use {@link #setConsumerProtectionAttributionLevel(Defines.BranchConsumerProtectionAttributionLevel)} instead.
+     * @deprecated Use {@link #setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel)} instead.
      */
     public void disableTracking(boolean disableTracking) {
         disableTracking(disableTracking, null);
@@ -2591,12 +2591,12 @@ public class Branch {
     /**
      * Sets the consumer protection attribution level
      *
-     * @param level The consumer protection attribution level {@link Defines.BranchConsumerProtectionAttributionLevel}.
+     * @param level The consumer protection attribution level {@link Defines.BranchAttributionLevel}.
      */
-    public void setConsumerProtectionAttributionLevel(Defines.BranchConsumerProtectionAttributionLevel level) {
+    public void setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel level) {
         prefHelper_.setConsumerProtectionAttributionLevel(level);
 
-        if (level == Defines.BranchConsumerProtectionAttributionLevel.NONE) {
+        if (level == Defines.BranchAttributionLevel.NONE) {
             trackingController.disableTracking(context_, true, null);
         } else {
             trackingController.disableTracking(context_, false, null);

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -225,7 +225,7 @@ public class Defines {
         DMA_Ad_User_Data("dma_ad_user_data"),
         Is_Meta_Click_Through("is_meta_ct"),
 
-        Consumer_Protection_Attribution_Level("consumer_protection_attribution_level");
+        Consumer_Protection_Attribution_Level("cpp_level");
 
         private final String key;
         

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -225,7 +225,7 @@ public class Defines {
         DMA_Ad_User_Data("dma_ad_user_data"),
         Is_Meta_Click_Through("is_meta_ct"),
 
-        Consumer_Protection_Preference("consumer_protection_preference");
+        Consumer_Protection_Preference("protection_preference");
 
         private final String key;
         
@@ -401,9 +401,44 @@ public class Defines {
      * </p>
      */
     public enum BranchConsumerProtectionPreference {
-        FULL,
-        PRIVACY_ONLY,
+        /**
+         * Full Attribution (Default)
+         * - Advertising Ids
+         * - Device Ids
+         * - Local IP
+         * - Persisted Non-Aggregate Ids
+         * - Persisted Aggregate Ids
+         * - Ads Postbacks / Webhooks
+         * - Data Integrations Webhooks
+         * - SAN Callouts
+         * - Privacy Frameworks
+         * - Deep Linking
+         */
+        FULL_ATTRIBUTION,
+        /**
+         * Privacy Attribution (Non-Ads + Privacy Frameworks)
+         * - Device Ids
+         * - Local IP
+         * - Data Integrations Webhooks
+         * - Privacy Frameworks
+         * - Deep Linking
+         */
+        PRIVACY_ATTRIBUTION,
+
+        /**
+         * Analytics Only - No Attribution
+         * - Device Ids
+         * - Local IP
+         * - Data Integrations Webhooks
+         * - Deep Linking
+         */
         ANALYTICS_ONLY,
-        NO_ATTRIBUTION
+
+        /**
+         * No Attribution - No Analytics (GDPR, CCPA)
+         * - Only Deterministic Deep Linking
+         * - Disables all other Branch requests
+         */
+        TRACKING_DISABLED
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -223,7 +223,9 @@ public class Defines {
         DMA_EEA("dma_eea"),
         DMA_Ad_Personalization("dma_ad_personalization"),
         DMA_Ad_User_Data("dma_ad_user_data"),
-        Is_Meta_Click_Through("is_meta_ct");
+        Is_Meta_Click_Through("is_meta_ct"),
+
+        Consumer_Protection_Preference("consumer_protection_preference");
 
         private final String key;
         
@@ -391,5 +393,17 @@ public class Defines {
         public String toString() {
             return key;
         }
+    }
+
+    /**
+     * <p>
+     * Defines Branch Consumer Protection Preference
+     * </p>
+     */
+    public enum BranchConsumerProtectionPreference {
+        FULL,
+        PRIVACY_ONLY,
+        ANALYTICS_ONLY,
+        NO_ATTRIBUTION
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -225,7 +225,7 @@ public class Defines {
         DMA_Ad_User_Data("dma_ad_user_data"),
         Is_Meta_Click_Through("is_meta_ct"),
 
-        Consumer_Protection_Preference("protection_preference");
+        Consumer_Protection_Attribution_Level("consumer_protection_attribution_level");
 
         private final String key;
         
@@ -400,7 +400,7 @@ public class Defines {
      * Defines Branch Consumer Protection Preference
      * </p>
      */
-    public enum BranchConsumerProtectionPreference {
+    public enum BranchConsumerProtectionAttributionLevel {
         /**
          * Full Attribution (Default)
          * - Advertising Ids
@@ -414,16 +414,16 @@ public class Defines {
          * - Privacy Frameworks
          * - Deep Linking
          */
-        FULL_ATTRIBUTION,
+        FULL,
         /**
-         * Privacy Attribution (Non-Ads + Privacy Frameworks)
+         * Redices Attribution (Non-Ads + Privacy Frameworks)
          * - Device Ids
          * - Local IP
          * - Data Integrations Webhooks
          * - Privacy Frameworks
          * - Deep Linking
          */
-        PRIVACY_ATTRIBUTION,
+        REDUCED,
 
         /**
          * Analytics Only - No Attribution
@@ -432,13 +432,13 @@ public class Defines {
          * - Data Integrations Webhooks
          * - Deep Linking
          */
-        ANALYTICS_ONLY,
+        MINIMAL,
 
         /**
          * No Attribution - No Analytics (GDPR, CCPA)
          * - Only Deterministic Deep Linking
          * - Disables all other Branch requests
          */
-        TRACKING_DISABLED
+        NONE
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -416,7 +416,7 @@ public class Defines {
          */
         FULL,
         /**
-         * Redices Attribution (Non-Ads + Privacy Frameworks)
+         * Reduces Attribution (Non-Ads + Privacy Frameworks)
          * - Device Ids
          * - Local IP
          * - Data Integrations Webhooks

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -416,7 +416,7 @@ public class Defines {
          */
         FULL,
         /**
-         * Reduces Attribution (Non-Ads + Privacy Frameworks)
+         * Reduced Attribution (Non-Ads + Privacy Frameworks)
          * - Device Ids
          * - Local IP
          * - Data Integrations Webhooks
@@ -426,7 +426,7 @@ public class Defines {
         REDUCED,
 
         /**
-         * Analytics Only - No Attribution
+         * Minimal Attribution - Analytics Only
          * - Device Ids
          * - Local IP
          * - Data Integrations Webhooks

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -397,10 +397,10 @@ public class Defines {
 
     /**
      * <p>
-     * Defines Branch Consumer Protection Preference
+     * Defines Branch Attribution Level
      * </p>
      */
-    public enum BranchConsumerProtectionAttributionLevel {
+    public enum BranchAttributionLevel {
         /**
          * Full Attribution (Default)
          * - Advertising Ids

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -1438,7 +1438,7 @@ public class PrefHelper {
      * @return A {@link Defines.BranchConsumerProtectionPreference} value representing the tracking level set.
      */
     public Defines.BranchConsumerProtectionPreference getConsumerProtectionPreference() {
-        int preferenceInt = getInteger(KEY_CONSUMER_PROTECTION_PREFERENCE, Defines.BranchConsumerProtectionPreference.FULL.ordinal());
+        int preferenceInt = getInteger(KEY_CONSUMER_PROTECTION_PREFERENCE, Defines.BranchConsumerProtectionPreference.FULL_ATTRIBUTION.ordinal());
         return Defines.BranchConsumerProtectionPreference.values()[preferenceInt];
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -1438,11 +1438,11 @@ public class PrefHelper {
      * @return A {@link Defines.BranchAttributionLevel} value representing the attribution level set.
      */
     public Defines.BranchAttributionLevel getConsumerProtectionAttributionLevel() {
-        int levelInt = getInteger(KEY_CONSUMER_PROTECTION_ATTRIBUTION_LEVEL, -1);
-        if (levelInt == -1) {
-            return null;
+        String levelString = getString(KEY_CONSUMER_PROTECTION_ATTRIBUTION_LEVEL);
+        if (levelString.equals(NO_STRING_VALUE)) {
+            return Defines.BranchAttributionLevel.FULL;
         } else {
-            return Defines.BranchAttributionLevel.values()[levelInt];
+            return Defines.BranchAttributionLevel.valueOf(levelString);
         }
     }
 
@@ -1452,6 +1452,13 @@ public class PrefHelper {
      * @param preference A {@link Defines.BranchAttributionLevel} value containing the desired attribution level.
      */
     public void setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel preference) {
-        setInteger(KEY_CONSUMER_PROTECTION_ATTRIBUTION_LEVEL, preference.ordinal());
+        setString(KEY_CONSUMER_PROTECTION_ATTRIBUTION_LEVEL, preference.toString());
+    }
+
+    /**
+     * Returns true if Consumer Protection Attribution Level - KEY_CONSUMER_PROTECTION_ATTRIBUTION_LEVEL value exist in pref helper.
+     */
+    boolean isAttributionLevelInitialized() {
+        return hasPrefValue(KEY_CONSUMER_PROTECTION_ATTRIBUTION_LEVEL);
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -1433,21 +1433,21 @@ public class PrefHelper {
     }
 
     /**
-     * <p>Gets the {@link Defines.BranchConsumerProtectionAttributionLevel} value that has been set.</p>
+     * <p>Gets the {@link Defines.BranchAttributionLevel} value that has been set.</p>
      *
-     * @return A {@link Defines.BranchConsumerProtectionAttributionLevel} value representing the attribution level set.
+     * @return A {@link Defines.BranchAttributionLevel} value representing the attribution level set.
      */
-    public Defines.BranchConsumerProtectionAttributionLevel getConsumerProtectionAttributionLevel() {
-        int levelInt = getInteger(KEY_CONSUMER_PROTECTION_ATTRIBUTION_LEVEL, Defines.BranchConsumerProtectionAttributionLevel.FULL.ordinal());
-        return Defines.BranchConsumerProtectionAttributionLevel.values()[levelInt];
+    public Defines.BranchAttributionLevel getConsumerProtectionAttributionLevel() {
+        int levelInt = getInteger(KEY_CONSUMER_PROTECTION_ATTRIBUTION_LEVEL, Defines.BranchAttributionLevel.FULL.ordinal());
+        return Defines.BranchAttributionLevel.values()[levelInt];
     }
 
     /**
-     * <p>Sets the {@link Defines.BranchConsumerProtectionAttributionLevel} value via the Branch API.</p>
+     * <p>Sets the {@link Defines.BranchAttributionLevel} value via the Branch API.</p>
      *
-     * @param preference A {@link Defines.BranchConsumerProtectionAttributionLevel} value containing the desired attribution level.
+     * @param preference A {@link Defines.BranchAttributionLevel} value containing the desired attribution level.
      */
-    public void setConsumerProtectionAttributionLevel(Defines.BranchConsumerProtectionAttributionLevel preference) {
+    public void setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel preference) {
         setInteger(KEY_CONSUMER_PROTECTION_ATTRIBUTION_LEVEL, preference.ordinal());
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -1438,8 +1438,12 @@ public class PrefHelper {
      * @return A {@link Defines.BranchAttributionLevel} value representing the attribution level set.
      */
     public Defines.BranchAttributionLevel getConsumerProtectionAttributionLevel() {
-        int levelInt = getInteger(KEY_CONSUMER_PROTECTION_ATTRIBUTION_LEVEL, Defines.BranchAttributionLevel.FULL.ordinal());
-        return Defines.BranchAttributionLevel.values()[levelInt];
+        int levelInt = getInteger(KEY_CONSUMER_PROTECTION_ATTRIBUTION_LEVEL, -1);
+        if (levelInt == -1) {
+            return null;
+        } else {
+            return Defines.BranchAttributionLevel.values()[levelInt];
+        }
     }
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -113,7 +113,7 @@ public class PrefHelper {
     private static final String KEY_DMA_AD_PERSONALIZATION = "bnc_dma_ad_personalization";
     private static final String KEY_DMA_AD_USER_DATA = "bnc_dma_ad_user_data";
     private static final String KEY_LOG_IAP_AS_EVENTS = "bnc_log_iap_as_events";
-
+    private static final String KEY_CONSUMER_PROTECTION_PREFERENCE = "bnc_consumer_protection_preference";
     static final String KEY_ORIGINAL_INSTALL_TIME = "bnc_original_install_time";
     static final String KEY_LAST_KNOWN_UPDATE_TIME = "bnc_last_known_update_time";
     static final String KEY_PREVIOUS_UPDATE_TIME = "bnc_previous_update_time";
@@ -1430,5 +1430,24 @@ public class PrefHelper {
             partnerData.put(e.getKey(), individualPartnerParams);
         }
         body.put(Defines.Jsonkey.PartnerData.getKey(), partnerData);
+    }
+
+    /**
+     * <p>Gets the {@link Defines.BranchConsumerProtectionPreference} value that has been set.</p>
+     *
+     * @return A {@link Defines.BranchConsumerProtectionPreference} value representing the tracking level set.
+     */
+    public Defines.BranchConsumerProtectionPreference getConsumerProtectionPreference() {
+        int preferenceInt = getInteger(KEY_CONSUMER_PROTECTION_PREFERENCE, Defines.BranchConsumerProtectionPreference.FULL.ordinal());
+        return Defines.BranchConsumerProtectionPreference.values()[preferenceInt];
+    }
+
+    /**
+     * <p>Sets the {@link Defines.BranchConsumerProtectionPreference} value via the Branch API.</p>
+     *
+     * @param preference A {@link Defines.BranchConsumerProtectionPreference} value containing the desired tracking level.
+     */
+    public void setConsumerProtectionPreference(Defines.BranchConsumerProtectionPreference preference) {
+        setInteger(KEY_CONSUMER_PROTECTION_PREFERENCE, preference.ordinal());
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -113,7 +113,7 @@ public class PrefHelper {
     private static final String KEY_DMA_AD_PERSONALIZATION = "bnc_dma_ad_personalization";
     private static final String KEY_DMA_AD_USER_DATA = "bnc_dma_ad_user_data";
     private static final String KEY_LOG_IAP_AS_EVENTS = "bnc_log_iap_as_events";
-    private static final String KEY_CONSUMER_PROTECTION_PREFERENCE = "bnc_consumer_protection_preference";
+    private static final String KEY_CONSUMER_PROTECTION_ATTRIBUTION_LEVEL = "bnc_consumer_protection_attribution_level";
     static final String KEY_ORIGINAL_INSTALL_TIME = "bnc_original_install_time";
     static final String KEY_LAST_KNOWN_UPDATE_TIME = "bnc_last_known_update_time";
     static final String KEY_PREVIOUS_UPDATE_TIME = "bnc_previous_update_time";
@@ -1433,21 +1433,21 @@ public class PrefHelper {
     }
 
     /**
-     * <p>Gets the {@link Defines.BranchConsumerProtectionPreference} value that has been set.</p>
+     * <p>Gets the {@link Defines.BranchConsumerProtectionAttributionLevel} value that has been set.</p>
      *
-     * @return A {@link Defines.BranchConsumerProtectionPreference} value representing the tracking level set.
+     * @return A {@link Defines.BranchConsumerProtectionAttributionLevel} value representing the attribution level set.
      */
-    public Defines.BranchConsumerProtectionPreference getConsumerProtectionPreference() {
-        int preferenceInt = getInteger(KEY_CONSUMER_PROTECTION_PREFERENCE, Defines.BranchConsumerProtectionPreference.FULL_ATTRIBUTION.ordinal());
-        return Defines.BranchConsumerProtectionPreference.values()[preferenceInt];
+    public Defines.BranchConsumerProtectionAttributionLevel getConsumerProtectionAttributionLevel() {
+        int levelInt = getInteger(KEY_CONSUMER_PROTECTION_ATTRIBUTION_LEVEL, Defines.BranchConsumerProtectionAttributionLevel.FULL.ordinal());
+        return Defines.BranchConsumerProtectionAttributionLevel.values()[levelInt];
     }
 
     /**
-     * <p>Sets the {@link Defines.BranchConsumerProtectionPreference} value via the Branch API.</p>
+     * <p>Sets the {@link Defines.BranchConsumerProtectionAttributionLevel} value via the Branch API.</p>
      *
-     * @param preference A {@link Defines.BranchConsumerProtectionPreference} value containing the desired tracking level.
+     * @param preference A {@link Defines.BranchConsumerProtectionAttributionLevel} value containing the desired attribution level.
      */
-    public void setConsumerProtectionPreference(Defines.BranchConsumerProtectionPreference preference) {
-        setInteger(KEY_CONSUMER_PROTECTION_PREFERENCE, preference.ordinal());
+    public void setConsumerProtectionAttributionLevel(Defines.BranchConsumerProtectionAttributionLevel preference) {
+        setInteger(KEY_CONSUMER_PROTECTION_ATTRIBUTION_LEVEL, preference.ordinal());
     }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -197,10 +197,10 @@ public abstract class ServerRequest {
         }
     }
 
-    void addConsumerProtectionPreference() {
+    void updateConsumerProtectionPreference() {
         try {
             if (prefHelper_.getConsumerProtectionPreference() != null) {
-                params_.put(Defines.Jsonkey.Consumer_Protection_Preference.getKey(), prefHelper_.getConsumerProtectionPreference());
+                params_.put(Defines.Jsonkey.Consumer_Protection_Preference.getKey(), prefHelper_.getConsumerProtectionPreference().ordinal());
             }
         } catch (JSONException e) {
             BranchLogger.d(e.getMessage());
@@ -634,9 +634,7 @@ public abstract class ServerRequest {
         if (shouldAddDMAParams()) {
             addDMAParams();
         }
-
-        addConsumerProtectionPreference();
-
+        updateConsumerProtectionPreference();
     }
     
     void doFinalUpdateOnBackgroundThread() {

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -197,6 +197,16 @@ public abstract class ServerRequest {
         }
     }
 
+    void addConsumerProtectionPreference() {
+        try {
+            if (prefHelper_.getConsumerProtectionPreference() != null) {
+                params_.put(Defines.Jsonkey.Consumer_Protection_Preference.getKey(), prefHelper_.getConsumerProtectionPreference());
+            }
+        } catch (JSONException e) {
+            BranchLogger.d(e.getMessage());
+        }
+    }
+
 
     /**
      * <p>Provides the path to server for this request.
@@ -624,6 +634,9 @@ public abstract class ServerRequest {
         if (shouldAddDMAParams()) {
             addDMAParams();
         }
+
+        addConsumerProtectionPreference();
+
     }
     
     void doFinalUpdateOnBackgroundThread() {

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -197,16 +197,22 @@ public abstract class ServerRequest {
         }
     }
 
-    void updateConsumerProtectionAttributionLevel() {
-        try {
-            if (prefHelper_.getConsumerProtectionAttributionLevel() != null) {
-                params_.put(Defines.Jsonkey.Consumer_Protection_Attribution_Level.getKey(), prefHelper_.getConsumerProtectionAttributionLevel().ordinal());
+    private void addConsumerProtectionAttributionLevel() {
+        if (prefHelper_.isAttributionLevelInitialized()) {
+            try {
+                if (getBranchRemoteAPIVersion() == BRANCH_API_VERSION.V1) {
+                    params_.put(Defines.Jsonkey.Consumer_Protection_Attribution_Level.getKey(), prefHelper_.getConsumerProtectionAttributionLevel().toString());
+                } else {
+                    JSONObject userDataObj = params_.optJSONObject(Defines.Jsonkey.UserData.getKey());
+                    if (userDataObj != null) {
+                        userDataObj.put(Defines.Jsonkey.Consumer_Protection_Attribution_Level.getKey(), prefHelper_.getConsumerProtectionAttributionLevel().toString());
+                    }
+                }
+            } catch (JSONException e) {
+                BranchLogger.d(e.getMessage());
             }
-        } catch (JSONException e) {
-            BranchLogger.d(e.getMessage());
         }
     }
-
 
     /**
      * <p>Provides the path to server for this request.
@@ -634,7 +640,7 @@ public abstract class ServerRequest {
         if (shouldAddDMAParams()) {
             addDMAParams();
         }
-        updateConsumerProtectionAttributionLevel();
+        addConsumerProtectionAttributionLevel();
     }
     
     void doFinalUpdateOnBackgroundThread() {

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -197,10 +197,10 @@ public abstract class ServerRequest {
         }
     }
 
-    void updateConsumerProtectionPreference() {
+    void updateConsumerProtectionAttributionLevel() {
         try {
-            if (prefHelper_.getConsumerProtectionPreference() != null) {
-                params_.put(Defines.Jsonkey.Consumer_Protection_Preference.getKey(), prefHelper_.getConsumerProtectionPreference().ordinal());
+            if (prefHelper_.getConsumerProtectionAttributionLevel() != null) {
+                params_.put(Defines.Jsonkey.Consumer_Protection_Attribution_Level.getKey(), prefHelper_.getConsumerProtectionAttributionLevel().ordinal());
             }
         } catch (JSONException e) {
             BranchLogger.d(e.getMessage());
@@ -634,7 +634,7 @@ public abstract class ServerRequest {
         if (shouldAddDMAParams()) {
             addDMAParams();
         }
-        updateConsumerProtectionPreference();
+        updateConsumerProtectionAttributionLevel();
     }
     
     void doFinalUpdateOnBackgroundThread() {

--- a/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
@@ -29,6 +29,7 @@ public class TrackingController {
         // If the tracking state is already set to the desired state, then return instantly
         if (trackingDisabled == disableTracking) {
             if (callback != null) {
+                BranchLogger.v("Tracking state is already set to " + disableTracking + ". Returning the same to the callback");
                 callback.onTrackingStateChanged(trackingDisabled, Branch.getInstance().getFirstReferringParams(), null);
             }
             return;
@@ -38,11 +39,13 @@ public class TrackingController {
         PrefHelper.getInstance(context).setBool(PrefHelper.KEY_TRACKING_STATE, disableTracking);
 
         if (disableTracking) {
+            BranchLogger.v("Tracking disabled. Clearing all pending requests");
             onTrackingDisabled(context);
             if (callback != null) {
                 callback.onTrackingStateChanged(true, null, null);
             }
         } else {
+            BranchLogger.v("Tracking enabled. Registering app init");
             onTrackingEnabled((referringParams, error) -> {
                 if (callback != null) {
                     callback.onTrackingStateChanged(false, referringParams, error);

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Sun Apr 07 13:06:19 PDT 2024
+#Wed Nov 06 12:51:09 PST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Reference
SDK-2459 -- [Android] Implement Consumer Protection Preferences

## Description
Added a new method for setting the consumer protection preference, setConsumerProtectionPreference. This value can be set and changed at any time, but persists across sessions. This change also deprecated the `disableTracking()` method since  setting the preference to `TRACKING_DISABLED` will perform the same logic.

## Testing Instructions
<!-- TESTING INSTRUCTIONS -->
Use the new method or the new testbed "Consumer Protection Preference" button to change the preference and observe the `protection_preference` field change in each request. 

## Risk Assessment [`MEDIUM`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->
It deprecated a frequently used method and replaces it with a new one with some shared logic.

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
