### PR TITLE
Release 5.14.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,9 @@
 # Branch Android SDK change log
+- v5.14.0
+* _*Master Release*_ - Nov 18, 2024
+  - Added `setConsumerProtectionAttributionLevel` for controlling attribution data collection
+  - Deprecated `disableTracking` in favor of `setConsumerProtectionAttributionLevel(NONE)`
+  
 - v5.13.0
 * _*Master Release*_ - Oct 29, 2024
   - Removal of internal event caching behavior

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.13.0
-VERSION_CODE=051500
+VERSION_NAME=5.14.0
+VERSION_CODE=051600
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.


### PR DESCRIPTION
  - Added `setConsumerProtectionAttributionLevel` for controlling attribution data collection
  - Deprecated `disableTracking` in favor of `setConsumerProtectionAttributionLevel(NONE)`
 