### PR TITLE
[INTENG-20861] v1/install is triggered before Install Referrer Data is fully fetched.

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1483,11 +1483,13 @@ public class Branch {
 
             if (request instanceof ServerRequestRegisterInstall) {
                 request.addProcessWaitLock(ServerRequest.PROCESS_WAIT_LOCK.INSTALL_REFERRER_FETCH_WAIT_LOCK);
+                BranchLogger.v("Adding INSTALL_REFERRER_FETCH_WAIT_LOCK");
 
                 deviceInfo_.getSystemObserver().fetchInstallReferrer(context_, new SystemObserver.InstallReferrerFetchEvents(){
                     @Override
                     public void onInstallReferrersFinished() {
                         request.removeProcessWaitLock(ServerRequest.PROCESS_WAIT_LOCK.INSTALL_REFERRER_FETCH_WAIT_LOCK);
+                        BranchLogger.v("INSTALL_REFERRER_FETCH_WAIT_LOCK removed");
                         requestQueue_.processNextQueueItem("onInstallReferrersFinished");
                     }
                 });

--- a/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
@@ -600,9 +600,13 @@ abstract class SystemObserver {
 
                 @Override
                 public void resumeWith(@NonNull Object o) {
-                    BranchLogger.v("fetchInstallReferrer resumeWith got result: " + o);
-                    InstallReferrerResult latestReferrer = (InstallReferrerResult) o;
-                    AppStoreReferrer.processReferrerInfo(context_, latestReferrer.getLatestRawReferrer(), latestReferrer.getLatestClickTimestamp(), latestReferrer.getLatestInstallTimestamp(), latestReferrer.getAppStore(), latestReferrer.isClickThrough());
+                    if (o != null) {
+                        BranchLogger.v("fetchInstallReferrer resumeWith got result: " + o);
+                        InstallReferrerResult latestReferrer = (InstallReferrerResult) o;
+                        AppStoreReferrer.processReferrerInfo(context_, latestReferrer.getLatestRawReferrer(), latestReferrer.getLatestClickTimestamp(), latestReferrer.getLatestInstallTimestamp(), latestReferrer.getAppStore(), latestReferrer.isClickThrough());
+                    } else {
+                        BranchLogger.v("fetchInstallReferrer resumeWith got null result");
+                    }
 
                     if (callback != null) {
                         callback.onInstallReferrersFinished();

--- a/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
@@ -600,18 +600,18 @@ abstract class SystemObserver {
 
                 @Override
                 public void resumeWith(@NonNull Object o) {
-                    if (o != null) {
-                        InstallReferrerResult latestReferrer = (InstallReferrerResult) o;
-                        AppStoreReferrer.processReferrerInfo(context_, latestReferrer.getLatestRawReferrer(), latestReferrer.getLatestClickTimestamp(), latestReferrer.getLatestInstallTimestamp(), latestReferrer.getAppStore(), latestReferrer.isClickThrough());
+                    BranchLogger.v("fetchInstallReferrer resumeWith got result: " + o);
+                    InstallReferrerResult latestReferrer = (InstallReferrerResult) o;
+                    AppStoreReferrer.processReferrerInfo(context_, latestReferrer.getLatestRawReferrer(), latestReferrer.getLatestClickTimestamp(), latestReferrer.getLatestInstallTimestamp(), latestReferrer.getAppStore(), latestReferrer.isClickThrough());
+
+                    if (callback != null) {
+                        callback.onInstallReferrersFinished();
                     }
                 }
             });
-        }
-        catch(Exception e){
+        } catch(Exception e) {
             BranchLogger.e("Caught Exception SystemObserver fetchInstallReferrer " + e.getMessage());
-        }
-        finally {
-            if(callback != null){
+            if (callback != null) {
                 callback.onInstallReferrersFinished();
             }
         }


### PR DESCRIPTION
## Reference
INTENG-20861 -- v1/install is triggered before Meta Install Referral Data is fully fetched.  

## Description
<!-- SUFFICIENT DESCRIPTION TO EXPLAIN THE PROBLEM THAT IS BEING SOLVED -->
When using `deferInitForPluginRuntime` with our React Native plugin, we encountered an issue where not all install referrers were fetched in time to be included in the `v1/install` request. This happened despite having a lock that should have ensured the fetch completed before continuing.

The issue was primarily observed when using `deferInitForPluginRuntime` and React Native, but did not occur consistently in native Android apps or when `deferInitForPluginRuntime` was not used.

The problem stemmed from the `callback.onInstallReferrersFinished()` being called in the finally block, which executed before the coroutine in the try block could finish. This caused the install referrer lock to be added and then instantly removed, leading to incomplete referrer data.

To resolve this, the `callback.onInstallReferrersFinished()` was moved from the finally block into the `resumeWith` and catch blocks. This ensures the callback is only triggered once the coroutine has either successfully completed or an exception has been caught, preventing premature lock removal.

## Testing Instructions
<!-- TESTING INSTRUCTIONS -->
Use the React Native sample app provided in the Jira ticket. Simulate an install with any install referrer and observe the logs to confirm that the lock is added and removed only after the referrers are fully fetched.

## Risk Assessment [`MEDIUM`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->
Modifying the initialization code.

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
