### PR TITLE
[Android] Add Play Store Install Referrer server timestamps

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/coroutines/InstallReferrers.kt
+++ b/Branch-SDK/src/main/java/io/branch/coroutines/InstallReferrers.kt
@@ -43,7 +43,10 @@ suspend fun getGooglePlayStoreReferrerDetails(context: Context): InstallReferrer
                                 InstallReferrerResult(Jsonkey.Google_Play_Store.key,
                                     result.installBeginTimestampSeconds,
                                     result.installReferrer,
-                                    result.referrerClickTimestampSeconds)
+                                    result.referrerClickTimestampSeconds,
+                                    result.installBeginTimestampServerSeconds,
+                                    result.referrerClickTimestampServerSeconds
+                                )
                             }
                             catch (e: Exception) {
                                 BranchLogger.w("Caught getGooglePlayStoreReferrerDetails installReferrer exception: $e")
@@ -97,7 +100,9 @@ suspend fun getHuaweiAppGalleryReferrerDetails(context: Context): InstallReferre
                                         Jsonkey.Huawei_App_Gallery.key,
                                         result.installBeginTimestampSeconds,
                                         result.installReferrer,
-                                        result.referrerClickTimestampSeconds
+                                        result.referrerClickTimestampSeconds,
+                                        null,
+                                        null
                                     )
                                 } catch (e: Exception) {
                                     BranchLogger.w("Caught getHuaweiAppGalleryReferrerDetails exception: $e")
@@ -154,7 +159,9 @@ suspend fun getSamsungGalaxyStoreReferrerDetails(context: Context): InstallRefer
                                         Jsonkey.Samsung_Galaxy_Store.key,
                                         result.installBeginTimestampSeconds,
                                         result.installReferrer,
-                                        result.referrerClickTimestampSeconds
+                                        result.referrerClickTimestampSeconds,
+                                        null,
+                                        null
                                     )
                                 } catch (e: RemoteException) {
                                     BranchLogger.w("Caught getSamsungGalaxyStoreReferrerDetails exception: $e")
@@ -206,7 +213,9 @@ suspend fun getXiaomiGetAppsReferrerDetails(context: Context): InstallReferrerRe
                                         Jsonkey.Xiaomi_Get_Apps.key,
                                         result.installBeginTimestampSeconds,
                                         result.installReferrer,
-                                        result.referrerClickTimestampSeconds
+                                        result.referrerClickTimestampSeconds,
+                                        result.installBeginTimestampServerSeconds,
+                                        result.referrerClickTimestampServerSeconds
                                     )
                                 } catch (e: RemoteException) {
                                     BranchLogger.w("Caught getXiaomiGetAppsReferrerDetails exception: $e")
@@ -316,6 +325,8 @@ private fun queryProvider(context: Context, provider: String): InstallReferrerRe
                 latestInstallTimestamp,
                 installReferrerString,
                 actualTimestamp,
+                null,
+                null,
                 isClickThrough
             )
         } catch (e: JSONException) {

--- a/Branch-SDK/src/main/java/io/branch/coroutines/InstallReferrers.kt
+++ b/Branch-SDK/src/main/java/io/branch/coroutines/InstallReferrers.kt
@@ -40,7 +40,10 @@ suspend fun getGooglePlayStoreReferrerDetails(context: Context): InstallReferrer
                         deferredReferrerDetails.complete(
                             try {
                                 val result = client.installReferrer
-                                InstallReferrerResult(Jsonkey.Google_Play_Store.key, result.installBeginTimestampSeconds, result.installReferrer, result.referrerClickTimestampSeconds)
+                                InstallReferrerResult(Jsonkey.Google_Play_Store.key,
+                                    result.installBeginTimestampSeconds,
+                                    result.installReferrer,
+                                    result.referrerClickTimestampSeconds)
                             }
                             catch (e: Exception) {
                                 BranchLogger.w("Caught getGooglePlayStoreReferrerDetails installReferrer exception: $e")
@@ -363,7 +366,7 @@ fun getLatestValidReferrerStore(allReferrers: List<InstallReferrerResult?>): Ins
 
 fun getLatestInstallTimeStamp(allReferrers: List<InstallReferrerResult?>): InstallReferrerResult? {
     val result = allReferrers.filterNotNull().maxByOrNull {
-        it.latestInstallTimestamp
+        it.installBeginTimestampSeconds
     }
 
     return result
@@ -378,7 +381,7 @@ private fun handleMetaInstallReferrer(allReferrers: List<InstallReferrerResult?>
         //The Meta Referrer is click through. Return it if it or the matching Play Store referrer is the latest
         if (latestReferrer.appStore == Jsonkey.Google_Play_Store.key) {
             //Deduplicate the Meta and Play Store referrers
-            if (latestReferrer.latestClickTimestamp == metaReferrer.latestClickTimestamp) {
+            if (latestReferrer.referrerClickTimestampSeconds == metaReferrer.referrerClickTimestampSeconds) {
                 return  metaReferrer
             }
         }
@@ -387,12 +390,12 @@ private fun handleMetaInstallReferrer(allReferrers: List<InstallReferrerResult?>
     } else {
         //The Meta Referrer is view through. Return it if the Play Store referrer is organic (latestClickTimestamp is 0)
         val googleReferrer = allReferrers.filterNotNull().firstOrNull { it.appStore == Jsonkey.Google_Play_Store.key }
-        if (googleReferrer?.latestClickTimestamp == 0L) {
+        if (googleReferrer?.referrerClickTimestampSeconds == 0L) {
             result =  metaReferrer
         } else {
             val referrersWithoutMeta = allReferrers.filterNotNull().filterNot { it.appStore == Jsonkey.Meta_Install_Referrer.key }
             result = referrersWithoutMeta.maxByOrNull {
-                it.latestInstallTimestamp
+                it.installBeginTimestampSeconds
             }
         }
     }

--- a/Branch-SDK/src/main/java/io/branch/data/InstallReferrerResult.kt
+++ b/Branch-SDK/src/main/java/io/branch/data/InstallReferrerResult.kt
@@ -1,7 +1,7 @@
 package io.branch.data
 
 data class InstallReferrerResult (var appStore: String?,
-                                  var latestInstallTimestamp: Long,
-                                  var latestRawReferrer: String?,
-                                  var latestClickTimestamp: Long,
+                                  var installBeginTimestampSeconds: Long,
+                                  var installReferrer: String?,
+                                  var referrerClickTimestampSeconds: Long,
                                   var isClickThrough: Boolean = true)

--- a/Branch-SDK/src/main/java/io/branch/data/InstallReferrerResult.kt
+++ b/Branch-SDK/src/main/java/io/branch/data/InstallReferrerResult.kt
@@ -4,4 +4,6 @@ data class InstallReferrerResult (var appStore: String?,
                                   var installBeginTimestampSeconds: Long,
                                   var installReferrer: String?,
                                   var referrerClickTimestampSeconds: Long,
+                                  var installBeginTimestampServerSeconds: Long?,
+                                  var referrerClickTimestampServerSeconds: Long?,
                                   var isClickThrough: Boolean = true)

--- a/Branch-SDK/src/main/java/io/branch/referral/AppStoreReferrer.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/AppStoreReferrer.java
@@ -15,7 +15,14 @@ public class AppStoreReferrer {
     /* Link identifier on installing app from play store. */
     private static String installID_ = PrefHelper.NO_STRING_VALUE;
 
-    public static void processReferrerInfo(Context context, String rawReferrerString, long referrerClickTS, long installClickTS, String store, Boolean isClickThrough) {
+    public static void processReferrerInfo(Context context,
+                                           String rawReferrerString,
+                                           long referrerClickTS,
+                                           long installClickTS,
+                                           String store,
+                                           Boolean isClickThrough,
+                                           Long installBeginTimestampServerSeconds,
+                                           Long referrerClickTimestampServerSeconds) {
         PrefHelper prefHelper = PrefHelper.getInstance(context);
         if(!TextUtils.isEmpty(store)){
             prefHelper.setAppStoreSource(store);
@@ -76,6 +83,12 @@ public class AppStoreReferrer {
             } catch (IllegalArgumentException e) {
                 BranchLogger.w("Caught IllegalArgumentException " + e.getMessage());
             }
+        }
+        if(installBeginTimestampServerSeconds != null && installBeginTimestampServerSeconds > 0){
+            prefHelper.setLong(PrefHelper.KEY_INSTALL_BEGIN_SERVER_TS, installBeginTimestampServerSeconds);
+        }
+        if(referrerClickTimestampServerSeconds != null && referrerClickTimestampServerSeconds > 0){
+            prefHelper.setLong(PrefHelper.KEY_REFERRER_CLICK_SERVER_TS, referrerClickTimestampServerSeconds);
         }
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Defines.java
@@ -16,11 +16,13 @@ public class Defines {
         GoogleSearchInstallReferrer("google_search_install_referrer"),
         GooglePlayInstallReferrer("install_referrer_extras"),
         ClickedReferrerTimeStamp("clicked_referrer_ts"),
+        ClickedReferrerServerTimeStamp("clicked_referrer_server_ts"),
         Gclid("gclid"), //The parameter that is passed in the url
         IsDeeplinkGclid("is_deeplink_gclid"),
         ReferrerGclid("referrer_gclid"), //Key APIOpen expects for gclid in event
         ReferringUrlQueryParameters("bnc_referringUrlQueryParameters"),
         InstallBeginTimeStamp("install_begin_ts"),
+        InstallBeginServerTimeStamp("install_begin_server_ts"),
         @Deprecated BranchLinkUsed("branch_used"),          //use Defines.IntentKeys.BranchLinkUsed
         ReferringBranchIdentity("referring_branch_identity"),
         BranchIdentity("branch_identity"),

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -118,7 +118,9 @@ public class PrefHelper {
     static final String KEY_LAST_KNOWN_UPDATE_TIME = "bnc_last_known_update_time";
     static final String KEY_PREVIOUS_UPDATE_TIME = "bnc_previous_update_time";
     static final String KEY_REFERRER_CLICK_TS = "bnc_referrer_click_ts";
+    static final String KEY_REFERRER_CLICK_SERVER_TS = "bnc_referrer_click_server_ts";
     static final String KEY_INSTALL_BEGIN_TS = "bnc_install_begin_ts";
+    static final String KEY_INSTALL_BEGIN_SERVER_TS = "bnc_install_begin_server_ts";
     static final String KEY_TRACKING_STATE = "bnc_tracking_state";
     static final String KEY_AD_NETWORK_CALLOUTS_DISABLED = "bnc_ad_network_callouts_disabled";
 

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterInstall.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterInstall.java
@@ -42,6 +42,9 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
         super.onPreExecute();
         long clickedReferrerTS = prefHelper_.getLong(PrefHelper.KEY_REFERRER_CLICK_TS);
         long installBeginTS = prefHelper_.getLong(PrefHelper.KEY_INSTALL_BEGIN_TS);
+        long clickedReferrerServerTS = prefHelper_.getLong(PrefHelper.KEY_REFERRER_CLICK_SERVER_TS);
+        long installReferrerServerTS = prefHelper_.getLong(PrefHelper.KEY_INSTALL_BEGIN_SERVER_TS);
+
         try {
             if (clickedReferrerTS > 0) {
                 getPost().put(Defines.Jsonkey.ClickedReferrerTimeStamp.getKey(), clickedReferrerTS);
@@ -51,6 +54,12 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
             }
             if (!AppStoreReferrer.getInstallationID().equals(PrefHelper.NO_STRING_VALUE)) {
                 getPost().put(Defines.Jsonkey.LinkClickID.getKey(), AppStoreReferrer.getInstallationID());
+            }
+            if(clickedReferrerServerTS > 0){
+                getPost().put(Defines.Jsonkey.ClickedReferrerServerTimeStamp.getKey(), clickedReferrerServerTS);
+            }
+            if(installReferrerServerTS > 0){
+                getPost().put(Defines.Jsonkey.InstallBeginServerTimeStamp.getKey(), installReferrerServerTS);
             }
         } catch (JSONException e) {
             BranchLogger.w("Caught JSONException " + e.getMessage());

--- a/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
@@ -606,7 +606,14 @@ abstract class SystemObserver {
                     if (o != null) {
                         BranchLogger.v("fetchInstallReferrer resumeWith got result: " + o);
                         InstallReferrerResult latestReferrer = (InstallReferrerResult) o;
-                        AppStoreReferrer.processReferrerInfo(context_, latestReferrer.getInstallReferrer(), latestReferrer.getReferrerClickTimestampSeconds(), latestReferrer.getInstallBeginTimestampSeconds(), latestReferrer.getAppStore(), latestReferrer.isClickThrough());
+                        AppStoreReferrer.processReferrerInfo(context_,
+                                latestReferrer.getInstallReferrer(),
+                                latestReferrer.getReferrerClickTimestampSeconds(),
+                                latestReferrer.getInstallBeginTimestampSeconds(),
+                                latestReferrer.getAppStore(),
+                                latestReferrer.isClickThrough(),
+                                latestReferrer.getInstallBeginTimestampServerSeconds(),
+                                latestReferrer.getReferrerClickTimestampServerSeconds());
                     } else {
                         BranchLogger.v("fetchInstallReferrer resumeWith got null result");
                     }

--- a/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/SystemObserver.java
@@ -606,7 +606,7 @@ abstract class SystemObserver {
                     if (o != null) {
                         BranchLogger.v("fetchInstallReferrer resumeWith got result: " + o);
                         InstallReferrerResult latestReferrer = (InstallReferrerResult) o;
-                        AppStoreReferrer.processReferrerInfo(context_, latestReferrer.getLatestRawReferrer(), latestReferrer.getLatestClickTimestamp(), latestReferrer.getLatestInstallTimestamp(), latestReferrer.getAppStore(), latestReferrer.isClickThrough());
+                        AppStoreReferrer.processReferrerInfo(context_, latestReferrer.getInstallReferrer(), latestReferrer.getReferrerClickTimestampSeconds(), latestReferrer.getInstallBeginTimestampSeconds(), latestReferrer.getAppStore(), latestReferrer.isClickThrough());
                     } else {
                         BranchLogger.v("fetchInstallReferrer resumeWith got null result");
                     }

--- a/Branch-SDK/src/test/java/io/branch/referral/InstallReferrerResultTests.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/InstallReferrerResultTests.kt
@@ -19,7 +19,10 @@ class InstallReferrerResultTests {
             1,
             "test1",
             1,
+            1,
+            1,
             true
+
         )
 
         val test2 = InstallReferrerResult(
@@ -27,6 +30,8 @@ class InstallReferrerResultTests {
             Long.MAX_VALUE,
             "test2",
             Long.MAX_VALUE,
+            1,
+            1,
             true
         )
 
@@ -35,6 +40,8 @@ class InstallReferrerResultTests {
             2,
             "test3",
             2,
+            1,
+            1,
             true
         )
 
@@ -43,6 +50,8 @@ class InstallReferrerResultTests {
             3,
             "test4",
             3,
+            1,
+            1,
             true
         )
 
@@ -75,6 +84,8 @@ class InstallReferrerResultTests {
             1,
             "test1",
             1,
+            1,
+            1,
             true
         )
 
@@ -89,26 +100,30 @@ class InstallReferrerResultTests {
     fun testMetaInstallReferrerCases() {
         // Case 1: Meta referrer is click-through with non-organic Play Store referrer
         var metaReferrerClickThrough =
-            InstallReferrerResult("Meta", 1700000050, "referrer", 1700000000, true)
+            InstallReferrerResult("Meta", 1700000050, "referrer", 1700000000, 1, 1, true)
         val playStoreReferrer = InstallReferrerResult(
             "PlayStore",
             1700000030,
             "utm_source=google-play&utm_medium=cpc",
             1700000000,
+            1,
+            1,
             true
         )
-        var allReferrers = Arrays.asList(metaReferrerClickThrough, playStoreReferrer)
+        var allReferrers = listOf(metaReferrerClickThrough, playStoreReferrer)
         var result = getLatestValidReferrerStore(allReferrers)
         Assert.assertEquals(metaReferrerClickThrough, result)
 
         // Case 2: Meta referrer is view-through with organic Play Store referrer
         var metaReferrerViewThrough =
-            InstallReferrerResult("Meta", 1700000050, "referrer", 1700000000, false)
+            InstallReferrerResult("Meta", 1700000050, "referrer", 1700000000, 1, 1, false)
         var latestPlayStoreReferrer = InstallReferrerResult(
             "PlayStore",
             1700000030,
             "utm_source=google-play&utm_medium=organic",
             0,
+            1,
+            1,
             true
         )
         allReferrers = Arrays.asList(metaReferrerViewThrough, latestPlayStoreReferrer)
@@ -117,12 +132,14 @@ class InstallReferrerResultTests {
 
         // Case 3: Meta referrer is view-through with non-organic Play Store referrer
         metaReferrerViewThrough =
-            InstallReferrerResult("Meta", 1700000050, "referrer", 1700000000, false)
+            InstallReferrerResult("Meta", 1700000050, "referrer", 1700000000, 1, 1, false)
         latestPlayStoreReferrer = InstallReferrerResult(
             "PlayStore",
             1700000030,
             "utm_source=google-play&utm_medium=cpc",
             1700000000,
+            1,
+            1,
             true
         )
         allReferrers = Arrays.asList(metaReferrerViewThrough, latestPlayStoreReferrer)
@@ -131,12 +148,14 @@ class InstallReferrerResultTests {
 
         // Case 4: Meta referrer is outdated click-through with non-organic Play Store referrer
         metaReferrerClickThrough =
-            InstallReferrerResult("Meta", 1700000030, "referrer", 1700000000, true)
+            InstallReferrerResult("Meta", 1700000030, "referrer", 1700000000, 1, 1, true)
         latestPlayStoreReferrer = InstallReferrerResult(
             "PlayStore",
             1700000500,
             "utm_source=google-play&utm_medium=cpc",
             1700000450,
+            1,
+            1,
             true
         )
         allReferrers = Arrays.asList(metaReferrerClickThrough, latestPlayStoreReferrer)
@@ -145,12 +164,14 @@ class InstallReferrerResultTests {
 
         // Case 5: Meta, Google Play, and Samsung Referrer (latest) are available
         metaReferrerClickThrough =
-            InstallReferrerResult("Meta", 1700000000, "referrer", 1700000000, true)
+            InstallReferrerResult("Meta", 1700000000, "referrer", 1700000000, 1, 1, true)
         latestPlayStoreReferrer = InstallReferrerResult(
             "PlayStore",
             1700000000,
             "utm_source=google-play&utm_medium=cpc",
             1700000000,
+            1,
+            1,
             true
         )
         val samsungReferrer = InstallReferrerResult(
@@ -158,6 +179,8 @@ class InstallReferrerResultTests {
             1700001000,
             "utm_source=samsung-store&utm_medium=cpc",
             1700001000,
+            1,
+            1,
             true
         )
         allReferrers =
@@ -168,10 +191,10 @@ class InstallReferrerResultTests {
 
     @Test
     fun testLatestInstallReferrerSort() {
-        val referrer1 = InstallReferrerResult("Test1", 100, "test1Referrer", 100)
-        val referrer2 = InstallReferrerResult("Test2", 1, "test1Referrer", 1)
+        val referrer1 = InstallReferrerResult("Test1", 100, "test1Referrer", 1, 1,100)
+        val referrer2 = InstallReferrerResult("Test2", 1, "test1Referrer", 1,1, 1)
         val referrer3 = null
-        val referrer4 = InstallReferrerResult("Test1", 101, "test1Referrer", 101)
+        val referrer4 = InstallReferrerResult("Test1", 101, "test1Referrer", 101, 1,1)
 
         val result = getLatestInstallTimeStamp((mutableListOf(referrer1, referrer2, referrer3, referrer4)))
 


### PR DESCRIPTION
## Reference
EMT-1834 [Android] Add Play Store Install Referrer server timestamps

## Description
While we already retrieve:
referrer_click_timestamp_seconds
install_begin_timestamp_seconds

We are not forwarding:
referrer_click_timestamp_server_seconds
install_begin_timestamp_server_seconds

Task is to simply add these into our internal data class and send it.

## Testing Instructions
<!-- TESTING INSTRUCTIONS -->

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
