### PR TITLE
[SDK-2485] Remove cached events

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -408,7 +408,6 @@ public abstract class ServerRequest {
      */
     private static ServerRequest getExtendedServerRequest(String requestPath, JSONObject post, Context context, boolean initiatedByClient) {
         ServerRequest extendedReq = null;
-
         if (requestPath.equalsIgnoreCase(Defines.RequestPath.GetURL.getPath())) {
             extendedReq = new ServerRequestCreateUrl(Defines.RequestPath.GetURL, post, context);
         } else if (requestPath.equalsIgnoreCase(Defines.RequestPath.RegisterInstall.getPath())) {
@@ -416,7 +415,6 @@ public abstract class ServerRequest {
         } else if (requestPath.equalsIgnoreCase(Defines.RequestPath.RegisterOpen.getPath())) {
             extendedReq = new ServerRequestRegisterOpen(Defines.RequestPath.RegisterOpen, post, context, initiatedByClient);
         }
-
         return extendedReq;
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -396,29 +396,6 @@ public abstract class ServerRequest {
     }
     
     /**
-     * <p>Factory method for creating the specific server requests objects. Creates requests according
-     * to the request path.</p>
-     *
-     * @param requestPath Path for the server request. see {@link Defines.RequestPath}
-     * @param post        A {@link JSONObject} object containing post data stored as key-value pairs.
-     * @param context     Application context.
-     * @return A {@link ServerRequest} object for the given Post data.
-     */
-    private static ServerRequest getExtendedServerRequest(String requestPath, JSONObject post, Context context, boolean initiatedByClient) {
-        ServerRequest extendedReq = null;
-        
-        if (requestPath.equalsIgnoreCase(Defines.RequestPath.GetURL.getPath())) {
-            extendedReq = new ServerRequestCreateUrl(Defines.RequestPath.GetURL, post, context);
-        } else if (requestPath.equalsIgnoreCase(Defines.RequestPath.RegisterInstall.getPath())) {
-            extendedReq = new ServerRequestRegisterInstall(Defines.RequestPath.RegisterInstall, post, context, initiatedByClient);
-        } else if (requestPath.equalsIgnoreCase(Defines.RequestPath.RegisterOpen.getPath())) {
-            extendedReq = new ServerRequestRegisterOpen(Defines.RequestPath.RegisterOpen, post, context, initiatedByClient);
-        }
-        
-        return extendedReq;
-    }
-    
-    /**
      * Updates the google ads parameters. This should be called only from a background thread since it involves GADS method invocation using reflection
      * Ensure that when there is a valid GAID/AID, remove the SSAID if it's being used
      * Otherwise we're good to send the generated UUID

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -348,7 +348,8 @@ public abstract class ServerRequest {
         }
         return json;
     }
-    
+
+    // TODO: Replace with in-memory only ServerRequest objects.
     /**
      * <p>Converts a {@link JSONObject} object containing keys stored as key-value pairs into
      * a {@link ServerRequest}.</p>
@@ -388,13 +389,37 @@ public abstract class ServerRequest {
         } catch (JSONException e) {
             BranchLogger.w("Caught JSONException " + e.getMessage());
         }
-        
+
         if (!TextUtils.isEmpty(requestPath)) {
             return getExtendedServerRequest(requestPath, post, context, initiatedByClient);
         }
         return null;
     }
-    
+
+    // TODO: Replace with in-memory only ServerRequest objects.
+    /**
+     * <p>Factory method for creating the specific server requests objects. Creates requests according
+     * to the request path.</p>
+     *
+     * @param requestPath Path for the server request. see {@link Defines.RequestPath}
+     * @param post        A {@link JSONObject} object containing post data stored as key-value pairs.
+     * @param context     Application context.
+     * @return A {@link ServerRequest} object for the given Post data.
+     */
+    private static ServerRequest getExtendedServerRequest(String requestPath, JSONObject post, Context context, boolean initiatedByClient) {
+        ServerRequest extendedReq = null;
+
+        if (requestPath.equalsIgnoreCase(Defines.RequestPath.GetURL.getPath())) {
+            extendedReq = new ServerRequestCreateUrl(Defines.RequestPath.GetURL, post, context);
+        } else if (requestPath.equalsIgnoreCase(Defines.RequestPath.RegisterInstall.getPath())) {
+            extendedReq = new ServerRequestRegisterInstall(Defines.RequestPath.RegisterInstall, post, context, initiatedByClient);
+        } else if (requestPath.equalsIgnoreCase(Defines.RequestPath.RegisterOpen.getPath())) {
+            extendedReq = new ServerRequestRegisterOpen(Defines.RequestPath.RegisterOpen, post, context, initiatedByClient);
+        }
+
+        return extendedReq;
+    }
+
     /**
      * Updates the google ads parameters. This should be called only from a background thread since it involves GADS method invocation using reflection
      * Ensure that when there is a valid GAID/AID, remove the SSAID if it's being used

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -408,6 +408,7 @@ public abstract class ServerRequest {
      */
     private static ServerRequest getExtendedServerRequest(String requestPath, JSONObject post, Context context, boolean initiatedByClient) {
         ServerRequest extendedReq = null;
+
         if (requestPath.equalsIgnoreCase(Defines.RequestPath.GetURL.getPath())) {
             extendedReq = new ServerRequestCreateUrl(Defines.RequestPath.GetURL, post, context);
         } else if (requestPath.equalsIgnoreCase(Defines.RequestPath.RegisterInstall.getPath())) {
@@ -417,7 +418,7 @@ public abstract class ServerRequest {
         }
         return extendedReq;
     }
-
+    
     /**
      * Updates the google ads parameters. This should be called only from a background thread since it involves GADS method invocation using reflection
      * Ensure that when there is a valid GAID/AID, remove the SSAID if it's being used

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -139,16 +139,7 @@ public abstract class ServerRequest {
     public boolean shouldRetryOnFail() {
         return false;
     }
-    
-    /**
-     * Specifies whether this request should be persisted to memory in order to re send in the next session
-     *
-     * @return {@code true} by default. Should be override for request that need not to be persisted
-     */
-    boolean isPersistable() {
-        return true;
-    }
-    
+
     /**
      * Specifies whether this request should add the limit app tracking value
      *
@@ -418,7 +409,7 @@ public abstract class ServerRequest {
         }
         return extendedReq;
     }
-    
+
     /**
      * Updates the google ads parameters. This should be called only from a background thread since it involves GADS method invocation using reflection
      * Ensure that when there is a valid GAID/AID, remove the SSAID if it's being used

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestCreateUrl.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestCreateUrl.java
@@ -258,11 +258,6 @@ class ServerRequestCreateUrl extends ServerRequest {
     }
 
     @Override
-    boolean isPersistable() {
-        return false; // No need to retrieve create url request from previous session
-    }
-
-    @Override
     protected boolean prepareExecuteWithoutTracking() {
         // SDK-271 -- Allow creation of short links when tracking is disabled.
         return true;

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 import  org.gradle.api.tasks.testing.logging.*
 
 plugins {
-    id("com.android.library") version "8.1.2" apply false
-    id("com.android.application") version "8.1.2" apply false
+    id("com.android.library") version "8.3.2" apply false
+    id("com.android.application") version "8.3.2" apply false
     id("org.jetbrains.kotlin.android") version "1.6.21" apply false
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Sun Apr 07 13:06:19 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Reference
SDK-2488 -- [Android] [Spike] Factor out persisted events/ In-memory only execution

## Description
Behavior between the iOS and Android SDKs concerning what to do with "cached events" has been inconsistent and has led to undesirable behavior. This PR simply removes the notion of cached events, which are read from disk _only_ when the Branch Singleton instance is initialized.

Events that fail during app foreground (no internet, failed server request) are not stored and are thus lost, never persisted to the disk. Further, only opens were able to be serialized. https://github.com/BranchMetrics/android-branch-deep-linking-attribution/issues/1215

`v1/url` was serialized, but never replayed.

Background processing of events is not yet in scope.

Keeping utility function as other unrelated tests have a dependency on manually creating `ServerRequest` objects.

## Testing Instructions
Prior behavior: open events will be added to the queue and persisted. Immediately background and close the app before the network request is executed and the request will be replayed.

After: SDK skips this steps and proceeds to process new open request, by design.

## Risk Assessment [`LOW`]

<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
