### PR TITLE
INTENG-22685 - Integration validator protected endpoint bugfix

### DIFF
--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/SettingsActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/SettingsActivity.java
@@ -54,7 +54,7 @@ public class SettingsActivity extends Activity {
     void setupApiUrlText() {
         final EditText apiUrlText = findViewById(R.id.api_url_text);
         final PrefHelper prefHelper = PrefHelper.getInstance(this);
-        String currentApiUrl = prefHelper.getAPIBaseUrl();
+        String currentApiUrl = prefHelper.getAPIBaseUrl(true);
 
         apiUrlText.setText(currentApiUrl);
 

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1793,7 +1793,7 @@ public class Branch {
     private class GetShortLinkTask extends AsyncTask<ServerRequest, Void, ServerResponse> {
         @Override protected ServerResponse doInBackground(ServerRequest... serverRequests) {
             return branchRemoteInterface_.make_restful_post(serverRequests[0].getPost(),
-                    prefHelper_.getAPIBaseUrl() + Defines.RequestPath.GetURL.getPath(),
+                    prefHelper_.getAPIBaseUrl(true) + Defines.RequestPath.GetURL.getPath(),
                     Defines.RequestPath.GetURL.getPath(), prefHelper_.getBranchKey());
         }
     }

--- a/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/PrefHelper.java
@@ -239,8 +239,8 @@ public class PrefHelper {
      * @return A {@link String} variable containing the hard-coded base URL that the Branch
      * API uses.
      */
-    public String getAPIBaseUrl() {
-        if (URLUtil.isHttpsUrl(customServerURL_)) {
+    public String getAPIBaseUrl(boolean useCustom) {
+        if (useCustom && URLUtil.isHttpsUrl(customServerURL_)) {
             return customServerURL_;
         }
 

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -252,7 +252,7 @@ public abstract class ServerRequest {
      * @return A url for executing this request against the server.
      */
     public String getRequestUrl() {
-        return prefHelper_.getAPIBaseUrl() + requestPath_.getPath();
+        return prefHelper_.getAPIBaseUrl(true) + requestPath_.getPath();
     }
     
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/validators/ServerRequestGetAppConfig.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/validators/ServerRequestGetAppConfig.java
@@ -43,7 +43,7 @@ class ServerRequestGetAppConfig extends ServerRequest {
 
     @Override
     public String getRequestUrl() {
-        return prefHelper_.getAPIBaseUrl() + getRequestPath() + "/" + prefHelper_.getBranchKey();
+        return prefHelper_.getAPIBaseUrl(false) + getRequestPath() + "/" + prefHelper_.getBranchKey();
     }
 
     @Override


### PR DESCRIPTION
## Reference
INTENG-22685

## Description
If a customer is using Advanced Compliance and then runs the Integration Validator code, the Integration Validator will not work. This is because the protected-api endpoint gets used for the requests, and there is no app-settings protected equivalent for that endpoint. Since the Integration Validator code is never released into the wild, but only used for testing, we can safely keep that endpoint going to the regular Branch endpoint, with all other calls like opens, installs, etc... still going through the protected endpoint for Advanced Compliance customers. To address this, I've added a boolean parameter to the getAPIBaseUrl() function, which can take in false in the case of any test code, like the integration validator, so that the regular endpoint (instead of protected-api) is used.  

## Testing Instructions
<!-- TESTING INSTRUCTIONS -->

## Risk Assessment [`LOW`]

- [X] I, the PR creator, have tested — integration, unit, or otherwise — this code.

cc @BranchMetrics/saas-sdk-devs for visibility.
