### PR TITLE
EMT-4260: build the beta's unit tests against the current init API

### DIFF
--- a/Branch-SDK/src/test/java/io/branch/referral/EventRequestPathTest.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/EventRequestPathTest.kt
@@ -22,7 +22,10 @@ class EventRequestPathTest : BranchTestBase() {
     @Before
     fun setUp() {
         super.setUpBase()
-        Branch.getAutoInstance(RuntimeEnvironment.getApplication())
+        Branch.initialize(
+            RuntimeEnvironment.getApplication(),
+            BranchConfiguration.Builder("key_live_test123").build(),
+        )
     }
 
     @After

--- a/Branch-SDK/src/test/java/io/branch/referral/QueueContainsInstallOrOpenTest.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/QueueContainsInstallOrOpenTest.kt
@@ -22,7 +22,10 @@ class QueueContainsInstallOrOpenTest : BranchTestBase() {
     @Before
     fun setUpQueue() {
         super.setUpBase()
-        Branch.getAutoInstance(RuntimeEnvironment.getApplication())
+        Branch.initialize(
+            RuntimeEnvironment.getApplication(),
+            BranchConfiguration.Builder("key_live_test123").build(),
+        )
         queue = BranchRequestQueue.getInstance(RuntimeEnvironment.getApplication())
         runBlocking { queue.clear() }
     }


### PR DESCRIPTION
`Branch.getAutoInstance(Context)` no longer exists on this line. The BranchConfiguration Builder change (#1381) removed it in favour of `Branch.initialize(Context, BranchConfiguration)`, and `git grep getAutoInstance` returns zero hits under `Branch-SDK/src/main`.

Two test classes still called it, so `:Branch-SDK:compileDebugUnitTestKotlin` failed and no unit test on the branch could run: `EventRequestPathTest.kt:25` and `QueueContainsInstallOrOpenTest.kt:25`.

## Why it was invisible

Neither test was wrong when written; both predate the removal. Nothing in CI compiles the unit test source set on this line, because `unit-and-instrumented-tests` is disabled at repo level with zero runs in its history. It surfaced only when the candidate gate in #1394 was run against the current beta.

## The change

Each call site becomes `Branch.initialize(context, BranchConfiguration.Builder("key_live_test123").build())`, the idiom `BranchInitializeTest` already uses. Both only need the singleton to exist; neither asserts on configuration. No assertion changed.

## Proof

```
:Branch-SDK:compileDebugUnitTestKotlin   BUILD SUCCESSFUL
:Branch-SDK:testDebugUnitTest            543 tests, 0 failures, 0 errors
```

## Not here

Enabling a gate that would have caught this is #1394.