### PR TITLE
EMT-4198: stamp the request identifiers on link creation

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1204,6 +1204,8 @@ public class Branch {
                 req.onUrlAvailable(url);
                 return url;
             }
+            // The link generators below bypass the queue, which is what normally stamps these.
+            req.addClientRequestParameters();
             if (req.isAsync()) {
                 // Use modern link generator for async requests when available
                 if (modernLinkGenerator_ != null) {

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchLegacyLinkGenerator.kt
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchLegacyLinkGenerator.kt
@@ -139,7 +139,7 @@ internal class BranchLegacyLinkGenerator(
      * @param linkData The BranchLinkData containing link generation parameters
      * @param defaultToLongUrl If true, returns longUrl parameter on API failure
      * @param longUrl Fallback URL to return when API fails and defaultToLongUrl is true
-     * @param linkCache Thread-safe String-based cache for generated URLs
+     * @param linkCache Thread-safe cache keyed by the link attributes
      * @return Generated short URL, longUrl fallback, or null on complete failure
      * 
      * @see BranchLinkData
@@ -149,7 +149,7 @@ internal class BranchLegacyLinkGenerator(
         linkData: BranchLinkData,
         defaultToLongUrl: Boolean,
         longUrl: String?,
-        linkCache: ConcurrentHashMap<String, String>
+        linkCache: ConcurrentHashMap<BranchLinkData, String>
     ): String? {
         var response: ServerResponse? = null
         
@@ -228,7 +228,7 @@ internal class BranchLegacyLinkGenerator(
         linkData: BranchLinkData,
         defaultToLongUrl: Boolean,
         longUrl: String?,
-        linkCache: ConcurrentHashMap<String, String>
+        linkCache: ConcurrentHashMap<BranchLinkData, String>
     ): String? {
         var url: String? = null
         
@@ -242,8 +242,8 @@ internal class BranchLegacyLinkGenerator(
             try {
                 url = response.`object`.getString("url")
                 
-                // Cache successful result using linkData toString as key
-                linkCache[linkData.toString()] = url
+                // Cache successful result
+                linkCache[linkData] = url
             } catch (e: JSONException) {
                 BranchLogger.e("Error parsing URL from direct response: ${e.message}")
             }

--- a/Branch-SDK/src/main/java/io/branch/referral/ModernLinkGenerator.kt
+++ b/Branch-SDK/src/main/java/io/branch/referral/ModernLinkGenerator.kt
@@ -79,7 +79,7 @@ class ModernLinkGenerator(
     )
     
     // Thread-safe cache for generated links - prevents duplicate requests
-    private val linkCache = ConcurrentHashMap<String, String>()
+    private val linkCache = ConcurrentHashMap<BranchLinkData, String>()
     
     /**
      * Generate short link asynchronously using coroutines.
@@ -95,15 +95,14 @@ class ModernLinkGenerator(
         
         try {
             // Check cache first to avoid duplicate requests
-            val cacheKey = linkData.toString()
-            linkCache[cacheKey]?.let { cachedUrl ->
+            linkCache[linkData]?.let { cachedUrl ->
                 return@withContext Result.success(cachedUrl)
             }
             
             // Apply timeout to prevent ANR
             withTimeout(timeoutMs) {
                 val response = performLinkRequest(linkData)
-                processLinkResponse(response, cacheKey)
+                processLinkResponse(response, linkData)
             }
         } catch (e: TimeoutCancellationException) {
             Result.failure(
@@ -323,13 +322,13 @@ class ModernLinkGenerator(
     /**
      * Process the server response and extract the URL.
      */
-    private fun processLinkResponse(response: ServerResponse, cacheKey: String): Result<String> {
+    private fun processLinkResponse(response: ServerResponse, linkData: BranchLinkData): Result<String> {
         return try {
             when (response.statusCode) {
                 HttpURLConnection.HTTP_OK -> {
                     val url = response.`object`.getString("url")
                     // Cache successful result
-                    linkCache[cacheKey] = url
+                    linkCache[linkData] = url
                     Result.success(url)
                 }
                 HttpURLConnection.HTTP_CONFLICT -> {

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -680,9 +680,10 @@ public abstract class ServerRequest {
     }
 
     /**
-     * Put request time stamp and uuid at top level of POST body
+     * Put request time stamp and uuid at top level of POST body. Idempotent: both values are
+     * fixed at construction.
      */
-    private void addClientRequestParameters() {
+    void addClientRequestParameters() {
         if(prefHelper_ != null){
             try {
                 params_.put(Defines.Jsonkey.Branch_Sdk_Request_Creation_Time_Stamp.getKey(), this.creation_ts);

--- a/Branch-SDK/src/test/java/io/branch/referral/LinkCacheKeyTest.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/LinkCacheKeyTest.kt
@@ -14,15 +14,16 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.robolectric.RuntimeEnvironment
+import java.util.concurrent.ConcurrentHashMap
 import java.net.HttpURLConnection
 
 /**
- * The link cache is keyed by BranchLinkData, whose hashCode covers the link attributes only.
+ * Both link generators cache by BranchLinkData, whose hashCode covers the link attributes only.
  * A request carries identifiers that differ on every call, so keying on the serialised payload
  * would make the cache miss every time.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class ModernLinkGeneratorCacheKeyTest : BranchTestBase() {
+class LinkCacheKeyTest : BranchTestBase() {
 
     @Mock
     private lateinit var remoteInterface: BranchRemoteInterface
@@ -71,6 +72,23 @@ class ModernLinkGeneratorCacheKeyTest : BranchTestBase() {
         generator.generateShortLink(sms)
 
         verify(remoteInterface, times(2)).make_restful_post(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `the direct path caches under the link attributes`() {
+        `when`(remoteInterface.make_restful_post(any(), any(), any(), any()))
+            .thenReturn(successResponse(URL))
+        val legacy = BranchLegacyLinkGenerator(prefHelper, remoteInterface)
+        val cache = ConcurrentHashMap<BranchLinkData, String>()
+
+        val url = legacy.generateShortLinkSyncDirect(
+            linkData().stamped("uuid-1", 1_000L), false, null, cache
+        )
+
+        assertEquals(URL, url)
+        // Retrievable by an equivalent link carrying different identifiers -- the property the
+        // queue path and Branch.linkCache_ both rely on, and the one toString() keying breaks.
+        assertEquals(URL, cache[linkData().stamped("uuid-2", 2_000L)])
     }
 
     private fun linkData() = BranchLinkData().apply {

--- a/Branch-SDK/src/test/java/io/branch/referral/ModernLinkGeneratorCacheKeyTest.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/ModernLinkGeneratorCacheKeyTest.kt
@@ -1,0 +1,100 @@
+package io.branch.referral
+
+import io.branch.referral.network.BranchRemoteInterface
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.robolectric.RuntimeEnvironment
+import java.net.HttpURLConnection
+
+/**
+ * The link cache is keyed by BranchLinkData, whose hashCode covers the link attributes only.
+ * A request carries identifiers that differ on every call, so keying on the serialised payload
+ * would make the cache miss every time.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ModernLinkGeneratorCacheKeyTest : BranchTestBase() {
+
+    @Mock
+    private lateinit var remoteInterface: BranchRemoteInterface
+
+    @Mock
+    private lateinit var prefHelper: PrefHelper
+
+    private lateinit var generator: ModernLinkGenerator
+
+    @Before
+    fun setUpGenerator() {
+        `when`(prefHelper.apiBaseUrl).thenReturn("https://api.branch.io/")
+        `when`(prefHelper.branchKey).thenReturn("key_live_test")
+        generator = ModernLinkGenerator(
+            context = RuntimeEnvironment.getApplication(),
+            branchRemoteInterface = remoteInterface,
+            prefHelper = prefHelper,
+            scope = CoroutineScope(testDispatcher + SupervisorJob()),
+            defaultTimeoutMs = 5_000L
+        )
+    }
+
+    @Test
+    fun `the same link requested twice reaches the network once`() = runTest {
+        `when`(remoteInterface.make_restful_post(any(), any(), any(), any()))
+            .thenReturn(successResponse(URL))
+
+        val first = linkData().stamped("uuid-1", 1_000L)
+        val second = linkData().stamped("uuid-2", 2_000L)
+
+        assertEquals(URL, generator.generateShortLink(first).getOrNull())
+        assertEquals(URL, generator.generateShortLink(second).getOrNull())
+
+        verify(remoteInterface, times(1)).make_restful_post(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `links that differ in an attribute are not shared`() = runTest {
+        `when`(remoteInterface.make_restful_post(any(), any(), any(), any()))
+            .thenReturn(successResponse(URL))
+
+        val email = linkData().stamped("uuid-1", 1_000L)
+        val sms = linkData().apply { putChannel("sms") }.stamped("uuid-2", 2_000L)
+
+        generator.generateShortLink(email)
+        generator.generateShortLink(sms)
+
+        verify(remoteInterface, times(2)).make_restful_post(any(), any(), any(), any())
+    }
+
+    private fun linkData() = BranchLinkData().apply {
+        putType(0)
+        putAlias("promo")
+        putChannel("email")
+        putFeature("sharing")
+        putStage("new user")
+        putDuration(0)
+    }
+
+    private fun BranchLinkData.stamped(uuid: String, timestamp: Long) = apply {
+        put(Defines.Jsonkey.Branch_Sdk_Request_Uuid.key, uuid)
+        put(Defines.Jsonkey.Branch_Sdk_Request_Creation_Time_Stamp.key, timestamp)
+    }
+
+    private fun successResponse(url: String) =
+        ServerResponse("v1/url", HttpURLConnection.HTTP_OK, "req-1", "Success").apply {
+            setPost(JSONObject().put("url", url))
+        }
+
+    private fun <T> any(): T = org.mockito.ArgumentMatchers.any()
+
+    private companion object {
+        const val URL = "https://test.app.link/abc"
+    }
+}


### PR DESCRIPTION
Worth taking before the wire-gate stack: without this the gate cannot go green at all, since the validator requires `branch_sdk_request_timestamp` and `branch_sdk_request_unique_id` on every request. Merging it also shrinks #1390 from 8 files to 3, because that PR carries this same fix inline out of necessity.

## The defect

On `6.0.0-beta.0` a link-creation request reaches `/v1/url` without `branch_sdk_request_timestamp` and `branch_sdk_request_unique_id`. Android `master` sends both; iOS sends the equivalents on both its lines. The Android beta is the only line missing them.

`generateShortLinkInternal` routes through `ModernLinkGenerator`, which posts straight to the network layer. Only the queue path reaches `addClientRequestParameters`.

## The fix

Stamp at one site, before the `isAsync` fork, so it covers both generators and the legacy fallback. `addClientRequestParameters` widens to package-private; public API is unchanged.

The second commit is required by the first. `ModernLinkGenerator` keyed its cache on the serialised body, so stamping a per-request identifier makes every key unique and the cache never hits. That key was already wrong, since the body carries `local_ip` and `ui_mode`. The typed key matches what `Branch.linkCache_` and the legacy generator already use.

## Proof

Run 33012098521, dispatched on this branch: same eight requests, `/v1/url` still at [4/8], both `branch_sdk_request_*` failures gone.

`LinkCacheKeyTest` covers both paths, each demonstrated failing against a deliberate regression: async gives `Wanted 1 time but was 2 times`, synchronous gives `expected:<...> but was:<null>`. Unit suite 441 tests, 0 failures.

## Known red, neither from this change

`hardware_id` on `/v1/url`: Android strips it deliberately, on master too. EMT-4199, needs a server-side answer.

`Mandatory endpoint '/v1/install'`: that assertion exists only on this base, and #1390 removes it.
