### PR TITLE
[SDK-2487] Reverted minimum sdk version change

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,8 @@
 # Branch Android SDK change log
+- v5.12.4
+  * _*Master Release*_ - Sep 30, 2024
+  - Reverted the minimum SDK build version back to 21
+  
 - v5.12.3
   * _*Master Release*_ - Sep 25, 2024
   - Fix to properly fetch install referrers when using deferred init in plugins

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.12.3
-VERSION_CODE=051403
+VERSION_NAME=5.12.4
+VERSION_CODE=051404
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.
@@ -13,7 +13,7 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=branch
 POM_DEVELOPER_NAME=Branch Metrics
 
-ANDROID_BUILD_SDK_VERSION_MINIMUM=23
+ANDROID_BUILD_SDK_VERSION_MINIMUM=21
 ANDROID_BUILD_SDK_VERSION_COMPILE=34
 ANDROID_BUILD_TOOLS_VERSION=34.0.0
 android.useAndroidX=true


### PR DESCRIPTION
## Reference
SDK-SDK -- Reverted minimum sdk version change

## Description
Changed the minimum SDK from 23 back to 21 since some clients may not want to upgrade this value in their app yet.

Original PR: https://github.com/BranchMetrics/android-branch-deep-linking-attribution/pull/1213

## Testing Instructions
Ensure the SDK still builds and integrates properly and all of the SDK's features still function.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
