### PR TITLE
Adding config for full initialization through Tracking Controller

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -538,9 +538,17 @@ public class Branch {
      *                        ({@code false}).
      * @param callback An optional {@link TrackingStateCallback} instance for receiving callback notifications about
      *                 the change in tracking state. This parameter can be {@code null} if no callback actions are needed.
+     * @param ignoreInitializationTasks A boolean to determine whether the SDK will execute tasks such as fetching
+     *                                  Install Referrer, Advertiser ID, or even the URI which opened the app.
+     *                                  Set to ({@code false}) if the SDK should obtain these values first before initializing.
+     *                                  Default is ({@code true}), which is the original behavior to only send an Open request
+     *                                  as soon as possible.
      */
+    public void disableTracking(boolean disableTracking, @Nullable TrackingStateCallback callback, boolean ignoreInitializationTasks) {
+        trackingController.disableTracking(context_, disableTracking, callback, ignoreInitializationTasks);
+    }
     public void disableTracking(boolean disableTracking, @Nullable TrackingStateCallback callback) {
-        trackingController.disableTracking(context_, disableTracking, callback);
+        disableTracking(disableTracking, callback, true);
     }
     public void disableTracking(boolean disableTracking) {
         disableTracking(disableTracking, null);

--- a/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
@@ -447,6 +447,7 @@ abstract class SystemObserver {
      * @return {@link Boolean} with true if GAID fetch process started.
      */
     public void fetchAdId(Context context, AdsParamsFetchEvents callback) {
+        BranchLogger.v("Begin fetchAdId");
         if (isFireOSDevice()) {
             setFireAdId(context, callback);
         }
@@ -469,6 +470,7 @@ abstract class SystemObserver {
 
                 @Override
                 public void resumeWith(Object o) {
+                    BranchLogger.v("fetchHuaweiAdId resumeWith " + o);
                     try {
                         if (o != null) {
                             com.huawei.hms.ads.identifier.AdvertisingIdClient.Info info = (com.huawei.hms.ads.identifier.AdvertisingIdClient.Info) o;
@@ -508,6 +510,7 @@ abstract class SystemObserver {
 
 
     private void fetchGoogleAdId(Context context, AdsParamsFetchEvents callback) {
+        BranchLogger.v("Begin fetchGoogleAdId");
         if(DependencyUtilsKt.classExists(DependencyUtilsKt.playStoreAdvertisingIdClientClass)) {
             AdvertisingIdsKt.getGoogleAdvertisingInfoObject(context, new Continuation<AdvertisingIdClient.Info>() {
                 @NonNull
@@ -518,6 +521,7 @@ abstract class SystemObserver {
 
                 @Override
                 public void resumeWith(Object o) {
+                    BranchLogger.v("fetchGoogleAdId resumeWith " + o);
                     try {
                         if (o != null) {
                             AdvertisingIdClient.Info info = (AdvertisingIdClient.Info) o;
@@ -565,6 +569,7 @@ abstract class SystemObserver {
 
             @Override
             public void resumeWith(@NonNull Object o) {
+                BranchLogger.v("setFireAdId resumeWith " + o);
                 try {
                     if (o != null) {
                         Pair<Integer, String> info = (Pair<Integer, String>) o;
@@ -590,6 +595,7 @@ abstract class SystemObserver {
     }
 
     public void fetchInstallReferrer(Context context_, InstallReferrerFetchEvents callback) {
+        BranchLogger.v("Begin fetchInstallReferrer");
         try {
             InstallReferrersKt.fetchLatestInstallReferrer(context_, new Continuation<InstallReferrerResult>() {
                 @NonNull

--- a/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
@@ -24,7 +24,8 @@ public class TrackingController {
         updateTrackingState(context);
     }
 
-    void disableTracking(Context context, boolean disableTracking, @Nullable Branch.TrackingStateCallback callback) {
+    void disableTracking(Context context, boolean disableTracking, @Nullable Branch.TrackingStateCallback callback, boolean ignoreWaitLocks){
+        BranchLogger.v("disableTracking called with context " + context + " disableTracking " + disableTracking + " callback " + callback + " ignoreWaitLocks " + ignoreWaitLocks);
         // If the tracking state is already set to the desired state, then return instantly
         if (trackingDisabled == disableTracking) {
             if (callback != null) {
@@ -46,8 +47,14 @@ public class TrackingController {
                 if (callback != null) {
                     callback.onTrackingStateChanged(false, referringParams, error);
                 }
-            });
+            }, ignoreWaitLocks);
         }
+    }
+
+    // Preserve the original behavior of this API, originally ignore wait locks would have been true
+    // Which signals to the initialization process to ignore fetching advertising ID, install referrer
+    void disableTracking(Context context, boolean disableTracking, @Nullable Branch.TrackingStateCallback callback) {
+        disableTracking(context, disableTracking, callback, true);
     }
 
     boolean isTrackingDisabled() {
@@ -85,10 +92,11 @@ public class TrackingController {
         Branch.getInstance().clearPartnerParameters();
     }
     
-    private void onTrackingEnabled(Branch.BranchReferralInitListener callback) {
+    private void onTrackingEnabled(Branch.BranchReferralInitListener callback, boolean ignoreWaitLocks) {
+        BranchLogger.v("onTrackingEnabled with callback " + callback + " ignoring wait locks " + ignoreWaitLocks);
         Branch branch = Branch.getInstance();
         if (branch != null) {
-            branch.registerAppInit(branch.getInstallOrOpenRequest(callback, true), true, false);
+            branch.registerAppInit(branch.getInstallOrOpenRequest(callback, true), ignoreWaitLocks, false);
         }
     }
 }


### PR DESCRIPTION
## Reference
SDK-XXX -- <TITLE>.

## Description
For implementations where the developer delays initialization of the Branch SDK _and_ uses the tracking controller to disable event processing before initialization, the SDK would only be able to start if reenabled by `Branch.getInstance().disableTracking(false, ...)`. 

Upon doing so, the SDK would re-initialize but _would not_ obtain the Install Referrer, Advertiser ID, or even possibly the URI, as the SDK immediately creates an Open request, without waiting for those parameters. This race condition would very likely lead to the omission of these fields in the first open request.

To resolve, an additional field is added to explicitly wait for these fields, replicating the behavior of a traditional session initialization.


## Testing Instructions
The implementation requires the following:
```
Branch.expectDelayedSessionInitialization(true);
Branch.getAutoInstance(this);
Branch.getInstance().disableTracking(true, new Branch.TrackingStateCallback() {
    @Override
    public void onTrackingStateChanged(boolean trackingDisabled, @Nullable JSONObject referringParams, @Nullable BranchError error) {
        Log.d("BranchSDK_Tester", "trackingDisabled " + trackingDisabled + " referringParams " + referringParams + " error " + error);
    }
});
```

Where the controller must disable tracking in the App class before any Activity. Validate that the aaid is not in the install post request.

When re-enabling, implement the fix by calling 
```
Branch.getInstance().disableTracking(true, new Branch.TrackingStateCallback() {
    @Override
    public void onTrackingStateChanged(boolean trackingDisabled, @Nullable JSONObject referringParams, @Nullable BranchError error) {
        Log.d("BranchSDK_Tester", "trackingDisabled " + trackingDisabled + " referringParams " + referringParams + " error " + error);
    }
}, false); // False to execute all init tasks
```
You should see the aaid field in the install post request. Verify as well that the link returns parameters.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
