### PR TITLE
Always execute init tasks through Tracking Controller

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
@@ -459,6 +459,7 @@ abstract class SystemObserver {
     }
 
     private void fetchHuaweiAdId(Context context, AdsParamsFetchEvents callback) {
+        BranchLogger.v("Begin fetchHuaweiAdId");
         if(DependencyUtilsKt.classExists(DependencyUtilsKt.huaweiAdvertisingIdClientClass)) {
             AdvertisingIdsKt.getHuaweiAdvertisingInfoObject(context, new Continuation<com.huawei.hms.ads.identifier.AdvertisingIdClient.Info>() {
                 @NonNull
@@ -508,6 +509,7 @@ abstract class SystemObserver {
 
 
     private void fetchGoogleAdId(Context context, AdsParamsFetchEvents callback) {
+        BranchLogger.v("Begin fetchGoogleAdId");
         if(DependencyUtilsKt.classExists(DependencyUtilsKt.playStoreAdvertisingIdClientClass)) {
             AdvertisingIdsKt.getGoogleAdvertisingInfoObject(context, new Continuation<AdvertisingIdClient.Info>() {
                 @NonNull
@@ -555,7 +557,7 @@ abstract class SystemObserver {
     }
 
     private void setFireAdId(Context context, AdsParamsFetchEvents callback) {
-        BranchLogger.v("setFireAdId");
+        BranchLogger.v("Begin setFireAdId");
         AdvertisingIdsKt.getAmazonFireAdvertisingInfoObject(context, new Continuation<Pair<? extends Integer, ? extends String>>() {
             @NonNull
             @Override
@@ -590,6 +592,7 @@ abstract class SystemObserver {
     }
 
     public void fetchInstallReferrer(Context context_, InstallReferrerFetchEvents callback) {
+        BranchLogger.v("Begin fetchInstallReferrer");
         try {
             InstallReferrersKt.fetchLatestInstallReferrer(context_, new Continuation<InstallReferrerResult>() {
                 @NonNull

--- a/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/TrackingController.java
@@ -25,6 +25,7 @@ public class TrackingController {
     }
 
     void disableTracking(Context context, boolean disableTracking, @Nullable Branch.TrackingStateCallback callback) {
+        BranchLogger.v("disableTracking context: " + context + " disableTracking: " + disableTracking + " callback: " + callback);
         // If the tracking state is already set to the desired state, then return instantly
         if (trackingDisabled == disableTracking) {
             if (callback != null) {
@@ -86,9 +87,10 @@ public class TrackingController {
     }
     
     private void onTrackingEnabled(Branch.BranchReferralInitListener callback) {
+        BranchLogger.v("onTrackingEnabled callback: " + callback);
         Branch branch = Branch.getInstance();
         if (branch != null) {
-            branch.registerAppInit(branch.getInstallOrOpenRequest(callback, true), true, false);
+            branch.registerAppInit(branch.getInstallOrOpenRequest(callback, true), false);
         }
     }
 }


### PR DESCRIPTION
## Reference
SDK-XXX -- <TITLE>.

## Description
For implementations where the developer delays initialization of the Branch SDK and uses the tracking controller to disable event processing before initialization, the SDK would only be able to start if reenabled by `Branch.getInstance().disableTracking(false, ...)`.

Upon doing so, the SDK would re-initialize but would not obtain the Install Referrer, Advertiser ID, or even possibly the URI, as the SDK immediately creates an Open request, without waiting for those parameters. This race condition would very likely lead to the omission of these fields in the first open/install request.

To resolve, the legacy check to bypass these retrieval methods has been removed and the new behavior is to always execute these routines.

## Testing Instructions
The implementation requires the following:
```
Branch.expectDelayedSessionInitialization(true);
Branch.getAutoInstance(this);
Branch.getInstance().disableTracking(true, new Branch.TrackingStateCallback() {
    @Override
    public void onTrackingStateChanged(boolean trackingDisabled, @Nullable JSONObject referringParams, @Nullable BranchError error) {
        Log.d("BranchSDK_Tester", "trackingDisabled " + trackingDisabled + " referringParams " + referringParams + " error " + error);
    }
});
```
Where the controller must disable tracking in the App class before any Activity. 
Then re-enable manually once some time has passed.
Validate that the aaid is not in the install post request.

Repeat with this change and observe the presence of the AAID.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
