### PR TITLE
EMT-4262: stop withDelay() from attaching a wait lock nothing removes

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1175,8 +1175,6 @@ public class Branch {
         BranchLogger.v("Session state set to INITIALISING");
 
         if (delay > 0) {
-            initRequest.addProcessWaitLock(ServerRequest.PROCESS_WAIT_LOCK.USER_SET_WAIT_LOCK);
-            BranchLogger.v("Adding USER_SET_WAIT_LOCK with delay: " + delay);
             getStaticHandler().postDelayed(new SessionInitRunnable(initRequest), delay);
         } else {
             BranchLogger.v("No delay, processing session initialization immediately");

--- a/Branch-SDK/src/test/java/io/branch/referral/BranchInitializeTest.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/BranchInitializeTest.kt
@@ -535,6 +535,60 @@ class BranchInitializeTest : BranchTestBase() {
             singleEvent(logs, BranchConfiguration.EVENT_CONFIGURATION_APPLIED).getString("branchKey"))
     }
 
+    // -------------------------------------------------------------------------
+    // withDelay(n)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun initialize_withDelay_completesOnlyAfterDelayElapses() {
+        Branch.initialize(context, BranchConfiguration.Builder("key_live_test123").build())
+
+        Branch.sessionBuilder(null).withDelay(200).init()
+        assertNull(
+            "a delayed init must not reach the queue before its own delay has elapsed",
+            Branch.getInstance().requestQueue_.peek()
+        )
+
+        advanceTimeBy(200)
+
+        val initRequest = Branch.getInstance().requestQueue_.peek()
+        assertNotNull("a delayed init must have reached the queue once its delay elapsed", initRequest)
+        assertFalse(
+            "a delayed init must not still be held on USER_SET_WAIT_LOCK once its own delay has " +
+                "elapsed, locks were: ${initRequest!!.printWaitLocks()}",
+            initRequest.printWaitLocks().contains("USER_SET_WAIT_LOCK")
+        )
+    }
+
+    @Test
+    fun initialize_noDelay_neverHoldsUserSetWaitLock() {
+        Branch.initialize(context, BranchConfiguration.Builder("key_live_test123").build())
+
+        Branch.sessionBuilder(null).init()
+
+        val initRequest = Branch.getInstance().requestQueue_.peek()
+        assertNotNull("an init with no delay must reach the queue without advancing the clock", initRequest)
+        assertFalse(
+            "an init with no delay must never hold USER_SET_WAIT_LOCK, locks were: " +
+                initRequest!!.printWaitLocks(),
+            initRequest.printWaitLocks().contains("USER_SET_WAIT_LOCK")
+        )
+    }
+
+    @Test
+    fun initialize_withDelayZero_neverHoldsUserSetWaitLock() {
+        Branch.initialize(context, BranchConfiguration.Builder("key_live_test123").build())
+
+        Branch.sessionBuilder(null).withDelay(0).init()
+
+        val initRequest = Branch.getInstance().requestQueue_.peek()
+        assertNotNull("withDelay(0) must reach the queue without advancing the clock", initRequest)
+        assertFalse(
+            "withDelay(0) must never hold USER_SET_WAIT_LOCK, locks were: " + initRequest!!.printWaitLocks(),
+            initRequest.printWaitLocks().contains("USER_SET_WAIT_LOCK")
+        )
+    }
+
     private companion object {
         const val TEST_KEY = "key_test_abcdefghijklmnop12345678"
     }

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,6 @@
 # Branch Android SDK change log
+- v6.0.0-beta.0
+  - Fix `withDelay(n)` on session init so it completes after the delay instead of hanging until the request timeout.
 - v5.20.3
 * _*Master Release*_ - Sep 24, 2025
   - Add some additional debug logging.


### PR DESCRIPTION
`sessionBuilder(activity).withDelay(n).init()` stalled for the 30 second request timeout and then failed, instead of initializing a session `n` milliseconds later. The API is public and documented, and nothing on this line calls it, which is why it could break with nothing turning red.

## Cause

The delay was applied twice. The `postDelayed` at `Branch.java:1180` already defers the call to `processSessionInitialization`, which is what reaches `registerAppInit` and enqueues the request, so the deferred enqueue is the delay. The `USER_SET_WAIT_LOCK` attached beside it then held that request in the queue on `isWaitingOnProcessToFinish`, and nothing ever removed it.

`USER_SET_WAIT_LOCK` had three occurrences under `Branch-SDK/src/main`: the add, the log line beside it, and the enum member. There was no matching `removeProcessWaitLock`, and `removeSessionInitializationDelay`, which owns the removal on `master`, has zero occurrences anywhere under `Branch-SDK/src` on this line. It is also the only one of the six enum members that `tryResolveStuckLocks` does not force-remove, so the queue's own rescue path could not reach it either.

On `master` the lock is the mechanism rather than a duplicate of it: the request is enqueued immediately and `postDelayed` calls `removeSessionInitializationDelay` to release it. This line replaced enqueue-then-hold with defer-then-enqueue, kept the lock from the old design, and dropped the method that released it.

## What changed

Two deleted lines. The `postDelayed` and the `else` branch are untouched, because the `postDelayed` is what delivers the delay.

The enum member stays. It is now unused, and deleting an enum member is a mechanical change that should not travel inside a behaviour fix. Adding the lock to `tryResolveStuckLocks` was also rejected: it would paper over a hang this change removes outright.

## Tests

Three cases in `BranchInitializeTest`. They assert on `printWaitLocks()` not containing `USER_SET_WAIT_LOCK` specifically rather than on `isWaitingOnProcessToFinish`, because the latter is confounded by `INTENT_PENDING_WAIT_LOCK`, `INSTALL_REFERRER_FETCH_WAIT_LOCK` and `GAID_FETCH_WAIT_LOCK`, which every init legitimately holds with or without a delay.

The delayed case asserts on both sides of the clock advance: the request has not reached the queue before the delay elapses, and has reached it without the lock after. The first of those was checked by temporarily replacing the `postDelayed` with a direct call, which turned it red, so it pins the delay rather than only its side effect. Without it, deleting the `postDelayed` would leave the suite green while `withDelay(n)` silently became `withDelay(0)`.

`./gradlew :Branch-SDK:testDebugUnitTest`: 548 tests, 0 failures, 0 errors, 0 skipped, against 545 on the base commit.

## Note for whoever merges second

This and #1407 both add the `v6.0.0-beta.0` heading to `ChangeLog.md`, since neither is on the branch yet. Whichever lands second should fold its bullet under the existing heading rather than adding a second one.
