### PR TITLE
EMT-4334: clear the resolved deep link payload at the session boundary

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/observers/BranchProcessLifecycleObserver.kt
+++ b/Branch-SDK/src/main/java/io/branch/observers/BranchProcessLifecycleObserver.kt
@@ -24,7 +24,10 @@ internal class BranchProcessLifecycleObserver(private val branchInstance: Branch
 
     override fun onStop(owner: LifecycleOwner) {
         BranchLogger.v("BranchProcessLifecycleObserver onStop: process backgrounded")
-        // Session close on background is intentionally not triggered here. The pre-existing
+        // Clears the resolved deep link payload. This is a persisted string, not session state,
+        // and does not touch BranchSessionState or setInitState.
+        branchInstance.prefHelper.sessionParams = PrefHelper.NO_STRING_VALUE
+        // Session close on background is still intentionally not triggered here. The pre-existing
         // BranchOpenObserver also did not call closeSessionInternal on background — no regression.
         // When the beta session model is finalized, session-close logic belongs here.
     }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -391,6 +391,12 @@ public class Branch {
 
         BranchConfigurationManager.loadConfiguration(context, branchReferral_);
 
+        // Clears whatever the previous process left behind, so a process that died without
+        // onStop (force stop, OOM kill) does not leak a stale resolved payload into this run.
+        // Outside the automatic-open-events branch below, since that is the configuration with
+        // no onStop to fall back on.
+        branchReferral_.prefHelper_.setSessionParams(PrefHelper.NO_STRING_VALUE);
+
         if (config.getAutomaticOpenEvents()) {
             branchReferral_.setupProcessLifecycleObserver();
         } else {

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterOpen.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestRegisterOpen.java
@@ -68,12 +68,13 @@ class ServerRequestRegisterOpen extends ServerRequestInitSession {
                 branch.openBrowserExperience(invokeFeaturesJson);
             }
             else {
+                // Write the slot only when this response actually carries session data. The
+                // open response has no "data" key, link-driven or organic, so writing whatever
+                // it says always cleared the payload a deep link resolution had just persisted.
+                // A data-less response leaves the slot as it stands, mirroring RequestOpen.kt.
                 if (resp.getObject().has(Defines.Jsonkey.Data.getKey())) {
                     String params = resp.getObject().getString(Defines.Jsonkey.Data.getKey());
                     prefHelper_.setSessionParams(params);
-                }
-                else {
-                    prefHelper_.setSessionParams(PrefHelper.NO_STRING_VALUE);
                 }
 
                 if (callback_ != null) {

--- a/Branch-SDK/src/test/java/io/branch/referral/BranchInitializeTest.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/BranchInitializeTest.kt
@@ -332,6 +332,36 @@ class BranchInitializeTest : BranchTestBase() {
     }
 
     // -------------------------------------------------------------------------
+    // Process-start clear (EMT-4334): a process that died without onStop must not leak the
+    // previous run's resolved payload into a cold start.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun initialize_clearsSessionParamsLeftByPreviousProcess() {
+        PrefHelper.getInstance(context).sessionParams =
+            """{"~channel":"Distribution Channel","+clicked_branch_link":true}"""
+
+        Branch.initialize(context, BranchConfiguration.Builder("key_live_test123").build())
+
+        assertEquals(PrefHelper.NO_STRING_VALUE, PrefHelper.getInstance(context).sessionParams)
+    }
+
+    @Test
+    fun initialize_automaticOpenEventsFalse_stillClearsSessionParams() {
+        PrefHelper.getInstance(context).sessionParams =
+            """{"~channel":"Distribution Channel","+clicked_branch_link":true}"""
+
+        Branch.initialize(
+            context,
+            BranchConfiguration.Builder("key_live_test123")
+                .setAutomaticOpenEvents(false)
+                .build()
+        )
+
+        assertEquals(PrefHelper.NO_STRING_VALUE, PrefHelper.getInstance(context).sessionParams)
+    }
+
+    // -------------------------------------------------------------------------
     // Singleton guard — second initialize() call is a no-op
     // -------------------------------------------------------------------------
 

--- a/Branch-SDK/src/test/java/io/branch/referral/BranchProcessLifecycleObserverStaticIsolationTest.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/BranchProcessLifecycleObserverStaticIsolationTest.kt
@@ -6,6 +6,8 @@ import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.robolectric.RuntimeEnvironment
 
 /**
  * Tests for static lifecycle isolation in BranchProcessLifecycleObserver.
@@ -27,6 +29,7 @@ class BranchProcessLifecycleObserverStaticIsolationTest : BranchTestBase() {
         super.setUpBase()
         branch = mock(Branch::class.java)
         owner = mock(LifecycleOwner::class.java)
+        `when`(branch.prefHelper).thenReturn(PrefHelper.getInstance(RuntimeEnvironment.getApplication()))
     }
 
     @Test

--- a/Branch-SDK/src/test/java/io/branch/referral/BranchProcessLifecycleObserverTest.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/BranchProcessLifecycleObserverTest.kt
@@ -1,12 +1,15 @@
 package io.branch.referral
 
 import androidx.lifecycle.LifecycleOwner
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.robolectric.RuntimeEnvironment
 
 /**
  * Unit tests for [BranchProcessLifecycleObserver].
@@ -19,9 +22,12 @@ import org.mockito.Mockito.verify
  */
 class BranchProcessLifecycleObserverTest : BranchTestBase() {
 
+    private val resolvedPayload = """{"~channel":"Distribution Channel","+clicked_branch_link":true}"""
+
     private lateinit var branch: Branch
     private lateinit var owner: LifecycleOwner
     private lateinit var observer: BranchProcessLifecycleObserver
+    private lateinit var prefHelper: PrefHelper
 
     @Before
     override fun setUpBase() {
@@ -29,6 +35,8 @@ class BranchProcessLifecycleObserverTest : BranchTestBase() {
         branch = mock(Branch::class.java)
         owner = mock(LifecycleOwner::class.java)
         observer = BranchProcessLifecycleObserver(branch)
+        prefHelper = PrefHelper.getInstance(RuntimeEnvironment.getApplication())
+        `when`(branch.prefHelper).thenReturn(prefHelper)
     }
 
     @Test
@@ -67,5 +75,23 @@ class BranchProcessLifecycleObserverTest : BranchTestBase() {
         observer.onStart(owner)
 
         verify(branch, times(3)).sendOpen()
+    }
+
+    @Test
+    fun onStop_clearsResolvedSessionParams() {
+        prefHelper.sessionParams = resolvedPayload
+
+        observer.onStop(owner)
+
+        assertEquals(PrefHelper.NO_STRING_VALUE, prefHelper.sessionParams)
+    }
+
+    @Test
+    fun onStart_doesNotClearSessionParams() {
+        prefHelper.sessionParams = resolvedPayload
+
+        observer.onStart(owner)
+
+        assertEquals(resolvedPayload, prefHelper.sessionParams)
     }
 }

--- a/Branch-SDK/src/test/java/io/branch/referral/RequestOpenSessionParamsTest.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/RequestOpenSessionParamsTest.kt
@@ -50,8 +50,34 @@ class RequestOpenSessionParamsTest : BranchTestBase() {
         assertEquals(openPayload, prefHelper.sessionParams)
     }
 
+    @Test
+    fun legacyOpenWithoutSessionData_leavesTheResolvedPayloadIntact() {
+        processLegacyOpenResponse(JSONObject().put("invoke_register_app", true))
+
+        assertEquals(resolvedPayload, prefHelper.sessionParams)
+    }
+
+    @Test
+    fun legacyOpenWithSessionData_stillWritesIt() {
+        val openPayload = """{"~channel":"Organic"}"""
+
+        processLegacyOpenResponse(JSONObject().put("data", openPayload))
+
+        assertEquals(openPayload, prefHelper.sessionParams)
+    }
+
     private fun processOpenResponse(body: JSONObject) {
         val request = RequestOpen(RuntimeEnvironment.getApplication(), null, false, null)
+        val response = ServerResponse("open", HttpURLConnection.HTTP_OK, "req-1", "OK")
+        response.setPost(body)
+
+        // onInitSessionCompleted runs after the write and reaches collaborators this test does not
+        // stand up. The write is what is under test, and it has already happened by then.
+        runCatching { request.onRequestSucceeded(response, branch) }
+    }
+
+    private fun processLegacyOpenResponse(body: JSONObject) {
+        val request = ServerRequestRegisterOpen(RuntimeEnvironment.getApplication(), null, false)
         val response = ServerResponse("open", HttpURLConnection.HTTP_OK, "req-1", "OK")
         response.setPost(body)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,6 @@
 # Branch Android SDK change log
+- v6.0.0-beta.0
+  - Clear the resolved deep link payload on background and at process start, so a later organic launch no longer returns the previous link's data.
 - v5.20.3
 * _*Master Release*_ - Sep 24, 2025
   - Add some additional debug logging.


### PR DESCRIPTION
## Defect

After a link launch, a background and a later organic launch, `getLatestReferringParams` still returns the previous link with `+clicked_branch_link: true`, so integrator code reading it at `onStart` routes an organic launch as a link launch. The wire is not affected: open counts and bodies are the same before and after this change.

## Fix

- `Branch.initialize` clears the resolved payload at process start, outside the automatic-open-events branch, so a process killed without `onStop` does not leak it.
- `BranchProcessLifecycleObserver.onStop` clears it only when no install, open or link resolution is queued or executing (`containsInstallOpenOrResolution`). Every response write runs on main, as `onStop` does, so a resolution's payload is never erased mid-launch.
- `processNextRequest` now puts a request into `activeRequests` before removing it from `queueList`, under the same lock, so the query never sees it in neither collection.

This follows the review request on #1366 that previous session parameters stop being referenced after `onStop`, narrowed to the payload: no session state is reset.

`ServerRequestRegisterOpen` was changed in an earlier commit on this branch and reverted: it has no live construction site.

## Evidence

- Unit: 567 of 567 on `7cef0e77` (this branch merged with `6.0.0-beta.0` at `05d9f706`), first attempt. The five new gate cases fail on `78ccd421`.
- Emulator API 34, base `05d9f706` against `7cef0e77`, 3 runs each, links opened by a real tap in Chrome:

| scenario | base | fix |
| --- | --- | --- |
| organic relaunch after Home, accessor at `onStart` | link 3/3 | empty 3/3 |
| force stop, relaunch | link 3/3 | empty 3/3 |
| warm link L2 after Home, read before resolution | L1 3/3 | empty 3/3, L2 after |
| shade pull, rotation | kept 6/6 | kept 6/6 |

## Limits

- A background during the link's two round trips keeps the payload for one organic launch (4 of 6 runs on `81c6b9d6`); the next idle background clears it. No follow-up is planned.
- A read made before the resolution lands now returns empty after a background, where it returned the previous link. Read after the resolution, or use the callback overload.
- A request stranded by the `registerAppInit` double enqueue (EMT-4360, reachable only through `sessionBuilder().init()` with `forceBranchSession`) keeps the queue busy, so the background clear does not run until process restart.
- Automatic open events off: no clear on background (EMT-4363).
- Not measured: a sub-700 ms app switch, a permission dialog.

## Out of scope, noticed

`BranchRequestQueue.kt` is over 1100 lines.

Open counts and bodies match on base and fix in every run.

iOS counterpart: https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/pull/1660
