### PR TITLE
Remove user agent string query from start up

### DIFF
--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
@@ -707,7 +707,7 @@ public class MainActivity extends Activity {
         Branch.getInstance().addFacebookPartnerParameterWithName("ph", getHashedValue("6516006060"));
         Log.d("BranchSDK_Tester", "initSession");
 
-        //initSessionsWithTests();
+        initSessionsWithTests();
 
         // Branch integration validation: Validate Branch integration with your app
         // NOTE : The below method will run few checks for verifying correctness of the Branch integration.
@@ -720,7 +720,7 @@ public class MainActivity extends Activity {
 
     private void initSessionsWithTests() {
         boolean testUserAgent = true;
-        userAgentTests(testUserAgent, 10);
+        userAgentTests(testUserAgent, 1);
     }
 
     // Enqueue several v2 events prior to init to simulate worst timing conditions for user agent fetch

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
@@ -707,7 +707,7 @@ public class MainActivity extends Activity {
         Branch.getInstance().addFacebookPartnerParameterWithName("ph", getHashedValue("6516006060"));
         Log.d("BranchSDK_Tester", "initSession");
 
-        initSessionsWithTests();
+        //initSessionsWithTests();
 
         // Branch integration validation: Validate Branch integration with your app
         // NOTE : The below method will run few checks for verifying correctness of the Branch integration.

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1465,6 +1465,7 @@ public class Branch {
 
          ServerRequestInitSession r = requestQueue_.getSelfInitRequest();
          BranchLogger.v("Ordering init calls");
+         BranchLogger.v("Self init request: " + r);
          requestQueue_.printQueue();
 
          // if forceBranchSession aka reInit is true, we want to preserve the callback order in case
@@ -1555,8 +1556,12 @@ public class Branch {
     }
 
     private void setActivityLifeCycleObserver(Application application) {
+        BranchLogger.v("setActivityLifeCycleObserver activityLifeCycleObserver: " + activityLifeCycleObserver
+                + " application: " + application);
         try {
             activityLifeCycleObserver = new BranchActivityLifecycleObserver();
+            BranchLogger.v("setActivityLifeCycleObserver set new activityLifeCycleObserver: " + activityLifeCycleObserver
+                    + " application: " + application);
             /* Set an observer for activity life cycle events. */
             application.unregisterActivityLifecycleCallbacks(activityLifeCycleObserver);
             application.registerActivityLifecycleCallbacks(activityLifeCycleObserver);

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1841,8 +1841,8 @@ public class Branch {
                         }
                     }
                 }
+                BranchLogger.v("deepLinkActivity " + deepLinkActivity + " getCurrentActivity " + getCurrentActivity());
                 if (deepLinkActivity != null && getCurrentActivity() != null) {
-                    BranchLogger.v("deepLinkActivity " + deepLinkActivity + " getCurrentActivity " + getCurrentActivity());
                     Activity currentActivity = getCurrentActivity();
 
                     Intent intent = new Intent(currentActivity, Class.forName(deepLinkActivity));

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -312,6 +312,8 @@ class DeviceInfo {
         }
         catch (Exception exception){
             BranchLogger.w("Caught exception trying to set userAgent " + exception.getMessage());
+            Branch.getInstance().requestQueue_.unlockProcessWait(ServerRequest.PROCESS_WAIT_LOCK.USER_AGENT_STRING_LOCK);
+            Branch.getInstance().requestQueue_.processNextQueueItem("getUserAgentAsync");
         }
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -92,32 +92,6 @@ abstract class ServerRequestInitSession extends ServerRequest {
     void onInitSessionCompleted(ServerResponse response, Branch branch) {
         DeepLinkRoutingValidator.validate(branch.currentActivityReference_);
         branch.updateSkipURLFormats();
-
-        // Run this after session init, ahead of any V2 event, in the background.
-        if (!Branch.userAgentSync && TextUtils.isEmpty(Branch._userAgentString)) {
-            DeviceSignalsKt.getUserAgentAsync(branch.getApplicationContext(), new Continuation<String>() {
-                @NonNull
-                @Override
-                public CoroutineContext getContext() {
-                    return EmptyCoroutineContext.INSTANCE;
-                }
-
-                @Override
-                public void resumeWith(@NonNull Object o) {
-                    if (o != null) {
-                        BranchLogger.v("onInitSessionCompleted resumeWith userAgent " + o + " on thread " + Thread.currentThread().getName());
-                        Branch._userAgentString = (String) o;
-                    }
-
-                    Branch.getInstance().requestQueue_.unlockProcessWait(PROCESS_WAIT_LOCK.USER_AGENT_STRING_LOCK);
-                    Branch.getInstance().requestQueue_.processNextQueueItem("getUserAgentAsync resumeWith");
-                }
-            });
-        }
-        else {
-            BranchLogger.v("Deferring userAgent string call for sync retrieval");
-        }
-
         BranchLogger.v("onInitSessionCompleted on thread " + Thread.currentThread().getName());
     }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestQueue.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestQueue.java
@@ -256,6 +256,7 @@ public class ServerRequestQueue {
     ServerRequestInitSession getSelfInitRequest() {
         synchronized (reqQueueLockObject) {
             for (ServerRequest req : queue) {
+                BranchLogger.v("Checking if " + req + " is instanceof ServerRequestInitSession");
                 if (req instanceof ServerRequestInitSession) {
                     ServerRequestInitSession r = (ServerRequestInitSession) req;
                     if (r.initiatedByClient) {
@@ -350,6 +351,7 @@ public class ServerRequestQueue {
     }
 
     void insertRequestAtFront(ServerRequest req) {
+        BranchLogger.v("insertRequestAtFront " + req + " networkCount_: " + networkCount_);
         if (networkCount_ == 0) {
             this.insert(req, 0);
         } else {

--- a/Branch-SDK/src/main/java/io/branch/referral/util/BranchEvent.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/util/BranchEvent.java
@@ -287,7 +287,7 @@ public class BranchEvent {
             BranchLogger.v("Preparing V2 event, user agent is " + Branch._userAgentString);
 
             if(TextUtils.isEmpty(Branch._userAgentString)){
-                BranchLogger.v("handleNewRequest adding process wait lock USER_AGENT_STRING_LOCK");
+                BranchLogger.v("User agent is empty, handleNewRequest adding process wait lock USER_AGENT_STRING_LOCK");
                 req.addProcessWaitLock(ServerRequest.PROCESS_WAIT_LOCK.USER_AGENT_STRING_LOCK);
             }
 


### PR DESCRIPTION
Originally this code replicated behavior to fetch the user agent string after opens. However, even though it is dispatched, it still requires main thread https://issuetracker.google.com/issues/289118199#comment9. For integrations with heavy start up sequences, this still has a performance impact of about 50ms to 200ms. 
After consideration, this technique does not offer a favorable trade off between impacting start up over invoking only when necessary.

This change only queries when needed by v2 event. The code to use either the `WebSettings` static or the `WebView` instance remains unchanged as that is needed to workaround certain external Chromium package crashes.

## Reference
SDK-XXX -- <TITLE>.

## Description
<!-- SUFFICIENT DESCRIPTION TO EXPLAIN THE PROBLEM THAT IS BEING SOLVED -->

## Testing Instructions
Run the test app to validate that the user agent string is still present on v2 events. 
- Include queueing events prior to open.
- User agent string query only called when a v2 event is enqueued.

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
