### PR TITLE
[INTENG-20913] - Fix initial referrer on re-open

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -892,6 +892,7 @@ public class Branch {
 
             // Capture the intent URI and extra for analytics in case started by external intents such as google app search
             extractExternalUriAndIntentExtras(data, activity);
+            extractInitialReferrer(activity);
 
             // if branch link is detected we don't need to look for click ID or app link anymore and can terminate early
             if (extractBranchLinkFromIntentExtra(activity)) return;
@@ -2264,6 +2265,19 @@ public class Branch {
         }
     }
 
+    private void extractInitialReferrer(Activity activity){
+        BranchLogger.v("extractInitialReferrer " + activity);
+
+        if(activity != null){
+            Uri initialReferrer = ActivityCompat.getReferrer(activity);
+            BranchLogger.v("Initial referrer: " + initialReferrer);
+
+            if(initialReferrer != null) {
+                prefHelper_.setInitialReferrer(initialReferrer.toString());
+            }
+        }
+    }
+
     @Nullable Activity getCurrentActivity() {
         if (currentActivityReference_ == null) return null;
         return currentActivityReference_.get();
@@ -2415,9 +2429,17 @@ public class Branch {
 
             Activity activity = branch.getCurrentActivity();
             Intent intent = activity != null ? activity.getIntent() : null;
+            Uri initialReferrer = null;
 
-            if (activity != null && intent != null && ActivityCompat.getReferrer(activity) != null) {
-                PrefHelper.getInstance(activity).setInitialReferrer(ActivityCompat.getReferrer(activity).toString());
+            if(activity != null) {
+             initialReferrer = ActivityCompat.getReferrer(activity);
+            }
+
+            BranchLogger.v("Activity: " + activity);
+            BranchLogger.v("Intent: " + intent);
+            BranchLogger.v("Initial Referrer: " + initialReferrer);
+            if (activity != null && intent != null &&  initialReferrer!= null) {
+                PrefHelper.getInstance(activity).setInitialReferrer(initialReferrer.toString());
             }
 
             if (uri != null) {

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -1132,6 +1132,7 @@ public class PrefHelper {
      * @param initialReferrer android.intent.extra.REFERRER
      */
     public void setInitialReferrer(String initialReferrer) {
+        BranchLogger.v("setInitialReferrer " + initialReferrer);
         setString(KEY_INITIAL_REFERRER, initialReferrer);
     }
 
@@ -1141,7 +1142,9 @@ public class PrefHelper {
      * @return {@link String} android.intent.extra.REFERRER
      */
     public String getInitialReferrer() {
-        return getString(KEY_INITIAL_REFERRER);
+        String initialReferrer = getString(KEY_INITIAL_REFERRER);
+        BranchLogger.v("getInitialReferrer " + initialReferrer);
+        return initialReferrer;
     }
 
 

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -54,9 +54,6 @@ abstract class ServerRequestInitSession extends ServerRequest {
         if (!DeviceInfo.isNullOrEmptyOrBlank(appVersion)) {
             post.put(Defines.Jsonkey.AppVersion.getKey(), appVersion);
         }
-        if(!TextUtils.isEmpty(prefHelper_.getInitialReferrer()) && !prefHelper_.getInitialReferrer().equals(PrefHelper.NO_STRING_VALUE)) {
-            post.put(Defines.Jsonkey.InitialReferrer.getKey(), prefHelper_.getInitialReferrer());
-        }
 
         updateInstallStateAndTimestamps(post);
         updateEnvironment(context_, post);
@@ -191,18 +188,30 @@ abstract class ServerRequestInitSession extends ServerRequest {
         super.onPreExecute();
         JSONObject post = getPost();
         try {
-            if (!prefHelper_.getAppLink().equals(PrefHelper.NO_STRING_VALUE)) {
-                post.put(Defines.Jsonkey.AndroidAppLinkURL.getKey(), prefHelper_.getAppLink());
+            String appLink = prefHelper_.getAppLink();
+            if (!appLink.equals(PrefHelper.NO_STRING_VALUE)) {
+                post.put(Defines.Jsonkey.AndroidAppLinkURL.getKey(), appLink);
             }
-            if (!prefHelper_.getPushIdentifier().equals(PrefHelper.NO_STRING_VALUE)) {
-                post.put(Defines.Jsonkey.AndroidPushIdentifier.getKey(), prefHelper_.getPushIdentifier());
+
+            String pushIdentifier = prefHelper_.getPushIdentifier();
+            if (!pushIdentifier.equals(PrefHelper.NO_STRING_VALUE)) {
+                post.put(Defines.Jsonkey.AndroidPushIdentifier.getKey(), pushIdentifier);
             }
+
             // External URI or Extras if exist
-            if (!prefHelper_.getExternalIntentUri().equals(PrefHelper.NO_STRING_VALUE)) {
-                post.put(Defines.Jsonkey.External_Intent_URI.getKey(), prefHelper_.getExternalIntentUri());
+            String externalIntentUri = prefHelper_.getExternalIntentUri();
+            if (!externalIntentUri.equals(PrefHelper.NO_STRING_VALUE)) {
+                post.put(Defines.Jsonkey.External_Intent_URI.getKey(), externalIntentUri);
             }
-            if (!prefHelper_.getExternalIntentExtra().equals(PrefHelper.NO_STRING_VALUE)) {
-                post.put(Defines.Jsonkey.External_Intent_Extra.getKey(), prefHelper_.getExternalIntentExtra());
+
+            String externalIntentExtra = prefHelper_.getExternalIntentExtra();
+            if (!externalIntentExtra.equals(PrefHelper.NO_STRING_VALUE)) {
+                post.put(Defines.Jsonkey.External_Intent_Extra.getKey(), externalIntentExtra);
+            }
+
+            String initialReferrer = prefHelper_.getInitialReferrer();
+            if(!TextUtils.isEmpty(initialReferrer) && !initialReferrer.equals(PrefHelper.NO_STRING_VALUE)) {
+                post.put(Defines.Jsonkey.InitialReferrer.getKey(), initialReferrer);
             }
 
         } catch (JSONException e) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 import  org.gradle.api.tasks.testing.logging.*
 
 plugins {
-    id("com.android.library") version "8.3.2" apply false
-    id("com.android.application") version "8.3.2" apply false
+    id("com.android.library") version "8.7.3" apply false
+    id("com.android.application") version "8.7.3" apply false
     id("org.jetbrains.kotlin.android") version "1.6.21" apply false
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Wed Nov 06 12:51:09 PST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Reference
[INTENG-20913]

## Description
When re-opening the app, the initial referrer may be incorrectly cached or not set due to ordering of the server request post body generation and querying of the initial referrer. To resolve, an additional query is added to the request's `onPreExecute` phase to set the initial referrer, similar to what is already done for the app link, uri, and intent extras.

## Testing Instructions
<!-- TESTING INSTRUCTIONS -->

## Risk Assessment [`LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.


[INTENG-20913]: https://branch.atlassian.net/browse/INTENG-20913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ