### PR TITLE
[SDK-2523] Added CPP level to branch.json

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -381,6 +381,8 @@ public class Branch {
 
             BranchUtil.setFbAppIdFromConfig(context);
 
+            BranchUtil.setCPPLevel(context);
+
             BranchUtil.setTestMode(BranchUtil.checkTestMode(context));
             branchReferral_ = initBranchSDK(context, BranchUtil.readBranchKey(context));
             getPreinstallSystemData(branchReferral_, context);
@@ -410,6 +412,7 @@ public class Branch {
 
             BranchUtil.setAPIBaseUrlFromConfig(context);
             BranchUtil.setFbAppIdFromConfig(context);
+            BranchUtil.setCPPLevel(context);
             BranchUtil.setTestMode(BranchUtil.checkTestMode(context));
             // If a Branch key is passed already use it. Else read the key
             if (!isValidBranchKey(branchKey)) {

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchJsonConfig.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchJsonConfig.java
@@ -31,7 +31,8 @@ public class BranchJsonConfig {
         enableLogging,
         deferInitForPluginRuntime,
         apiUrl,
-        fbAppId
+        fbAppId,
+        cppLevel
     }
 
     /*
@@ -48,7 +49,8 @@ public class BranchJsonConfig {
             "enableLogging": true,
             "deferInitForPluginRuntime": true,
             "apiUrl": "https://api2.branch.io",
-            "fbAppId": "xyz123456789"
+            "fbAppId": "xyz123456789",
+            "consumerProtectionAttributionLevel: "Reduced"
        }
     */
 
@@ -217,6 +219,25 @@ public class BranchJsonConfig {
             }
             
             return mConfiguration.getString(BranchJsonKey.fbAppId.toString());
+        }
+        catch (JSONException exception) {
+            Log.e(TAG, "Error parsing branch.json: " + exception.getMessage());
+            return null;
+        }
+    }
+
+    @Nullable
+    public String getConsumerProtectionAttributionLevel() {
+        if (mConfiguration == null) {
+            return null;
+        }
+
+        try {
+            if (!mConfiguration.has(BranchJsonKey.cppLevel.toString())) {
+                return null;
+            }
+
+            return mConfiguration.getString(BranchJsonKey.cppLevel.toString());
         }
         catch (JSONException exception) {
             Log.e(TAG, "Error parsing branch.json: " + exception.getMessage());

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchUtil.java
@@ -156,6 +156,12 @@ public class BranchUtil {
         }
     }
 
+    public static void setCPPLevel(Context context) {
+        BranchJsonConfig jsonConfig = BranchJsonConfig.getInstance(context);
+        Defines.BranchAttributionLevel cppLevel = Defines.BranchAttributionLevel.valueOf(jsonConfig.getConsumerProtectionAttributionLevel());
+        Branch.getInstance().setConsumerProtectionAttributionLevel(cppLevel);
+    }
+
     /**
      * Get the value of "io.branch.sdk.TestMode" entry in application manifest or from String res.
      * This value can be overridden via. {@link Branch#enableTestMode()}


### PR DESCRIPTION
## Reference
SDK-2523 -- Support CPP level in branch.json

## Description
Added a check in the brach.json for the CPP Level

## Testing Instructions
Add consumerProtectionAttributionLevel: "Full/Reduced/None" to branch.json and observe the CPP level being changed.

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
