### PR TITLE
updated default logging level to VERBOSE in Branch.java and updated note

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1933,10 +1933,10 @@ public class Branch {
     }
 
     /**
-     * Enable Logging, independent of Debug Mode. Defaults to DEBUG level.
+     * Enable Logging, independent of Debug Mode. Defaults to VERBOSE level.
      */
     public static void enableLogging() {
-        enableLogging(null, BranchLogger.BranchLogLevel.DEBUG);
+        enableLogging(null, BranchLogger.BranchLogLevel.VERBOSE);
     }
 
     /**


### PR DESCRIPTION


## Reference
[SDK-XXX -- <TITLE>.](https://branch.slack.com/archives/CS8E89QQ4/p1743012239495759)

## Description
Change default logging level that is referenced by plugins to assist with plugin debugging.

## Testing Instructions

1. Remove `BranchLogger.BranchLogLevel.VERBOSE` from Branch.enableLogging() call in CustomBranchApp.java
2. Run the Branch-SDK-TestBed app and observe how the default logging level is only returning DEBUG level logs
3. Update the part in line 1938 in Branch.java from `BranchLogger.BranchLogLevel.DEBUG` to `BranchLogger.BranchLogLevel.VERBOSE`
4. Run the Branch-SDK-TestBed app and observe how the default logging level is now returning VERBOSE level logs

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW
N/A

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
