### PR TITLE
Android Integration Validator failing when multiple URI scheme present in the manifest file.

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/validators/URISchemeCheck.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/validators/URISchemeCheck.java
@@ -37,7 +37,7 @@ public class URISchemeCheck extends IntegrationValidatorCheck {
     @Override
     public boolean RunTests(Context context) {
         String branchAppUriScheme = branchAppConfig.optString("android_uri_scheme").substring(0, branchAppConfig.optString("android_uri_scheme").length() - 3);
-        String dashboardUriScheme = String.valueOf(integrationModel.deeplinkUriScheme.keys().next());
+        String dashboardUriScheme = checkBranchKey(integrationModel.deeplinkUriScheme.keys(), branchAppUriScheme);
         boolean isUriSchemeProperlySetOnDashboard = !TextUtils.isEmpty(branchAppUriScheme);
         boolean isUriSchemeIntentProperlySetup = checkIfIntentAddedForURIScheme(branchAppConfig.optString("android_uri_scheme")) && integrationModel.appSettingsAvailable;
         boolean doUriSchemesMatch = branchAppUriScheme.trim().equals(dashboardUriScheme.trim());
@@ -56,6 +56,17 @@ public class URISchemeCheck extends IntegrationValidatorCheck {
         }
 
         return doUriSchemesMatch && isUriSchemeProperlySetOnDashboard && isUriSchemeIntentProperlySetup;
+    }
+
+    private String checkBranchKey(Iterator<String> keys, String branchAppUriScheme) {
+        String targetKey = branchAppUriScheme.replace("://", "");
+        while (keys.hasNext()) {
+            String key = keys.next();
+            if (targetKey.equals(key)) {
+                return key;
+            }
+        }
+        return "";
     }
 
     @Override


### PR DESCRIPTION
## Reference
[SDK-2544 ](https://branch.atlassian.net/browse/SDK-2544)

## Description
The integration validator's URI Scheme check fails if more than one URI scheme is present on the manifest file along with the branch URI scheme. This also depends on the order in which the schemes are added to the manifest file because we are comparing the dashboard URI scheme with the first entry on the manifest file. 

## Testing Instructions


## Risk Assessment [`LOW`]
- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [x] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
