### PR TITLE
EMT-4133: align the TestBed with the beta integration guide

### DIFF
--- a/Branch-SDK-GPTDriver/src/main/java/io/branch/gptdriver/tests/DeepLinkColdOpenHybridTest.kt
+++ b/Branch-SDK-GPTDriver/src/main/java/io/branch/gptdriver/tests/DeepLinkColdOpenHybridTest.kt
@@ -30,20 +30,20 @@ import org.junit.runner.RunWith
  * HYBRID — Tests deep link cold open (app launched directly via Branch link).
  *
  * Simulates:  User taps a Branch link → app launches with the link as intent data
- *             → Branch SDK processes the link during session init in onStart().
+ *             → the app resolves the link with requestDeepLinkData() in onCreate().
  *
  * Flow:
  * 1. Launch the app normally to generate a real Branch link
  * 2. Extract the URL via AI
  * 3. Close the activity
  * 4. Relaunch with an ACTION_VIEW intent containing the Branch link
- *    (FLAG_ACTIVITY_CLEAR_TASK forces a fresh activity + session init with the URI)
+ *    (FLAG_ACTIVITY_CLEAR_TASK forces a fresh activity, so onCreate sees the URI)
  * 5. Verify "Latest Referring Params" shows link metadata (channel, feature, tags)
  *
- * Note: ActivityScenario.close() does not kill the process, so Branch singleton
+ * Note: ActivityScenario.close() does not kill the process, so the Branch singleton
  * persists. However, FLAG_ACTIVITY_CLEAR_TASK + new intent data triggers a fresh
- * sessionBuilder().withData(intent.getData()).init() in onStart(), which is the
- * same code path as a real cold open.
+ * requestDeepLinkData(getIntent().getData()) in onCreate, which is the same code
+ * path as a real cold open.
  */
 @LargeTest
 @RunWith(AndroidJUnit4::class)
@@ -118,8 +118,8 @@ class DeepLinkColdOpenHybridTest {
         normalLaunch.close()
 
         // PHASE 2: Relaunch with deep link intent
-        // CLEAR_TASK forces fresh activity creation → onStart() calls
-        // Branch.sessionBuilder().withData(intent.getData()).init()
+        // CLEAR_TASK forces fresh activity creation → onCreate() calls
+        // Branch.getInstance().requestDeepLinkData(getIntent().getData(), callback)
         val deepLinkIntent = Intent(Intent.ACTION_VIEW, Uri.parse(generatedUrl)).apply {
             setClassName(
                 InstrumentationRegistry.getInstrumentation().targetContext,
@@ -130,9 +130,9 @@ class DeepLinkColdOpenHybridTest {
 
         val deepLinkLaunch = ActivityScenario.launch<MainActivity>(deepLinkIntent)
 
-        // Wait for Branch session init to resolve the deep link.
+        // Wait for requestDeepLinkData to resolve the deep link.
         // Note: Thread.sleep is used because after ActivityScenario relaunch, there is no
-        // observable UI state to create an IdlingResource for — the SDK init happens
+        // observable UI state to create an IdlingResource for — resolution happens
         // internally before any UI update. The AI driver handles the rest.
         Thread.sleep(5000)
 

--- a/Branch-SDK-GPTDriver/src/main/java/io/branch/gptdriver/tests/DeepLinkWarmOpenHybridTest.kt
+++ b/Branch-SDK-GPTDriver/src/main/java/io/branch/gptdriver/tests/DeepLinkWarmOpenHybridTest.kt
@@ -34,7 +34,7 @@ import org.junit.runner.RunWith
  * HYBRID — Tests deep link warm open (app already running → receives Branch link).
  *
  * Simulates:  App is in foreground → user taps a Branch link → system delivers
- *             new intent → onNewIntent() calls Branch.sessionBuilder().reInit()
+ *             new intent → onNewIntent() calls requestDeepLinkData(intent.getData())
  *
  * Does NOT extend BaseGptDriverTest to avoid ActivityScenarioRule lifecycle
  * conflicts when delivering new intents. Manages its own ActivityScenario.
@@ -139,9 +139,9 @@ class DeepLinkWarmOpenHybridTest {
         }
         InstrumentationRegistry.getInstrumentation().targetContext.startActivity(deepLinkIntent)
 
-        // Wait for Branch reInit to resolve the deep link.
+        // Wait for requestDeepLinkData to resolve the deep link.
         // Note: Thread.sleep is used because after startActivity with a new intent,
-        // the SDK reInit happens internally with no observable UI change to wait on.
+        // resolution happens internally with no observable UI change to wait on.
         Thread.sleep(8000)
 
         // PHASE 3: Verify deep link data via "Latest Referring Params"

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
@@ -7,6 +7,7 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.net.Uri;
 import android.graphics.Bitmap;
 import android.os.Build;
 import android.os.Bundle;
@@ -74,6 +75,8 @@ public class MainActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main_activity);
+
+        handleDeepLink(this.getIntent().getData());
 
         txtShortUrl = findViewById(R.id.editReferralShortUrl);
 
@@ -754,35 +757,7 @@ public class MainActivity extends Activity {
 
         Branch.getInstance().setIdentity("Identity1");
 
-        Branch.sessionBuilder(this).withCallback(new Branch.BranchUniversalReferralInitListener() {
-            @Override
-            public void onInitFinished(BranchUniversalObject branchUniversalObject, LinkProperties linkProperties, BranchError error) {
-                if (error != null) {
-                    Log.d("BranchSDK_Tester", "branch init failed. Caused by -" + error.getMessage());
-                    Log.d("BranchSDK_Tester", "Session state should be not be INITIALISED, actual: " + Branch.getInstance().getInitState());
-                } else {
-                    Log.d("BranchSDK_Tester", "branch init complete!");
-                    Log.d("BranchSDK_Tester", "Session state should be INITIALISED, actual: " + Branch.getInstance().getInitState());
-                    if (branchUniversalObject != null) {
-                        Log.d("BranchSDK_Tester", "title " + branchUniversalObject.getTitle());
-                        Log.d("BranchSDK_Tester", "CanonicalIdentifier " + branchUniversalObject.getCanonicalIdentifier());
-                        Log.d("BranchSDK_Tester", "metadata " + branchUniversalObject.getContentMetadata().convertToJson());
-                    }
-
-                    if (linkProperties != null) {
-                        Log.d("BranchSDK_Tester", "Channel " + linkProperties.getChannel());
-                        Log.d("BranchSDK_Tester", "control params " + linkProperties.getControlParams());
-                    }
-                }
-
-
-                // QA purpose only
-                // TrackingControlTestRoutines.runTrackingControlTest(MainActivity.this);
-                // BUOTestRoutines.TestBUOFunctionalities(MainActivity.this);
-            }
-        }).withData(this.getIntent().getData()).init();
-
-        initSessionsWithTests();
+        userAgentTests(true, 1);
 
         // Branch integration validation: Validate Branch integration with your app
         // NOTE : The below method will run few checks for verifying correctness of the Branch integration.
@@ -794,10 +769,6 @@ public class MainActivity extends Activity {
     }
 
 
-    private void initSessionsWithTests() {
-        boolean testUserAgent = true;
-        userAgentTests(testUserAgent, 1);
-    }
 
     // Enqueue several v2 events prior to init to simulate worst timing conditions for user agent fetch
     // TODO Add to automation.
@@ -805,30 +776,34 @@ public class MainActivity extends Activity {
     private void userAgentTests(boolean userAgentSync, int n) {
         BranchLogger.d("Beginning stress tests");
 
-        // Initialize session first, then create events in callback
-        initializeSessionWithEventTests(n);
+        TestBedHelper.logTestEvents(this, n);
     }
 
-    private void initializeSessionWithEventTests(int eventCount) {
-        TestBedHelper.initializeSessionWithEventTests(this, eventCount);
-    }
 
     @Override
     public void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         this.setIntent(intent);
-        Branch.sessionBuilder(this).withCallback(new BranchReferralInitListener() {
+
+        handleDeepLink(intent.getData());
+    }
+
+    /**
+     * Resolves Branch data for a launch or new intent.
+     *
+     * @param data the intent's URI, or null when the app was not opened from a link
+     */
+    private void handleDeepLink(Uri data) {
+        Branch.getInstance().requestDeepLinkData(data, new BranchReferralInitListener() {
             @Override
             public void onInitFinished(JSONObject referringParams, BranchError error) {
                 if (error != null) {
-                    BranchLogger.d(error.getMessage());
+                    BranchLogger.d("Deep link error: " + error.getMessage());
                 } else if (referringParams != null) {
-                    BranchLogger.d(referringParams.toString());
+                    BranchLogger.d("Deep link params: " + referringParams.toString());
                 }
             }
-            // reInit() was removed in 6.0 (EMT-3883); init() is its sanctioned replacement and,
-            // with the ERR_IMPROPER_REINITIALIZATION guard gone, is now valid to call in onNewIntent.
-        }).init();
+        });
     }
 
     @Override

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/TestBedHelper.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/TestBedHelper.java
@@ -6,14 +6,9 @@ import android.os.Handler;
 import android.os.Looper;
 import android.widget.Toast;
 
-import java.lang.ref.WeakReference;
-
-import io.branch.indexing.BranchUniversalObject;
 import io.branch.referral.Branch;
-import io.branch.referral.BranchError;
 import io.branch.referral.BranchLogger;
 import io.branch.referral.util.BranchEvent;
-import io.branch.referral.util.LinkProperties;
 
 /**
  * Test utility helpers extracted from MainActivity to reduce class size.
@@ -32,53 +27,16 @@ public class TestBedHelper {
     }
 
     /**
-     * Initializes Branch session and creates test events after successful initialization.
+     * Logs test events to exercise the user agent fetch under load.
+     *
+     * @param activity   the activity the events are logged from
+     * @param eventCount how many test events to log
      */
-    public static void initializeSessionWithEventTests(Activity activity, int eventCount) {
-        Branch.sessionBuilder(activity)
-                .withCallback(new SessionInitHandler(activity, eventCount))
-                .withData(activity.getIntent().getData())
-                .init();
-    }
-
-    /**
-     * Handler for Branch session initialization with event creation capability.
-     */
-    static class SessionInitHandler implements Branch.BranchUniversalReferralInitListener {
-        private final WeakReference<Activity> activityRef;
-        private final int eventCount;
-
-        SessionInitHandler(Activity activity, int eventCount) {
-            this.activityRef = new WeakReference<>(activity);
-            this.eventCount = eventCount;
-        }
-
-        @Override
-        public void onInitFinished(BranchUniversalObject branchUniversalObject, LinkProperties linkProperties, BranchError error) {
-            if (error != null) {
-                BranchLogger.d("branch init failed. Caused by -" + error.getMessage());
-                return;
-            }
-
-            BranchLogger.d("branch init complete!");
-            if (branchUniversalObject != null) {
-                BranchLogger.d("title " + branchUniversalObject.getTitle());
-                BranchLogger.d("CanonicalIdentifier " + branchUniversalObject.getCanonicalIdentifier());
-                BranchLogger.d("metadata " + branchUniversalObject.getContentMetadata().convertToJson());
-            }
-
-            if (linkProperties != null) {
-                BranchLogger.d("Channel " + linkProperties.getChannel());
-                BranchLogger.d("control params " + linkProperties.getControlParams());
-            }
-
-            BranchLogger.d("Creating " + eventCount + " test events after session initialization");
-            Activity activity = activityRef.get();
-            if (activity != null && !activity.isFinishing()) {
-                for (int i = 0; i < eventCount; i++) {
-                    new BranchEvent("Event " + i).logEvent(activity);
-                }
-            }
+    public static void logTestEvents(Activity activity, int eventCount) {
+        BranchLogger.d("Creating " + eventCount + " test events");
+        for (int i = 0; i < eventCount; i++) {
+            new BranchEvent("Event " + i).logEvent(activity);
         }
     }
+
 }


### PR DESCRIPTION
## The problem

The TestBed still integrated the pre-6.0 way — `Branch.sessionBuilder(...).init()` in `onStart`, `onNewIntent` and `TestBedHelper` — which drove `getInstallOrOpenRequest` down the `ServerRequestRegisterInstall` branch. So the beta emitted `/v1/install` where iOS `4.0.0-beta.0` emits `/v3/events/open`.

The beta integration guide specifies `requestDeepLinkData(uri, callback)` in `onCreate` and `onNewIntent`, no `sessionBuilder`, no `reInit()`. The iOS TestBed was already migrated.

## What changed

`MainActivity` resolves the intent once in `onCreate` and again in `onNewIntent`. The three `init()` call sites are gone. `TestBedHelper` only logs its test events now, since resolution happens once. Five orphaned imports removed. Second commit fixes E2E test comments that named the replaced mechanism — comments only.

**No SDK source was touched.** The v3 parity already existed; a test app integrating the old way was hiding it.

## Evidence

Clean install each run, API 34 emulator.

| | before | after |
| --- | ---: | ---: |
| log lines | 1954 | 378 |
| `/v1/install` | 2 | 0 |
| `/v3/deeplink` | 0 | 1 |
| `/v3/events/open` | 0 | 2 |
| `Added INTENT_PENDING_WAIT_LOCK` | 2 | 0 |
| `STUCK_LOCK_RESOLUTION` | 2 | 0 |
| lock retries | 157 | 5 |

Cold launch on `https://bnctestbed.app.link/izPBY2xCqF` resolved and the callback received `~channel`, `~feature`, `~campaign`, `+clicked_branch_link=true` — what the E2E tests assert on. Cold launch with no link gave the identical shape; warm open via `onNewIntent` resolved and delivered params again.

The five remaining retries are the bounded path: counter `1/5` to `5/5`, no lock held. Before, the lock-waiting exemption let it reach `98/5`.

`:Branch-SDK:testDebugUnitTest` passes. The two GPT Driver deep link E2E tests pass with EMT-4137 applied (`tests=2 failures=0 errors=0`); they fail on this branch alone, which is what EMT-4137 fixes.

## Surfaced, not caused

Two defects were masked while the legacy path dominated. **EMT-4137** — the open erased the resolved payload, so Latest Referring Params came back empty; fixed in #1389, which this branch needs. EMT-4136: two `/v3/events/open` per launch. EMT-4135: the launch-intent lock is never released on the legacy path.

Unblocks EMT-4077, which cannot retarget the validator at v3 while the app under test emits v1.

Ticket: https://branch.atlassian.net/browse/EMT-4133
