### PR TITLE
EMT-4136: send one open per launch

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2419,6 +2419,13 @@ public class Branch {
 
             BranchLogger.d("sendOpen BranchAttributionLevel: " + branchAttributionLevel);
             if(branchAttributionLevel != Defines.BranchAttributionLevel.NONE){
+                // The foreground observer and the deep link callback both reach here, and the
+                // first open is still queued when the second arrives. Without this the launch
+                // sends two.
+                if (branchReferral_.requestQueue_.containsInstallOrOpen()) {
+                    BranchLogger.d("sendOpen skipped: an install or open is already pending");
+                    return;
+                }
                 RequestOpen requestOpen = new RequestOpen(context_, null, false, null);
                 branchReferral_.requestQueue_.handleNewRequest(requestOpen);
             }
@@ -2433,6 +2440,10 @@ public class Branch {
 
             BranchLogger.d("sendOpen BranchAttributionLevel: " + branchAttributionLevel);
             if(branchAttributionLevel != Defines.BranchAttributionLevel.NONE){
+                if (branchReferral_.requestQueue_.containsInstallOrOpen()) {
+                    BranchLogger.d("sendOpen skipped: an install or open is already pending");
+                    return;
+                }
                 RequestOpen requestOpen = new RequestOpen(context_, null, false, responseData);
                 branchReferral_.requestQueue_.handleNewRequest(requestOpen);
             }

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchRequestQueue.kt
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchRequestQueue.kt
@@ -841,6 +841,38 @@ class BranchRequestQueue private constructor(private val context: Context) {
     }
     
     /**
+     * Whether an install or open is already queued or in flight.
+     *
+     * Deep link resolution is not an open: the beta's flow is /v3/deeplink followed by
+     * /v3/events/open, so RequestDeepLink is deliberately excluded — counting it would suppress
+     * the open that has to follow it.
+     *
+     * Checks both the queue and the requests already executing, because the duplicate this guards
+     * against is enqueued while the first open is pending, before it reaches the network.
+     */
+    fun containsInstallOrOpen(): Boolean {
+        synchronized(queueList) {
+            if (queueList.any { isInstallOrOpen(it) }) {
+                BranchLogger.v("containsInstallOrOpen: found one queued")
+                return true
+            }
+        }
+        val executing = activeRequests.values.any { isInstallOrOpen(it) }
+        if (executing) {
+            BranchLogger.v("containsInstallOrOpen: found one executing")
+        }
+        return executing
+    }
+
+    // RequestOpen is the beta's open. ServerRequestRegisterInstall is still reachable here:
+    // getInstallOrOpenRequest builds one when there is no randomized bundle token, and
+    // sessionBuilder().init() remains public API. ServerRequestRegisterOpen is not included —
+    // its only construction site is the queue-restore path in ServerRequest, and nothing on this
+    // line restores a persisted queue.
+    private fun isInstallOrOpen(request: ServerRequest): Boolean =
+        request is ServerRequestRegisterInstall || request is RequestOpen
+
+    /**
      * Peek at request at specific index
      */
     fun peekAt(index: Int): ServerRequest? {

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchRequestQueueAdapter.kt
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchRequestQueueAdapter.kt
@@ -148,6 +148,12 @@ class BranchRequestQueueAdapter private constructor(context: Context) {
         BranchLogger.v("BranchRequestQueueAdapter.hasUser result: $result")
         return result
     }
+    fun containsInstallOrOpen(): Boolean {
+        BranchLogger.v("BranchRequestQueueAdapter.containsInstallOrOpen called")
+        val result = newQueue.containsInstallOrOpen()
+        BranchLogger.v("BranchRequestQueueAdapter.containsInstallOrOpen result: $result")
+        return result
+    }
     fun peek(): ServerRequest? {
         BranchLogger.v("BranchRequestQueueAdapter.peek called")
         val result = newQueue.peek()

--- a/Branch-SDK/src/test/java/io/branch/referral/QueueContainsInstallOrOpenTest.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/QueueContainsInstallOrOpenTest.kt
@@ -1,0 +1,65 @@
+package io.branch.referral
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import io.branch.coroutines.RequestDeepLink
+import kotlinx.coroutines.runBlocking
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * Pins what counts as an open already in flight.
+ *
+ * On the beta two producers reach sendOpen — the foreground observer and the deep link callback —
+ * and the first open is still queued when the second arrives, so a launch sent two. No existing
+ * test asserts on what the queue holds, which is why that went unnoticed.
+ */
+class QueueContainsInstallOrOpenTest : BranchTestBase() {
+
+    private lateinit var queue: BranchRequestQueue
+
+    @Before
+    fun setUpQueue() {
+        super.setUpBase()
+        Branch.getAutoInstance(RuntimeEnvironment.getApplication())
+        queue = BranchRequestQueue.getInstance(RuntimeEnvironment.getApplication())
+        runBlocking { queue.clear() }
+    }
+
+    @Test
+    fun emptyQueue_containsNeither() {
+        assertFalse(queue.containsInstallOrOpen())
+    }
+
+    @Test
+    fun queuedOpen_isFound() {
+        queue.enqueue(RequestOpen(RuntimeEnvironment.getApplication(), null, false, null))
+
+        assertTrue(queue.containsInstallOrOpen())
+    }
+
+    /**
+     * sessionBuilder().init() is still public API, and getInstallOrOpenRequest builds an install
+     * when there is no randomized bundle token. An app on that path must get the same protection;
+     * the migrated TestBed no longer exercises it, so only this test covers the branch.
+     */
+    @Test
+    fun queuedInstall_isFound() {
+        queue.enqueue(ServerRequestRegisterInstall(RuntimeEnvironment.getApplication(), null, false))
+
+        assertTrue(queue.containsInstallOrOpen())
+    }
+
+    /**
+     * The guard must not count a deep link resolution. The beta's flow is /v3/deeplink followed by
+     * /v3/events/open; counting the resolution would suppress the open that has to follow it, and
+     * the launch would lose attribution instead of duplicating it.
+     */
+    @Test
+    fun queuedDeepLink_isNotAnOpen() {
+        queue.enqueue(RequestDeepLink(RuntimeEnvironment.getApplication(), null, null, false))
+
+        assertFalse(queue.containsInstallOrOpen())
+    }
+}


### PR DESCRIPTION
Worth taking early: every black-box scenario contract asserts an exact `/v3/events/open` count, and every one of them is one too high on the wire until this lands. Measured, the duplicate is in the cold, first-install and organic captures alike, so this unblocks EMT-4081, EMT-4083 and EMT-4087.

## The defect

Two producers reach `sendOpen` and neither checked the queue. The foreground observer enqueues an open; the deep link callback chains another. The first is still queued when the second arrives, so a launch sends two.

New on the beta: master has a single producer of session requests, and one producer does not duplicate against itself.

## What changed

The queue could not answer "is an open already pending". It exposes `peek`, `peekAt` and `hasUser`, and `queueList` is private, so this adds the capability alongside the guard. iOS's `containsInstallOrOpen` is the shape being mirrored.

`RequestOpen` and `ServerRequestRegisterInstall` count. `ServerRequestRegisterOpen` does not, since its only construction site is the queue-restore path nothing on this line uses. `RequestDeepLink` does not, deliberately.

## Counting the deep link would be worse than the defect

Measured with the predicate widened to `ServerRequestInitSession`: both producers back off and the launch sends **no open at all**. `sessionParams` is still populated, so `getLatestReferringParams` works and a UI assertion passes while the attribution event never reaches the server. Silent on the device, invisible to the E2E suite.

## Evidence

With the guard, clean install each run:

```
link launch     1 /v3/deeplink   1 /v3/events/open   1 skip
organic launch  1 /v3/deeplink   1 /v3/events/open   1 skip
```

Four tests, each demonstrated failing against a distinct regression: an inert predicate fails `queuedOpen_isFound`, a widened one fails `queuedDeepLink_isNotAnOpen`, a dropped install branch fails `queuedInstall_isFound`. No existing test asserts on what the queue holds, which is why this went unnoticed. `:Branch-SDK:testDebugUnitTest` passes.

## Scope

Android counterpart of iOS EMT-3892 / #1612. The damaging consequence, the second open erasing the resolved payload, is #1389.

Ticket: https://branch.atlassian.net/browse/EMT-4136
