### PR TITLE
docs: cut CLAUDE.md to what changes behavior, move the rest to docs/internal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,142 +1,59 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Branch Android SDK. One published library module, `:Branch-SDK`, released to Maven Central as `io.branch.sdk.android:library`. Package root `io.branch.referral`.
 
-This is the **Branch Android SDK** for deep linking and attribution. Production code is a single Android library module, `:Branch-SDK`, published to Maven Central as `io.branch.sdk.android:library`. Package root: `io.branch.referral`.
+**What the SDK does.** It creates and resolves Branch links, and it attributes app activity to them. When a link is tapped, the SDK reports the app launch to the Branch API and gets back the link's data, so the app can route the user to the right content and Branch can credit the campaign that drove them. The first launch after an app is installed is an **install**; every later launch is an **open**. That distinction runs through the whole codebase, because install is the event that ties a new user back to the link they came from. Integrator-facing docs: https://help.branch.io/developers-hub/docs/android-sdk-overview
 
-## Modules
+**You are on `master`, the 5.x release line.** The other live branch, `6.0.0-beta.0`, is a different architecture (coroutine request queue, sealed session state). Patterns from that branch do not belong here, and a fact from one line is not evidence about the other. Verify against the source on the branch you are on.
 
-- **`Branch-SDK`** — the published SDK library (`com.android.library`). All production code lives under `Branch-SDK/src/main/java/io/branch/`, most of it in `referral/`.
-- **`Branch-SDK-TestBed`** — a sample/demo app (`com.android.application`, `io.branch.branchandroidtestbed`) that depends on `:Branch-SDK`. Used for manual testing and as the target app for E2E tests.
-- **`Branch-SDK-GPTDriver`** — a `com.android.test` module (MobileBoost/GPTDriver hybrid E2E tests) whose `targetProjectPath` is `:Branch-SDK-TestBed`. Deterministic Espresso first, AI-assisted validation only when Espresso can't express the intent. Requires a `MOBILEBOOST_API_KEY` (see `local.properties.example` / `Branch-SDK-GPTDriver/README.md`).
+## Read on demand
 
-## Source layout
+Not loaded automatically. Open the one that matches the task.
 
-Most code is in `io.branch.referral`, but not all — check these sibling packages under `Branch-SDK/src/main/java/io/branch/` before assuming a class lives in `referral/`:
-
-- **`referral/`** — the SDK core: `Branch`, `PrefHelper`, `ServerRequest*` + `ServerRequestQueue`, device/tracking/config, link & share builders. Sub-dirs: `network/` (`BranchRemoteInterface` + `…UrlConnection` HTTP impl), `util/` (`BranchEvent`, `BRANCH_STANDARD_EVENT`, `LinkProperties`, `CommerceEvent`, content-metadata types), `validators/` (integration & deep-link diagnostics), `QRCode/`.
-- **`indexing/`** — `BranchUniversalObject` (the BUO content model used for link creation and tracking).
-- **`coroutines/`** — Kotlin coroutine entry points for async fetches: `AdvertisingIds`, `DeviceSignals`, `InstallReferrers`.
-- **`data/`** — `InstallReferrerResult` (result model for the referrer fetch).
-- **`interfaces/`** — public callback interfaces (e.g. `IBranchLoggingCallbacks`).
-- **`receivers/`** — `SharingBroadcastReceiver` (captures the chosen app from the system share sheet).
-
-## Where to make changes
-
-| Task | Start here |
+| File | Read it when |
 | --- | --- |
-| Session/init flow, deep-link callbacks, intent parsing | `Branch.java` (`sessionBuilder`, `initializeSession`, `registerAppInit`, `readAndStripParam`) |
-| A new API request type or changing request bodies | subclass `ServerRequest`; wire dispatch/gating in `ServerRequestQueue.java`; add path to `Defines.RequestPath` |
-| Persisted state / new SharedPreferences key | `PrefHelper.java` (add `KEY_*` + typed accessors) |
-| Wire-format field names / enums / endpoints | `Defines.java` (`Jsonkey`, `RequestPath`, `IntentKeys`, `HeaderKey`) |
-| Device/hardware signals on requests | `DeviceInfo.java`, `SystemObserver.java`, `coroutines/DeviceSignals.kt` |
-| Ad ID (GAID/Huawei/etc.) fetch | `coroutines/AdvertisingIds.kt` |
-| Install-referrer fetch | `coroutines/InstallReferrers.kt`, `data/InstallReferrerResult.kt`, `AppStoreReferrer.java`, `BranchPreinstall.java` |
-| Link creation (short/long URLs) | `BranchShortLinkBuilder.java`, `BranchUrlBuilder.java`, `BranchLinkData.java`; content model in `indexing/BranchUniversalObject.java`, `util/LinkProperties.java` |
-| Sharing / share sheet | `BranchShareSheetBuilder.java`, `ShareLinkManager.java`, `NativeShareLinkManager.java`, `receivers/SharingBroadcastReceiver.kt` |
-| Custom analytics / commerce events | `util/BranchEvent.java`, `util/BRANCH_STANDARD_EVENT.java`, `util/CommerceEvent.java` |
-| Tracking-disabled / consent / DMA | `TrackingController.java`, plus the DMA/consent keys in `PrefHelper.java` |
-| `branch.json` / config flags | `BranchJsonConfig.java`, `BranchConfigurationController.kt`, `BranchUtil.java` (key resolution) |
-| HTTP transport / retries / timeouts | `network/BranchRemoteInterfaceUrlConnection.java` (impl), `network/BranchRemoteInterface.java` (abstract) |
-| QR codes | `QRCode/BranchQRCode.java`, `QRCode/ServerRequestCreateQRCode.java` |
-| Integration / deep-link diagnostics | `validators/IntegrationValidator.java`, `validators/DeepLinkRoutingValidator.java` |
-| Logging | `BranchLogger.kt`, `interfaces/IBranchLoggingCallbacks.java` |
+| `docs/internal/code-map.md` | you need to find where something lives |
+| `docs/internal/architecture.md` | you are touching session init, the request queue, or persisted state (opens with a glossary) |
+| `docs/internal/testing.md` | you are writing or running tests, or a CI check failed |
+| `docs/internal/working-agreements.md` | you are opening a PR or reviewing one |
 
-## Build, test, lint
+## First hour
 
-Toolchain: **Java 17** for Gradle (CI uses Corretto/Temurin 17), `compileSdk 34`, `minSdk 21` for `:Branch-SDK` (`:Branch-SDK-GPTDriver` sets `minSdk 24`). Copy `local.properties.example` → `local.properties` (Android Studio fills in `sdk.dir`).
+Java 17 for Gradle, `compileSdk 34`, `minSdk 21` (the `:Branch-SDK-GPTDriver` module sets 24). Kotlin 1.6.21, coroutines 1.6.4.
 
 ```bash
-# JVM unit tests (fast, no emulator) — the everyday loop
-./gradlew :Branch-SDK:testDebugUnitTest
-
-# A single unit test class or method
-./gradlew :Branch-SDK:testDebugUnitTest --tests "io.branch.referral.BranchConfigurationControllerTest"
-./gradlew :Branch-SDK:testDebugUnitTest --tests "*BranchConfigurationControllerTest.someMethod"
-
-# Instrumented tests (need a connected device/emulator) — the bulk of the suite
-./gradlew :Branch-SDK:connectedDebugAndroidTest
-# A single instrumented class
-./gradlew :Branch-SDK:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=io.branch.referral.BranchApiTests
-
-# Coverage (JaCoCo, aggregates unit + instrumented; depends on createDebugCoverageReport, so it needs a device like the line above)
-./gradlew :Branch-SDK:jacocoTestReport
-
-# Lint (SDK module has abortOnError = false — lint won't fail the build)
-./gradlew :Branch-SDK:lint
+cp local.properties.example local.properties   # then set sdk.dir, or export ANDROID_HOME
+./gradlew :Branch-SDK-TestBed:installDebug     # the sample app, on a device or emulator
 ```
 
-**Most of the test suite is instrumented** (`Branch-SDK/src/androidTest/`), so it requires an emulator/device. Only three files are JVM unit tests (`Branch-SDK/src/test/`): `BranchConfigurationControllerTest.kt`, `InstallReferrerResultTests.kt`, `BranchPartnerParametersTest.java`. Test tasks are configured with `test-retry` (up to 3 retries) — flakes get retried in CI.
+**The TestBed needs no Branch account.** It ships a test key in `Branch-SDK-TestBed/src/main/AndroidManifest.xml` with `io.branch.sdk.TestMode` set true, so you can create a link, tap it, and watch the SDK resolve it on first run. Turn on wire logging with `Branch.enableLogging()` to read what actually goes to the API; that log is what the CI wire gate validates.
 
-### CI
+## Commands
 
-- **`unit-and-instrumented-tests-action.yml`** — runs `testDebugUnitTest` + `connectedDebugAndroidTest` on API 21 and 34, plus `jacocoTestReport` → Codecov.
-- **`sdk-l1-validation.yml`** — the "Layer 1" PR gate. Builds TestBed + GPTDriver APKs, runs an instrumented test on the emulator, pulls `branchlogs.txt`, and asserts required device/SDK fields are on the wire via `scripts/validate_l1_logs.py`. To reproduce the wire check locally: `python3 scripts/validate_l1_logs.py path/to/branchlogs.txt` (validator self-tests: `python3 -m unittest scripts.test_validate_l1_logs -v`). Required-field lists live at the top of `validate_l1_logs.py`; the check is presence-only and scoped to `/v1/*`.
-- **`gptdriverautomation.yaml`** — drives the `:Branch-SDK-GPTDriver` module (MobileBoost/GPTDriver hybrid E2E tests).
+```bash
+./gradlew :Branch-SDK:testDebugUnitTest          # JVM only, no device, covers three classes
+./gradlew :Branch-SDK:connectedDebugAndroidTest  # the real suite, needs a device
+./gradlew :Branch-SDK:assembleDebug              # build the AAR
+```
 
-## Architecture
+Full test and CI detail, including the Layer 1 wire gate that runs on every PR into `master`: `docs/internal/testing.md`.
 
-### Singleton wiring (`Branch.java`)
+## Non-obvious behavior
 
-`Branch` is a process singleton (`branchReferral_`). Apps obtain it with `Branch.getAutoInstance(Context)`; `getInstance()` is a pure accessor that never creates. The private constructor `Branch(Context)` (~line 321) wires up the sub-systems, most held in `final` fields set once at construction:
+- **`testDebugUnitTest` covers almost nothing.** Only three files are JVM tests; the real suite is instrumented and needs an emulator. A green unit run is not evidence your change works.
+- **Request ordering is a guarantee the SDK makes to apps, not an accident.** Every call goes through one serial queue. Init is force-inserted at the head, because nothing else can be attributed until it returns, and `setIdentity` and `logout` are enqueued as no-network placeholders purely so they take effect in the order the app called them. Reorder or short-circuit the queue and events get attributed to the wrong user, with no test to tell you.
+- **Several integrations are compiled against but not shipped** (ad IDs, Huawei/Samsung/Xiaomi referrers, billing, in-app browser). They are `compileOnly`, so the classes exist at compile time and may be absent at runtime in a host app. Touch that code without a reflection or try/catch guard and the SDK crashes in any app that skipped the optional dependency, while your build and tests stay green. The Google Play install referrer is the exception: a hard `implementation` dependency, always present.
+- **The request queue is in-memory only.** It opens a SharedPreferences file that nothing ever reads or writes after construction. Anything queued when the process dies is silently lost.
+- **`PrefHelper` string getters default to `NO_STRING_VALUE = "bnc_no_value"`.** Use `hasPrefValue(key)` to tell unset from empty; do not compare against the default.
+- **`Branch.shutDown()` is package-private and test-only.** It nulls the singleton and resets statics, and the instrumented suite depends on that between runs.
 
-- `prefHelper_` — `PrefHelper.getInstance(context)` (SharedPreferences-backed state)
-- `requestQueue_` — `ServerRequestQueue.getInstance(context)` (the API request queue)
-- `deviceInfo_` — device/hardware data for request bodies
-- `trackingController` — tracking-disabled state
-- `branchConfigurationController_` — resolved config flags
-- `branchRemoteInterface_` — `BranchRemoteInterfaceUrlConnection` (non-final; swappable via `setBranchRemoteInterface`, and mocked in tests)
-- `branchPluginSupport_`, `branchQRCodeCache_`, `linkCache_`
+## Working agreements
 
-`initBranchSDK()` is the one-time constructor caller and early-returns if the singleton already exists. `shutDown()` (package-private, test-only) nulls the singleton and resets statics — tests rely on this to reset global state between runs.
+- Never commit to `master`. Branch, open a PR, get CI green.
+- The PR title references the ticket, and the key is yours, not a teammate's. Jira auto-links whatever key it sees.
+- Every PR must request `@BranchMetrics/sdk-maintainers`. It is not reliably requested for you; check with `gh pr view <n> --json reviewRequests`.
+- Every user-visible change gets a `ChangeLog.md` entry under the new version heading.
+- **Comments in public API are minimal**: what the function does and what the parameters mean. Nothing else.
+- Keep changes surgical, so the diff stays reviewable: do not reformat, rename, or improve code your task did not require.
 
-### Session init flow (intent → callback)
-
-Callers drive init through the fluent `Branch.sessionBuilder(activity).withCallback(...).init()`. The flow:
-
-1. **Intent parsing** — `readAndStripParam(uri/intent, activity)` runs a chain of extractors (`extractBranchLinkFromIntentExtra`, `extractClickID`, `extractAppLink`, `extractExternalUriAndIntentExtras`, …) that write results into `PrefHelper` (link click id, app link, push identifier, external intent uri/extra, initial referrer). A Branch link in an intent is consumed exactly once, marked by the `BranchLinkUsed` intent extra.
-2. **Request selection** — `getInstallOrOpenRequest()` picks `ServerRequestRegisterInstall` vs `ServerRequestRegisterOpen` based on `requestQueue_.hasUser()` (true iff a randomized bundle token is already persisted).
-3. **Queueing with wait locks** — `registerAppInit()` sets state `INITIALISING` and force-inserts the init request at the front of the queue (or reuses an in-flight self-init request and transfers the callback, to preserve ordering). `initTasks()` attaches `PROCESS_WAIT_LOCK`s so the request won't fire until prerequisites resolve: `INTENT_PENDING_WAIT_LOCK` (until `onIntentReady` at `Activity.onResume`), `INSTALL_REFERRER_FETCH_WAIT_LOCK` (install only), `GAID_FETCH_WAIT_LOCK` (always). `initializeSession` separately attaches `USER_SET_WAIT_LOCK` when `withDelay` is used.
-4. **Response → callback** — on success the init request stores returned params into `PrefHelper` as **session params** (latest) and **install params** (first-ever), then invokes `callback.onInitFinished(...)`.
-
-`getLatestReferringParams()` reads `PrefHelper.getSessionParams()`; `getFirstReferringParams()` reads `PrefHelper.getInstallParams()`. Sync variants block on a `CountDownLatch` (≤2500 ms) and must be called off the UI thread.
-
-**Init state machine:** `SessionState { INITIALISED, INITIALISING, UNINITIALISED }`, exposed via `getInitState()`. `INITIALISED` means the SDK has consumed the current intent and can send events.
-
-**Intent lock:** by default the SDK waits for `Activity.onResume` (`intentState_` PENDING→READY via `onIntentReady`) so it captures the freshest intent (e.g. `onNewIntent` single-top). `bypassWaitingForIntent(true)` or `unlockPendingIntent()` are escape hatches. `removeSessionInitializationDelay()` clears the `withDelay` lock.
-
-**Instant Deep Linking (IDL, off by default):** when enabled, `init()` fires the callback synchronously from cached intent params, then nulls the callback and lets the network init run for analytics only.
-
-**Plugin deferral:** `deferInitForPluginRuntime` caches the session builder until `notifyNativeToInit()` is called (used by cross-platform plugins like React Native/Flutter).
-
-### ServerRequest lifecycle and the queue
-
-`ServerRequest` (abstract) is the base for every API call. It owns the POST/GET body (`params_`), a `Defines.RequestPath`, a set of wait locks (`locks_`), and a retry count. `BRANCH_API_VERSION` has three values — `V1`, `V1_LATD`, `V2`. `setPost()` branches `if (== V1) ... else ...`: **V1** (`/v1/install`, `/v1/open`, `/v1/url`) puts device fields at the top level; everything else — **V2** (`/v2/event/…`) and **`V1_LATD`** (`ServerRequestGetLATD`) — nests them under a `user_data` object. Subclasses: `ServerRequestInitSession` (→ `ServerRequestRegisterInstall`, `ServerRequestRegisterOpen`), `ServerRequestLogEvent` (V2), `ServerRequestCreateUrl`, `ServerRequestGetLATD` (V1_LATD), `QRCode/ServerRequestCreateQRCode`, `validators/ServerRequestGetAppConfig`, plus the queue-only operations `QueueOperationSetIdentity` and `QueueOperationLogout` (these are enqueued but are not network requests).
-
-**`ServerRequestQueue` is serialized, single-flight, and currently in-memory:**
-
-- The backing store is `Collections.synchronizedList(new LinkedList<>())` guarded by a static `reqQueueLockObject` — **not** a `ConcurrentLinkedQueue`. Capacity `MAX_ITEMS = 25`; on overflow it drops index 1 (never the head).
-- A `Semaphore(1)` (`serverSema_`) plus an `int networkCount_` flag enforce **one in-flight request at a time**. `processNextQueueItem()` peeks the head; if it has no pending wait locks it runs it on a `BranchPostTask` (a `BranchAsyncTask`) with a task-timeout latch. Completion resets `networkCount_` and re-posts `processNextQueueItem` on a main-thread `Handler` (avoids stack overflow on the timeout path).
-- **Disk persistence is currently vestigial.** The constructor opens a SharedPreferences file `"BNC_Server_Request_Queue"` (constant `PREF_KEY = "BNCServerRequestQueue"`) but nothing reads or writes it after init — the queue does not survive a process restart. `toJSON`/`fromJSON` on `ServerRequest` are similarly marked "TODO: in-memory only." Don't assume queued requests are durable.
-
-**Queue vs PrefHelper storage are separate SharedPreferences files.** PrefHelper uses `"branch_referral_shared_pref"`; the (unused) queue file is `"BNC_Server_Request_Queue"`. The queue reaches PrefHelper only via `Branch.getInstance().prefHelper_` for session values.
-
-**Session gating:** a request other than install/logout/set-identity fails with `ERR_NO_SESSION` if there's no user. `requestNeedsSession()` exempts init, create-url, logout, and set-identity; everything else waits behind `SDK_INIT_WAIT_LOCK` until `INITIALISED`. On init success, the new `SessionID` / `RandomizedBundleToken` / `RandomizedDeviceToken` are written to PrefHelper **and** `updateAllRequestsInQueue()` rewrites those keys into every already-queued request's body.
-
-### PrefHelper — persistent state (`PrefHelper.java`)
-
-Singleton wrapper over the `"branch_referral_shared_pref"` SharedPreferences file with typed get/set accessors. String getters default to `NO_STRING_VALUE = "bnc_no_value"` — code distinguishes "unset" from "empty" using `hasPrefValue(...)` (see `isDMAParamsInitialized`, `isAttributionLevelInitialized`), so prefer that pattern over comparing against defaults. Stores: branch key + key **source**, randomized device/bundle tokens, identity, session params vs install params, link-click / app-link / push / external-intent identifiers, install & referrer data (GCLID self-expires after 30 days), consent/DMA flags, tracking state, and network tuning. In-memory-only (not persisted): request/install metadata, partner params, custom server/CDN URLs, logging + EU-endpoint flags.
-
-**Branch key resolution precedence** (`BranchUtil.readBranchKey`): `branch.json` → manifest meta-data (`io.branch.sdk.BranchKey` / `.test`; test mode falls back to the live key) → string resources. Each source is persisted alongside a key-**source** string. `branch.json` is read by `BranchJsonConfig` (a separate singleton); `BranchConfigurationController` surfaces resolved config flags and delegates its own storage to `prefHelper_`.
-
-## Non-obvious invariants
-
-- **Request ordering is a guarantee, not a side effect.** Init is force-moved to the front; `setIdentity`/`logout` are queue operations specifically so they execute in enqueue order relative to other requests (see ChangeLog 5.20.0). Don't reorder or short-circuit queue handling casually.
-- **`clearPrefOnBranchKeyChange()`** (triggered when `setBranchKey` sees a different key) does `prefsEditor_.clear()` but deliberately re-writes four values so an in-flight deep link survives: link-click id, link-click identifier, app link, push identifier.
-- **Tracking-disabled** (`TrackingController`, or `setConsumerProtectionAttributionLevel(NONE)`) blocks network calls except deep-linking. Disabling clears session/link/referrer prefs but **not** identity or device/bundle tokens. Only requests whose `prepareExecuteWithoutTracking()` returns true are allowed through; init requests strip all PII and set `TrackingDisabled=true` in that mode. There is no `SKIP_QUEUE` mechanism — gating is entirely via `prepareExecuteWithoutTracking()` and the `ERR_BRANCH_TRACKING_DISABLED` checks.
-- **One-time writes:** `KEY_ORIGINAL_INSTALL_TIME` is written once (when 0); enhanced-web-link UX type/load-time are consumed once then reset; `postInitClear` resets link/referrer/intent identifiers only when ≤1 init request remains queued.
-- **Retry policy** (`onRequestFailed`): a request is dropped on HTTP 400–451, on `ERR_BRANCH_TRACKING_DISABLED`, when `!shouldRetryOnFail()`, or once `currentRetryCount` hits the no-connection retry max; otherwise it stays for replay. Init failure resets state to `UNINITIALISED` — but only if no session params are stored yet, so the intra-app-linking case deliberately keeps `INITIALISED`.
-
-## Optional integrations
-
-Ad-ID / Huawei-Samsung-Xiaomi install-referrer / billing / in-app-browser dependencies are `compileOnly` in `Branch-SDK/build.gradle.kts` — the SDK works without any of them and detects them by reflection at runtime. When touching that code, guard every reference so the SDK still builds and runs when the optional dependency is absent. The **Google** Play install referrer is the exception: it is a hard `implementation` dependency and is always present.
+Details: `docs/internal/working-agreements.md`.

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -1,0 +1,101 @@
+# Architecture (master)
+
+> Contributor-facing notes for work on this branch. Integration docs live at https://help.branch.io/developers-hub/docs/android-sdk-overview
+> Last updated 2026-09-03, against `master` at 827655ea.
+
+How the SDK actually behaves at runtime, and the invariants a change must not break. Read `code-map.md` first if you only need to locate a file.
+
+## Terms
+
+| Term | What it means |
+| --- | --- |
+| **install** / **open** | the first app launch after installation, versus every later launch. `getInstallOrOpenRequest()` picks between them, and the choice decides whether a new user is tied back to the link that brought them |
+| **randomized bundle token** / **randomized device token** | opaque identifiers the Branch API assigns on a successful init and the SDK persists. The bundle token is per app install, the device token per device. Their presence is what "the SDK has a user" means |
+| **session params** / **install params** | the link data returned by init. Session params are from the most recent init; install params are frozen from the first-ever one |
+| **wait lock** | a `PROCESS_WAIT_LOCK` on a queued request. While any lock is attached the queue will not send that request. Locks are how the SDK waits for the intent, the ad ID, and the install referrer without blocking a thread |
+| **LATD** | Last Attributed Touch Data. The API that reports which touch a conversion is credited to, served by `ServerRequestGetLATD` |
+| **DMA** | the EU Digital Markets Act consent parameters, carried on requests and stored in `PrefHelper` |
+| **attribution level** | the consumer-protection setting that decides how much the SDK may collect and send. `NONE` disables attribution while leaving deep linking working |
+
+## Where this is going
+
+The 6.0 line, on `6.0.0-beta.0`, replaces AsyncTask with Kotlin coroutines, models session state as a sealed `BranchSessionState`, and moves link generation to `ModernLinkGenerator`.
+
+That line is moving away from session state as an asserted flag. On `master` it is still live: `SessionState` and `SessionID` are load-bearing and documented below. Do not port beta patterns back here, and do not remove either one as cleanup.
+
+## Singleton wiring
+
+`Branch` is a process singleton (`branchReferral_`). Apps obtain it with `Branch.getAutoInstance(Context)`. `getInstance()` is a pure accessor that never creates, and returns `null` if the SDK was never set up.
+
+The private constructor `Branch(Context)` wires the sub-systems, most into `final` fields set once:
+
+| Field | What it is |
+| --- | --- |
+| `prefHelper_` | `PrefHelper.getInstance(context)`, SharedPreferences-backed state |
+| `requestQueue_` | `ServerRequestQueue.getInstance(context)`, the API request queue |
+| `deviceInfo_` | device and hardware data for request bodies |
+| `trackingController` | tracking-disabled state |
+| `branchConfigurationController_` | resolved config flags |
+| `branchRemoteInterface_` | `BranchRemoteInterfaceUrlConnection`. Non-final and swappable via `setBranchRemoteInterface`, which is how tests mock the network |
+| `branchPluginSupport_`, `branchQRCodeCache_`, `linkCache_` | supporting caches |
+
+`initBranchSDK()` is the one-time constructor caller and early-returns if the singleton exists. `shutDown()` is package-private, test-only, and nulls the singleton plus statics.
+
+## Session init: intent to callback
+
+Callers drive init through `Branch.sessionBuilder(activity).withCallback(...).init()`.
+
+1. **Intent parsing.** `readAndStripParam(uri, activity)` runs a chain of extractors (`extractBranchLinkFromIntentExtra`, `extractClickID`, `extractAppLink`, `extractExternalUriAndIntentExtras`, and others) that write results into `PrefHelper`: link click id, app link, push identifier, external intent uri and extras, initial referrer. A Branch link in an intent is consumed exactly once, marked by the `BranchLinkUsed` intent extra.
+2. **Request selection.** `getInstallOrOpenRequest()` picks `ServerRequestRegisterInstall` or `ServerRequestRegisterOpen` based on `requestQueue_.hasUser()`, true only when a randomized bundle token is already persisted.
+3. **Queueing with wait locks.** `registerAppInit()` sets state `INITIALISING` and force-inserts the init request at the front of the queue, or reuses an in-flight self-init request and transfers the callback to preserve ordering. `initTasks()` attaches `PROCESS_WAIT_LOCK`s so the request does not fire until prerequisites resolve:
+   - `INTENT_PENDING_WAIT_LOCK` until `onIntentReady` at `Activity.onResume`
+   - `INSTALL_REFERRER_FETCH_WAIT_LOCK` on install only
+   - `GAID_FETCH_WAIT_LOCK` always
+   - `USER_SET_WAIT_LOCK` attached separately by `initializeSession` when `withDelay` is used
+4. **Response to callback.** On success the init request stores returned params into `PrefHelper` as **session params** (latest) and **install params** (first-ever), then invokes `callback.onInitFinished(...)`.
+
+`getLatestReferringParams()` reads session params; `getFirstReferringParams()` reads install params. The synchronous variants block on a `CountDownLatch` for up to 2500 ms and must be called off the UI thread.
+
+**Init state.** `Branch.SessionState { INITIALISED, INITIALISING, UNINITIALISED }` (`Branch.java:242`), exposed by `getInitState()` (`Branch.java:1447`). `INITIALISED` means the SDK has consumed the current intent and can send events.
+
+**Intent lock.** By default the SDK waits for `Activity.onResume` (`intentState_` moves PENDING to READY via `onIntentReady`) so it captures the freshest intent, including the `onNewIntent` single-top case. `bypassWaitingForIntent(true)` and `unlockPendingIntent()` are the escape hatches. `removeSessionInitializationDelay()` clears the `withDelay` lock.
+
+**Instant Deep Linking**, off by default: when enabled, `init()` fires the callback synchronously from cached intent params, nulls the callback, and lets the network init run for analytics only.
+
+**Plugin deferral.** `deferInitForPluginRuntime` caches the session builder until `notifyNativeToInit()` is called. Used by React Native and Flutter wrappers.
+
+## ServerRequest and the queue
+
+`ServerRequest` (abstract) is the base for every API call. It owns the POST/GET body (`params_`), a `Defines.RequestPath`, a set of wait locks (`locks_`), and a retry count.
+
+`BRANCH_API_VERSION` has three values: `V1`, `V1_LATD`, `V2`. `setPost()` branches on `V1`. **V1** (`/v1/install`, `/v1/open`, `/v1/url`) puts device fields at the top level. Everything else, meaning **V2** (`/v2/event/...`) and **`V1_LATD`** (`ServerRequestGetLATD`), nests them under a `user_data` object.
+
+Subclasses: `ServerRequestInitSession` (leading to `ServerRequestRegisterInstall` and `ServerRequestRegisterOpen`), `ServerRequestLogEvent` (V2), `ServerRequestCreateUrl`, `ServerRequestGetLATD` (V1_LATD), `QRCode/ServerRequestCreateQRCode`, `validators/ServerRequestGetAppConfig`, plus the queue-only operations `QueueOperationSetIdentity` and `QueueOperationLogout`, which are enqueued for ordering but are not network requests.
+
+**`ServerRequestQueue` is serialized, single-flight, and in-memory:**
+
+- The backing store is `Collections.synchronizedList(new LinkedList<>())` (`ServerRequestQueue.java:87`) guarded by a static `reqQueueLockObject` (`:41`). Not a `ConcurrentLinkedQueue`. Capacity `MAX_ITEMS = 25` (`:35`); on overflow it drops index 1, never the head.
+- A `Semaphore(1)` (`serverSema_`, `:43`) plus an `int networkCount_` (`:45`) enforce **one in-flight request at a time**. `processNextQueueItem()` peeks the head; if it has no pending wait locks it runs on a `BranchPostTask` (a `BranchAsyncTask`) with a task-timeout latch. Completion resets `networkCount_` and re-posts `processNextQueueItem` on a main-thread `Handler`, which avoids a stack overflow on the timeout path.
+- **Disk persistence is vestigial.** The constructor opens a SharedPreferences file `"BNC_Server_Request_Queue"` (`PREF_KEY = "BNCServerRequestQueue"`), but nothing reads or writes it after init. `ServerRequest.toJSON`/`fromJSON` are implemented but unused by the queue, and both carry a TODO to drop serialization entirely. Queued requests do not survive a process restart.
+
+**Queue storage and `PrefHelper` storage are separate SharedPreferences files.** `PrefHelper` uses `"branch_referral_shared_pref"`; the unused queue file is `"BNC_Server_Request_Queue"`. The queue reaches `PrefHelper` only through `Branch.getInstance().prefHelper_`.
+
+**Session gating.** A request other than install, logout, or set-identity fails with `ERR_NO_SESSION` if there is no user. `requestNeedsSession()` exempts init, create-url, logout, and set-identity; everything else waits behind `SDK_INIT_WAIT_LOCK` until `INITIALISED`. On init success, the new `SessionID`, `RandomizedBundleToken`, and `RandomizedDeviceToken` are written to `PrefHelper` **and** `updateAllRequestsInQueue()` rewrites those keys into every already-queued request's body.
+
+## PrefHelper
+
+Singleton wrapper over the `"branch_referral_shared_pref"` file with typed accessors. String getters default to `NO_STRING_VALUE = "bnc_no_value"` (`PrefHelper.java:48`), so code distinguishes unset from empty with `hasPrefValue(...)` (`:1207`). Prefer that over comparing to the default; `isDMAParamsInitialized` and `isAttributionLevelInitialized` are the pattern to copy.
+
+Stores: branch key plus key **source**, randomized device and bundle tokens, identity, session params versus install params, link-click / app-link / push / external-intent identifiers, install and referrer data (GCLID self-expires after 30 days), consent and DMA flags, tracking state, network tuning. In-memory only, not persisted: request and install metadata, partner params, custom server and CDN URLs, logging and EU-endpoint flags.
+
+**Branch key resolution precedence** (`BranchUtil.readBranchKey`): `branch.json`, then manifest meta-data (`io.branch.sdk.BranchKey` and `.test`, where test mode falls back to the live key), then string resources. Each source is persisted alongside a key-source string. `branch.json` is read by `BranchJsonConfig`, a separate singleton; `BranchConfigurationController` surfaces resolved flags and delegates its own storage to `prefHelper_`.
+
+## Invariants
+
+Break one of these and the failure is usually silent, and usually not caught by CI.
+
+- **Ordering is a contract.** Init is force-moved to the front. `setIdentity` and `logout` are queue operations precisely so they execute in enqueue order relative to other requests (ChangeLog 5.20.0).
+- **`clearPrefOnBranchKeyChange()`**, triggered when `setBranchKey` sees a different key, calls `prefsEditor_.clear()` but deliberately re-writes four values so an in-flight deep link survives: link-click id, link-click identifier, app link, push identifier.
+- **Tracking-disabled** (`TrackingController`, or `setConsumerProtectionAttributionLevel(NONE)`) blocks network calls except deep linking. Disabling clears session, link, and referrer prefs but **not** identity or the device and bundle tokens. Only requests whose `prepareExecuteWithoutTracking()` returns true pass through; init requests strip all PII and set `TrackingDisabled=true` in that mode. There is no `SKIP_QUEUE` mechanism; gating is entirely `prepareExecuteWithoutTracking()` plus the `ERR_BRANCH_TRACKING_DISABLED` checks.
+- **One-time writes.** `KEY_ORIGINAL_INSTALL_TIME` is written once, when 0. Enhanced-web-link UX type and load-time are consumed once then reset. `postInitClear` resets link, referrer, and intent identifiers only when at most one init request remains queued.
+- **Retry policy** (`onRequestFailed`): a request is dropped on HTTP 400 through 451, on `ERR_BRANCH_TRACKING_DISABLED`, when `shouldRetryOnFail()` is false, or once `currentRetryCount` hits the no-connection retry max. Otherwise it stays for replay. Init failure resets state to `UNINITIALISED`, but only when no session params are stored yet, so the intra-app-linking case deliberately stays `INITIALISED`.

--- a/docs/internal/code-map.md
+++ b/docs/internal/code-map.md
@@ -1,0 +1,50 @@
+# Code map (master)
+
+> Contributor-facing notes for work on this branch.
+> Last updated 2026-09-03, against `master` at 827655ea.
+
+Where things live, and which file to open for a given task. Line numbers drift; treat any `file:line` as a locate-then-confirm hint.
+
+## Modules
+
+| Module | What it is |
+| --- | --- |
+| `:Branch-SDK` | the published library (`com.android.library`). All production code under `Branch-SDK/src/main/java/io/branch/` |
+| `:Branch-SDK-TestBed` | sample/demo app (`io.branch.branchandroidtestbed`), depends on `:Branch-SDK`. Manual testing, and the target app for E2E |
+| `:Branch-SDK-GPTDriver` | `com.android.test` E2E module targeting the TestBed. Hybrid philosophy: deterministic Espresso first, AI-assisted validation only when Espresso matchers cannot express the intent. See `Branch-SDK-GPTDriver/README.md` |
+
+## Packages
+
+Most code is in `io.branch.referral`, but not all. Check these siblings before assuming.
+
+- **`referral/`** the SDK core: `Branch`, `PrefHelper`, `ServerRequest*` and `ServerRequestQueue`, device/tracking/config, link and share builders.
+  - `referral/network/` `BranchRemoteInterface` plus the `...UrlConnection` HTTP implementation
+  - `referral/util/` `BranchEvent`, `BRANCH_STANDARD_EVENT`, `LinkProperties`, `CommerceEvent`, content-metadata types
+  - `referral/validators/` integration and deep-link diagnostics
+  - `referral/QRCode/`
+- **`indexing/`** `BranchUniversalObject`, the BUO content model used for link creation and tracking
+- **`coroutines/`** Kotlin entry points for async fetches: `AdvertisingIds`, `DeviceSignals`, `InstallReferrers`
+- **`data/`** `InstallReferrerResult`
+- **`interfaces/`** public callback interfaces, for example `IBranchLoggingCallbacks`
+- **`receivers/`** `SharingBroadcastReceiver`, captures the chosen app from the system share sheet
+
+## Where to make changes
+
+| Task | Start here |
+| --- | --- |
+| Session init, deep-link callbacks, intent parsing | `Branch.java`: `sessionBuilder`, `initializeSession`, `registerAppInit`, `readAndStripParam` |
+| A new API request type, or changing a request body | subclass `ServerRequest`; wire dispatch and gating in `ServerRequestQueue.java`; add the path to `Defines.RequestPath` |
+| Persisted state, a new SharedPreferences key | `PrefHelper.java`: add `KEY_*` plus typed accessors |
+| Wire-format field names, enums, endpoints | `Defines.java`: `Jsonkey`, `RequestPath`, `IntentKeys`, `HeaderKey` |
+| Device or hardware signals on requests | `DeviceInfo.java`, `SystemObserver.java`, `coroutines/DeviceSignals.kt` |
+| Ad ID fetch (GAID, Huawei, and so on) | `coroutines/AdvertisingIds.kt` |
+| Install-referrer fetch | `coroutines/InstallReferrers.kt`, `data/InstallReferrerResult.kt`, `AppStoreReferrer.java`, `BranchPreinstall.java` |
+| Link creation (short and long URLs) | `BranchShortLinkBuilder.java`, `BranchUrlBuilder.java`, `BranchLinkData.java`; content model in `indexing/BranchUniversalObject.java` and `util/LinkProperties.java` |
+| Sharing and the share sheet | `BranchShareSheetBuilder.java`, `ShareLinkManager.java`, `NativeShareLinkManager.java`, `receivers/SharingBroadcastReceiver.kt` |
+| Custom or commerce events | `util/BranchEvent.java`, `util/BRANCH_STANDARD_EVENT.java`, `util/CommerceEvent.java` |
+| Tracking-disabled, consent, DMA | `TrackingController.java`, plus the DMA and consent keys in `PrefHelper.java` |
+| `branch.json` and config flags | `BranchJsonConfig.java`, `BranchConfigurationController.kt`, `BranchUtil.java` for key resolution |
+| HTTP transport, retries, timeouts | `network/BranchRemoteInterfaceUrlConnection.java` (impl), `network/BranchRemoteInterface.java` (abstract) |
+| QR codes | `QRCode/BranchQRCode.java`, `QRCode/ServerRequestCreateQRCode.java` |
+| Integration and deep-link diagnostics | `validators/IntegrationValidator.java`, `validators/DeepLinkRoutingValidator.java` |
+| Logging | `BranchLogger.kt`, `interfaces/IBranchLoggingCallbacks.java` |

--- a/docs/internal/testing.md
+++ b/docs/internal/testing.md
@@ -1,0 +1,71 @@
+# Testing and CI (master)
+
+> Contributor-facing notes for work on this branch.
+> Last updated 2026-09-03, against `master` at 827655ea.
+
+## The shape of the suite
+
+Two source sets, both under `io.branch.referral`:
+
+| Source set | Runner | Contents |
+| --- | --- | --- |
+| `Branch-SDK/src/test/` | JVM, no device | **Three files only**: `BranchConfigurationControllerTest.kt`, `InstallReferrerResultTests.kt`, `BranchPartnerParametersTest.java` |
+| `Branch-SDK/src/androidTest/` | emulator or device | 21 files. This is the real suite |
+
+**Do not treat a green `testDebugUnitTest` as verification of a behavior change.** It exercises three narrow classes. Anything touching init, the request queue, `PrefHelper`, or the wire format has to run on a device.
+
+Instrumented tests reset global state in `@Before` using `Branch.shutDown()` plus a shared-prefs clear, and swap the network with `setBranchRemoteInterface(new MockRemoteInterface())`. Follow the existing base classes rather than inventing a new harness.
+
+Test tasks set `maxRetries = 3`, so a failing test gets up to three retries (four attempts total) before CI reports it red.
+
+## Running
+
+```bash
+# JVM
+./gradlew :Branch-SDK:testDebugUnitTest
+./gradlew :Branch-SDK:testDebugUnitTest --tests "io.branch.referral.BranchConfigurationControllerTest"
+./gradlew :Branch-SDK:testDebugUnitTest --tests "*BranchConfigurationControllerTest.someMethod"
+
+# Instrumented (device required)
+./gradlew :Branch-SDK:connectedDebugAndroidTest
+./gradlew :Branch-SDK:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=io.branch.referral.BranchApiTests
+
+# Coverage: aggregates unit and instrumented, depends on createDebugCoverageReport, so it needs a device
+./gradlew :Branch-SDK:jacocoTestReport
+
+# Lint: the SDK module sets abortOnError = false, so lint reports but never fails the build
+./gradlew :Branch-SDK:lint
+```
+
+## Adding a test
+
+Before adding a test, name the failure it catches that no existing test catches, and say so in the PR body.
+
+Test the edge the code exists to handle, not the happy path. A guard, a cap, a truncation, a retry, a fallback: each was written for one specific input, and that input is the only one that verifies it.
+
+Timing and ordering bugs in the queue do not reliably surface in CI. When you fix one, add a regression test that reproduces the exact scenario, not a unit test of the mechanism in isolation.
+
+## CI
+
+| Workflow | Trigger | What it does |
+| --- | --- | --- |
+| `unit-and-instrumented-tests-action.yml` | every push | `testDebugUnitTest` plus `connectedDebugAndroidTest` on API 21 and 34, then `jacocoTestReport` to Codecov |
+| `sdk-l1-validation.yml` | PRs into `master`, `main`, `feature/mobileboost-e2e-tests` | the Layer 1 wire gate, described below |
+| `gptdriverautomation.yaml` | pushes to `Release-*`, or manual | drives the `:Branch-SDK-GPTDriver` MobileBoost E2E module |
+| `stale.yml` | nightly | marks and closes inactive issues |
+
+### The Layer 1 wire gate
+
+`sdk-l1-validation.yml` builds the TestBed and GPTDriver APKs, runs an instrumented test on an emulator, pulls `branchlogs.txt` off the device, and asserts that the required device and SDK fields are actually on the wire. The check is **presence-only** and scoped to `/v1/*`: a required field is either there or it is not. Type and value-format checks are deliberately left to the backend ingestion gate.
+
+Reproduce it locally against any captured log:
+
+```bash
+./scripts/run_l1_instrumented.sh <your MobileBoost key>   # installs both APKs, runs the test, pulls the log
+python3 scripts/validate_l1_logs.py path/to/branchlogs.txt
+python3 -m unittest scripts.test_validate_l1_logs -v      # the validator's own tests
+```
+
+The required-field lists live at the top of `scripts/validate_l1_logs.py`. Full notes: `scripts/README.md`.
+
+The workflow deliberately bypasses `connectedDebugAndroidTest`, because for `com.android.test` modules using the test orchestrator with `clearPackageData=true`, AGP uninstalls the target package when the run finishes and the log can never be pulled. Do not "fix" that by routing it back through the standard task.

--- a/docs/internal/working-agreements.md
+++ b/docs/internal/working-agreements.md
@@ -1,0 +1,61 @@
+# Working agreements (master)
+
+> Contributor-facing notes for work on this branch. This is not a public contributing guide.
+> Last updated 2026-09-03, against `master` at 827655ea.
+
+## Branches and commits
+
+`master` is the base branch and is never committed to directly. Branch, push, open a PR.
+
+There is no enforced branch-naming convention. History carries author-prefixed (`gdeluna/...`), ticket-key-first (`SDK-1234-...`), and type-prefixed (`fix/...`) names side by side. Pick one and move on.
+
+The PR title must reference the ticket. This is a reviewer-checklist item in `.github/pull_request_template.md`, not a style preference. Use your own key, never a teammate's: Jira auto-links any key it sees, so naming their ticket attaches your work to their scope. When another ticket explains why a change is needed, reference the PR number in the body instead (`#1401`), which carries the same information without auto-linking.
+
+Commit subject formats vary across the history and none is enforced. Commit message bodies wrap at 72 columns, because git renders them in a terminal.
+
+## Pull requests
+
+Fill in `.github/pull_request_template.md`: reference, description, testing instructions, risk assessment.
+
+**Request a reviewer, and verify it took.** `.github/CODEOWNERS` is `* @BranchMetrics/sdk-maintainers`, but the request is not reliably created for you. An unrequested PR sits invisible while its author believes it is queued.
+
+```bash
+gh pr view <n> --json reviewRequests -q '[.reviewRequests[]?.name, .reviewRequests[]?.login] | map(select(.)) | join(",")'
+gh pr edit <n> --add-reviewer BranchMetrics/sdk-maintainers
+```
+
+An empty result is the defect. Re-check after any base-branch change, since retargeting can drop the request.
+
+Keep the PR body to the defect, the fix, the proof it works, and what changed after a review round.
+
+### Reviewing someone else's PR
+
+A review comment carries the defect and the fix, not the investigation. One or two sentences per line comment, and a `suggestion` block instead of prose whenever the fix is code. Say what the code does wrong, where, and what closes it.
+
+## Code style and scope
+
+- **AOSP style.** Match the surrounding file even when you would write it differently.
+- **Comments in public API earn their place.** What the function does, and what the parameters mean. Nothing else. Public doc comments render into the generated docs, so anything a consumer of the SDK would not act on does not go there.
+- **Surgical changes**, so the diff stays reviewable. Every changed line traces to the request. Do not refactor adjacent code, do not fix pre-existing lint in a file you happen to touch, do not rename existing symbols to fit new code. Note anything you spotted in passing in the PR body under "Out of scope".
+- **Clean up only your own orphans.** Remove imports and locals *your* change made unused. Leave pre-existing dead code alone unless asked.
+
+## Splitting work
+
+When a change has two separable halves, ship two stacked PRs titled `(1 of 2)` and `(2 of 2)`. A small PR gets picked up in a gap between meetings; a large one waits for an uninterrupted slot that may not come, and while it waits it drifts and collects conflicts.
+
+Split at a seam that already exists: measurement before assertion, contract before driver, driver before CI wiring, mechanism before adoption. The one hard constraint is that **each piece must be verifiable on its own**. A contract with no test, a helper with no caller, a migration with no green build are fragments, not deliverables. When a seam would produce an unverifiable piece, keep the halves together and say why in the PR body.
+
+## Releases
+
+- Version lives in `gradle.properties`: `VERSION_NAME` and `VERSION_CODE`.
+- Every user-visible change gets a `ChangeLog.md` entry under the new version heading.
+- Release branches are named `Release-*`, which is what triggers `gptdriverautomation.yaml`.
+- Published to Maven Central as `io.branch.sdk.android:library`. `./gradlew publishToMavenLocal` to consume a build before it ships.
+
+## Public surfaces
+
+This is a public repository. Audit what a change *publishes*, not just what it changes. Internal ticket keys, tracker URLs, internal hostnames, and colleague names must not reach the README, the integration docs, CI step summaries (`$GITHUB_STEP_SUMMARY`), workflow logs, build artifacts, or badge links. An `echo` inside a workflow reads like code and behaves like publishing.
+
+Ticket keys are fine in commit subjects, branch names, PR titles, and PR bodies. Those are the repo's convention. The line is drawn at rendered product surfaces.
+
+Security issues go to security@branch.io, never a public issue.


### PR DESCRIPTION
Applying practices from the flight school cohort to our own agent-facing docs.

CLAUDE.md is loaded into context on every session, so length has a cost on every task. At 16.9KB most of it was dead weight for any given piece of work and competed with the actual prompt. The guidance is to keep only what would cause a wrong action if removed, and to defer the rest so it loads on demand.

This cuts CLAUDE.md to 4.5KB and moves the task-specific material into `docs/internal/`: `code-map.md` (where things live), `architecture.md` (runtime behavior, invariants, glossary), `testing.md` (the suites, CI, the L1 wire gate), `working-agreements.md` (PR and review process).

`docs/internal/` rather than `docs/` is deliberate. `docs/` is one of the three paths GitHub resolves community health files from, and this repo has no CONTRIBUTING file, so a `docs/contributing.md` would have become the "Contributing Guidelines" link on every new issue and PR of a public repo, pointing external contributors at internal process.

Corrections made while verifying against source at 827655ea:

- Branch and commit conventions are now described as they are, not prescribed. An earlier draft published `feat/` `fix/` `chore/` as the repo standard; 27 of the 30 type-prefixed branches on origin belong to one contributor, and the dominant patterns are author-prefixed and ticket-key-first.
- The "session state is being retired" framing was removed. That is the 6.0 direction, and master runs on `SessionState` and `SessionID` today, so the file was forbidding what it documented thirty lines below.
- `ServerRequest.toJSON`/`fromJSON` are described as implemented but unused by the queue, which is what the source shows.

Every `file:line` anchor was checked against source. No production code is touched.

Out of scope, noticed in passing: `.github/pull_request_template.md` line 2 carries `SDK-XXX -- <TITLE>`, a legacy project key with a separator that appears in none of the last 40 commit subjects.